### PR TITLE
Update CONTRIBUTING.md to point to the How to contribute page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing to the Enarx project
 The Enarx project welcomes contributions!
 
-Please refer to our [guidelines](https://github.com/enarx/enarx.github.io/blob/master/CONTRIBUTING.md) for information on how to do so.
+Please refer to our [guidelines](https://github.com/enarx/enarx/wiki/How-to-contribute) for information on how to do so.


### PR DESCRIPTION
Moving things around so we eventually have:
enarx/enarx.github.io/CONTRIBUTING.md --> https://github.com/enarx/enarx/wiki/How-to-contribute
enarx/enarx/CONTRIBUTING.md --> https://github.com/enarx/enarx/wiki/How-to-contribute

Companion PR to https://github.com/enarx/enarx.github.io/pull/23.