### PR TITLE
Remove outdated alignment and size tests in sgx-types/secs.rs

### DIFF
--- a/sgx-types/src/secs.rs
+++ b/sgx-types/src/secs.rs
@@ -85,22 +85,3 @@ impl Default for Secs {
 }
 
 /// TODO: Implement Secs::new()
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn align() {
-        use std::mem::align_of;
-
-        assert_eq!(align_of::<Secs>(), 4096);
-    }
-
-    #[test]
-    fn size() {
-        use std::mem::size_of;
-
-        assert_eq!(size_of::<Secs>(), 4096);
-    }
-}


### PR DESCRIPTION
These tests are outdated now that the `paging` crate exists.