### PR TITLE
Add existing CI tests from other Enarx repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# Copyright 2019 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+install:
+  - rustup component add rustfmt
+  - cargo install --force cargo-audit
+script:
+  - cargo fmt -- --check
+  - cargo audit
+  - cargo test


### PR DESCRIPTION
`enarx/enarx` now has a Travis config! Resolves #3.

Tagging @npmccallum for review.