### PR TITLE
Add documentation for SGX in sgx-crypto and sgx-types.

### DIFF
--- a/sgx-types/src/attr.rs
+++ b/sgx-types/src/attr.rs
@@ -1,10 +1,32 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Attributes (Section 38.7.1)
+//! The attributes of an enclave are specified by the struct below as described.
+
 bitflags::bitflags! {
-    /// Section 38.7.1
+    /// Section 38.7.1.
     pub struct Flags: u64 {
+        /// Enclave has been initialized by EINIT.
         const INIT = 1 << 0;
+        /// Perm for debugger to r/w enclave data with EDBGRD and EDBGWR.
         const DEBUG = 1 << 1;
+        /// Enclave runs in 64-bit mode.
         const BIT64 = 1 << 2;
+        /// Provisioning Key is available from EGETKEY.
         const PROV_KEY = 1 << 4;
+        /// EINIT token key is available from EGETKEY.
         const EINIT_KEY = 1 << 5;
     }
 }
@@ -12,19 +34,30 @@ bitflags::bitflags! {
 defflags!(Flags BIT64);
 
 bitflags::bitflags! {
-    /// Section 42.7.2.1 and https://en.wikipedia.org/wiki/Control_register
+    /// Section 42.7.2.1; more info can be found at https://en.wikipedia.org/wiki/Control_register.
     pub struct Xfrm: u64 {
-        const X87 = 1 << 0;       // x87 FPU/MMX State, note, must be '1'
-        const SSE = 1 << 1;       // XSAVE feature set enable for MXCSR and XMM regs
-        const AVX = 1 << 2;       // AVX enable and XSAVE feature set can be used to manage YMM regs
-        const BNDREG = 1 << 3;    // MPX enable and XSAVE feature set can be used for BND regs
-        const BNDCSR =  1 << 4;   // PMX enable and XSAVE feature set can be used for BNDCFGU and BNDSTATUS regs
-        const OPMASK = 1 << 5;    // AVX-512 enable and XSAVE feature set can be used for AVX opmask, AKA k-mask, regs
-        const ZMM_HI256 = 1 << 6; // AVX-512 enable and XSAVE feature set can be used for upper-halves of the lower ZMM regs
-        const HI16_ZMM = 1 << 7;  // AVX-512 enable and XSAVE feature set can be used for the upper ZMM regs
-        const PKRU = 1 << 9;      // XSAVE feature set can be used for PKRU register (part of protection keys mechanism)
-        const CETU = 1 << 11;     // Control-flow Enforcement Technology (CET) user state
-        const CETS = 1 << 12;     // Control-flow Enforcement Technology (CET) supervisor state
+        /// x87 FPU/MMX State, note, must be '1'.
+        const X87 = 1 << 0;
+        /// XSAVE feature set enable for MXCSR and XMM regs.
+        const SSE = 1 << 1;
+        /// AVX enable and XSAVE feature set can be used to manage YMM regs.
+        const AVX = 1 << 2;
+        /// MPX enable and XSAVE feature set can be used for BND regs.
+        const BNDREG = 1 << 3;
+        /// PMX enable and XSAVE feature set can be used for BNDCFGU and BNDSTATUS regs.
+        const BNDCSR =  1 << 4;
+        /// AVX-512 enable and XSAVE feature set can be used for AVX opmask, AKA k-mask, regs.
+        const OPMASK = 1 << 5;
+        /// AVX-512 enable and XSAVE feature set can be used for upper-halves of the lower ZMM regs.
+        const ZMM_HI256 = 1 << 6;
+        /// AVX-512 enable and XSAVE feature set can be used for the upper ZMM regs.
+        const HI16_ZMM = 1 << 7;
+        /// XSAVE feature set can be used for PKRU register (part of protection keys mechanism).
+        const PKRU = 1 << 9;
+        /// Control-flow Enforcement Technology (CET) user state.
+        const CETU = 1 << 11;
+        /// Control-flow Enforcement Technology (CET) supervisor state.
+        const CETS = 1 << 12;
     }
 }
 
@@ -32,20 +65,24 @@ defflags!(Xfrm X87 | SSE);
 
 #[repr(C, packed(4))]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+/// Section 38.7.1.
 pub struct Attributes {
     flags: Flags,
     xfrm: Xfrm,
 }
 
 impl Attributes {
+    /// Creates new Attributes struct from Flags and Xfrm.
     pub const fn new(flags: Flags, xfrm: Xfrm) -> Self {
         Self { flags, xfrm }
     }
 
+    /// Returns flags value of Attributes.
     pub const fn flags(&self) -> Flags {
         self.flags
     }
 
+    /// Returns xfrm value of Attributes.
     pub const fn xfrm(&self) -> Xfrm {
         self.xfrm
     }

--- a/sgx-types/src/isv.rs
+++ b/sgx-types/src/isv.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Red Hat, Inc.
+// Copyright 2020 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sgx-types/src/lib.rs
+++ b/sgx-types/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Red Hat, Inc.
+// Copyright 2020 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #![no_std]
 #![deny(clippy::all)]
 #![allow(clippy::identity_op)]
+#![deny(missing_docs)]
 
 macro_rules! defflags {
     ($name:ident $($value:ident)|*) => {
@@ -96,10 +97,16 @@ pub mod tcs;
 use core::fmt::Debug;
 use core::ops::BitAnd;
 
+/// Succinctly describes a masked type, e.g. masked Attributes or masked MiscSelect.
+/// A mask is applied to Attributes and MiscSelect structs in a Signature (SIGSTRUCT)
+/// to specify values of Attributes and MiscSelect to enforce. This struct combines
+/// the struct and its mask for simplicity.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Masked<T: Copy + Debug + PartialEq + BitAnd<Output = T>> {
+    /// The data being masked, e.g. Attribute flags.
     pub data: T,
+    /// The mask.
     pub mask: T,
 }
 

--- a/sgx-types/src/misc.rs
+++ b/sgx-types/src/misc.rs
@@ -1,6 +1,25 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! MiscSelect (Section 38.7.2)
+//! The bit vector of MISCSELECT selects which extended information is to be saved in the MISC
+//! region of the SSA frame when an AEX is generated.
+
 bitflags::bitflags! {
     /// Section 38.7.2
     pub struct MiscSelect: u32 {
+        /// Report info about page faults and general protection exception that occurred inside an enclave.
         const EXINFO = 1 << 0;
     }
 }

--- a/sgx-types/src/page.rs
+++ b/sgx-types/src/page.rs
@@ -1,4 +1,19 @@
-//! Section 38.11
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Page SecInfo (Section 38.11)
+//! These structs specify metadata about en enclave page.
 
 use bitflags::bitflags;
 
@@ -16,8 +31,13 @@ bitflags! {
         /// The page can be executed from inside the enclave.
         const X = 1 << 2;
 
+        /// The page is in the PENDING state.
         const PENDING = 1 << 3;
+
+        /// The page is in the MODIFIED state.
         const MODIFIED = 1 << 4;
+
+        /// A permission restriction operation on the page is in progress.
         const PR = 1 << 5;
     }
 }
@@ -31,10 +51,15 @@ bitflags! {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum Class {
+    /// Page is an SECS.
     Secs = 0,
+    /// Page is a TCS.
     Tcs = 1,
+    /// Page is a regular page.
     Reg = 2,
+    /// Page is a Version Array.
     Va = 3,
+    /// Page is in trimmed state.
     Trim = 4,
 }
 
@@ -47,7 +72,9 @@ pub enum Class {
 #[derive(Copy, Clone, Debug)]
 #[repr(C, align(64))]
 pub struct SecInfo {
+    /// Section 38.11.1
     pub flags: Flags,
+    /// Section 38.11.2
     pub class: Class,
     reserved: [u16; 31],
 }
@@ -64,6 +91,7 @@ impl AsRef<[u8]> for SecInfo {
 }
 
 impl SecInfo {
+    /// Creates a SecInfo (page) of class type Regular.
     pub const fn reg(flags: Flags) -> Self {
         Self {
             flags,
@@ -72,6 +100,7 @@ impl SecInfo {
         }
     }
 
+    /// Creates a SecInfo (page) of class type TCS.
     pub const fn tcs() -> Self {
         Self {
             flags: Flags::empty(),

--- a/sgx-types/src/secs.rs
+++ b/sgx-types/src/secs.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Red Hat, Inc.
+// Copyright 2020 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,29 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! SECS (Section 38.7)
+//! The SGX Enclave Control Structure (SECS) is a special enclave page that is not
+//! visible in the address space. In fact, this structure defines the address
+//! range and other global attributes for the enclave and it is the first EPC
+//! page created for any enclave. It is moved from a temporary buffer to an EPC
+//! by the means of ENCLS(ECREATE) leaf.
+
 use super::{attr, isv, misc::MiscSelect, sig::Contents};
 
-/// The SGX Enclave Control Structure (SECS) is a special enclave page that is not
-/// visible in the address space. In fact, this structure defines the address
-/// range and other global attributes for the enclave and it is the first EPC
-/// page created for any enclave. It is moved from a temporary buffer to an EPC
-/// by the means of ENCLS(ECREATE) leaf.
-///
 /// Section 38.7
 #[derive(Copy, Clone, Debug)]
 #[repr(C, align(4096))]
 pub struct Secs {
+    /// Size of address space (power of 2).
     pub size: u64,
+    /// Base address of address space.
     pub base: u64,
+    /// Size of an SSA frame.
     pub ssa_size: u32,
+    /// Enumerates info the processor can save into the MISC region of SSA when an AEX occurs.
     pub misc: MiscSelect,
     reserved0: [u8; 24],
+    /// Enclave attributes as described in Table 38-3.
     pub attr: attr::Attributes,
+    /// SHA256 hash of enclave contents.
     pub mrenclave: [u8; 32],
     reserved1: [u8; 32],
+    /// SHA256 hash of pubkey used to sign SIGSTRUCT.
     pub mrsigner: [u8; 32],
     reserved2: [u64; 12],
+    /// User-defined value used in key derivation.
     pub isv_prod_id: isv::ProdId,
+    /// User-defined value used in key derivation.
     pub isv_svn: isv::Svn,
 }
 
@@ -56,8 +66,10 @@ testaso! {
 }
 
 impl Secs {
+    /// TODO: The max size of an enclave should come from CPUID, which is inaccessible from within SGX.
     pub const SIZE_MAX: u64 = 0x1_000_000_000;
 
+    /// Creates a new SECS struct based on a base address, size, SSA size, and Contents.
     pub fn new(base: u64, size: u64, ssa: u32, mrsigner: [u8; 32], contents: &Contents) -> Self {
         Self {
             size,

--- a/sgx-types/src/tcs.rs
+++ b/sgx-types/src/tcs.rs
@@ -1,6 +1,24 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Thread Control Structure (Section 38.8)
+//! Each executing thread in the enclave is associated with a Thread Control Structure.
+
 bitflags::bitflags! {
     /// Section 38.8.1
     pub struct Flags: u64 {
+        /// Allows debugging features while executing in the enclave on this TCS. Hardware clears this bit on EADD.
         const DBGOPTIN = 1 << 0;
     }
 }
@@ -14,20 +32,32 @@ bitflags::bitflags! {
 #[derive(Debug)]
 #[repr(C, align(4096))]
 pub struct Tcs {
-    pub state: u64,         // used to mark an entered TCS
-    pub flags: Flags,       // execution flags (cleared by EADD)
-    pub ssa_offset: u64,    // SSA stack offset relative to the enclave base
-    pub ssa_index: u32,     // the current SSA frame index (cleard by EADD)
-    pub nr_ssa_frames: u32, // the number of frames in the SSA stack
-    pub entry_offset: u64,  // entry point offset relative to the enclave base
-    pub exit_addr: u64,     // address outside enclave to exit on an exception or interrupt
-    pub fs_offset: u64, // offset relative to enclave base to become FS segment inside the enclave
-    pub gs_offset: u64, // offset relative to enclave base to become GS segment inside the enclave
-    pub fs_limit: u32,  // size to become a new FS-limit (only 32-bit enclaves)
-    pub gs_limit: u32,  // size to become a new GS-limit (only 32-bit enclaves)
+    /// Used to mark an entered TCS.
+    state: u64,
+    /// Execution flags (cleared by EADD)
+    flags: Flags,
+    /// SSA stack offset relative to the enclave base
+    ssa_offset: u64,
+    /// The current SSA frame index (cleared by EADD)
+    ssa_index: u32,
+    /// The number of frames in the SSA stack
+    nr_ssa_frames: u32,
+    /// Entry point offset relative to the enclave base.
+    entry_offset: u64,
+    /// Address outside enclave to exit on an exception or interrupt.
+    exit_addr: u64,
+    /// Offset relative to enclave base to become FS segment inside the enclave.
+    fs_offset: u64,
+    /// Offset relative to enclave base to become GS segment inside the enclave.
+    gs_offset: u64,
+    /// Size to become a new FS-limit (only 32-bit enclaves).
+    fs_limit: u32,
+    /// Size to become a new GS-limit (only 32-bit enclaves).
+    gs_limit: u32,
 }
 
 impl Tcs {
+    /// Creates new TCS from an entry offset, SSA offset, and number of SSA frames.
     pub const fn new(entry: u64, ssa: u64, nssa: u32) -> Self {
         Self {
             state: 0,


### PR DESCRIPTION
Fixes #28 and fixes #58 for `sgx-types` and `sgx-crypto` crates (no other crates were modified). 

Added `#![deny(missing_docs)]` to these crates, so it is possible that the requirements are too verbose at this point, for example in `pub struct Gpr` in `sgx-types/src/ssa.rs` where all registers have to be labeled. 

Edit: Also added the licensing info to each file in these two crates.