### PR TITLE
Use .unwrap() in tests instead of assert!(.is_ok())

### DIFF
--- a/sgx-sys/src/lib.rs
+++ b/sgx-sys/src/lib.rs
@@ -121,14 +121,18 @@ mod test {
             // TCS pages MUST NOT specify permissions.
             let si = page::SecInfo::tcs();
             eprintln!("{:?} {:?} {:?}", off, *f, si);
-            assert!(unsafe { builder.add(off, &page.0, *f, si).is_ok() });
+            unsafe {
+                builder.add(off, &page.0, *f, si).unwrap();
+            }
             off += 4096;
 
             // REG pages can have permissions.
             for p in &perms {
                 let si = page::SecInfo::reg(*p);
                 eprintln!("{:?} {:?} {:?}", off, *f, si);
-                assert!(unsafe { builder.add(off, &page.0, *f, si).is_ok() });
+                unsafe {
+                    builder.add(off, &page.0, *f, si).unwrap();
+                }
                 off += 4096;
             }
         }


### PR DESCRIPTION
This surfaces the errors when tests fail.