### PR TITLE
Implement Travis tests as git pre-push hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,11 @@ matrix:
       rust: stable
       install:
         - cargo install --force cargo-audit
-      script:
-        - cargo audit
+      script: ./hooks/pre-push.d/cargo-audit --force
     - name: "sev"
       rust: stable
       script:
         - cargo test --manifest-path sev/Cargo.toml --verbose --features=openssl
 install:
   - rustup component add rustfmt
-script:
-  - cargo fmt -- --check
-  - cargo test
+script: ./hooks/pre-push

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+for f in $0.d/*; do $f; done

--- a/hooks/pre-push.d/cargo-audit
+++ b/hooks/pre-push.d/cargo-audit
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+[[ -n "$TRAVIS" && "$1" != "--force" ]] && exit 0
+cargo audit

--- a/hooks/pre-push.d/cargo-fmt
+++ b/hooks/pre-push.d/cargo-fmt
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+cargo fmt -- --check

--- a/hooks/pre-push.d/cargo-test
+++ b/hooks/pre-push.d/cargo-test
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+cargo test


### PR DESCRIPTION
This PR moves all the tests we were previously running in Travis to shell scripts within the `hooks` folder. This allows us to run these tests before push time, ensuring that _every_ commit passes tests locally before being pushed remotely.

Since the tests now exist in their own file, Travis has also been updated to call that file (for organization). To add new tests, we should only need to add a new shell script to `hooks/pre-push.d`, and they will run both pre-push and on Travis.

Resolves #43. 