### PR TITLE
Speed up Travis tests by splitting cargo audit into its own task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,15 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
+  include:
+    - name: "cargo audit"
+      rust: stable
+      install:
+        - cargo install --force cargo-audit
+      script:
+        - cargo audit
 install:
   - rustup component add rustfmt
-  - cargo install --force cargo-audit
 script:
   - cargo fmt -- --check
-  - cargo audit
   - cargo test


### PR DESCRIPTION
Resolves #57.