### PR TITLE
Clean up Offset type

### DIFF
--- a/sgx-traits/src/lib.rs
+++ b/sgx-traits/src/lib.rs
@@ -47,20 +47,3 @@ pub trait Builder<'b>: Sized {
 
     fn build(self, sig: Signature) -> Result<Self::Enclave>;
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn align() {
-        use std::mem::align_of;
-        assert_eq!(align_of::<Offset<u32>>(), align_of::<u64>());
-    }
-
-    #[test]
-    fn size() {
-        use std::mem::size_of;
-        assert_eq!(size_of::<Offset<u32>>(), size_of::<u64>());
-    }
-}

--- a/sgx-traits/src/lib.rs
+++ b/sgx-traits/src/lib.rs
@@ -25,7 +25,7 @@ bitflags! {
 }
 
 pub trait Enclave<'e> {
-    fn enter(&self, offset: &mut Offset<'e, Tcs>) -> Result<()>;
+    unsafe fn enter(&self, offset: &mut Offset<Tcs>) -> Result<()>;
 }
 
 pub trait Builder<'b>: Sized {
@@ -33,17 +33,22 @@ pub trait Builder<'b>: Sized {
 
     fn new(secs: Secs) -> Result<Self>;
 
-    fn add_tcs(&mut self, tcs: Tcs, offset: usize) -> Result<Offset<'b, Tcs>>;
+    unsafe fn add_tcs(&mut self, tcs: Tcs, offset: usize) -> Result<Offset<Tcs>>;
 
-    fn add_struct<T>(&mut self, data: T, offset: usize, flags: PageFlags) -> Result<Offset<'b, T>>;
+    unsafe fn add_struct<T>(
+        &mut self,
+        data: T,
+        offset: usize,
+        flags: PageFlags,
+    ) -> Result<Offset<T>>;
 
-    fn add_slice(
+    unsafe fn add_slice(
         &mut self,
         data: &[u8],
         offset: usize,
         flags: Flags,
         secinfo: SecInfo,
-    ) -> Result<Offset<'b, ()>>;
+    ) -> Result<Offset<[u8]>>;
 
     fn build(self, sig: Signature) -> Result<Self::Enclave>;
 }

--- a/sgx-types/src/lib.rs
+++ b/sgx-types/src/lib.rs
@@ -73,28 +73,12 @@ pub mod tcs;
 
 use core::marker::PhantomData;
 
-/// An offset reference with neither read nor write capabilities
-///
-/// The Offset struct allows the creation of an opaque reference to a
-/// type that cannot be read or written. Neither the lifetime nor the
-/// type are discarded. This allows us to refer to an offset inside
-/// an enclave without fear that it will be dereferenced. The size of
-/// the Offset is always 64 bits with natural alignment. Therefore,
-/// the Offset type can be embedded in structs.
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct Offset<'h, T>(u64, PhantomData<&'h T>);
+pub struct Offset<T: ?Sized>(u64, PhantomData<T>);
 
-impl<'h, T> Offset<'h, T> {
-    /// Create a new `Offset`
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe because you could create an Offset to an
-    /// offset that doesn't exist. This could cause an invalid memory
-    /// reference later in the program. You must ensure that both the
-    /// lifetime and the offset are valid.
-    pub unsafe fn new(offset: usize) -> Self {
-        Offset(offset as u64, PhantomData)
+impl<T: ?Sized> From<usize> for Offset<T> {
+    fn from(value: usize) -> Self {
+        Offset(value as u64, PhantomData)
     }
 }


### PR DESCRIPTION
This removes the lifetime enforcement I thought we could make work, but realized we can't.