### PR TITLE
Update README using the one from the enarx.github.io repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,67 @@
 # Enarx
-A client for deploying WebAssembly applications into Enarx Keeps.
 
-This is currently a placeholder repository.
+## Introduction
+Enarx is an application deployment system enabling applications to run within Trusted Execution Environments (TEEs) without rewriting for particular platforms or SDKs. It handles attestation and delivery into a run-time “Keep” based on WebAssembly, offering developers a wide range of language choices for implementation. Enarx is CPU-architecture independent, enabling the same application code to be deployed across multiple targets, abstracting issues such as cross-compilation and differing attestation mechanisms between hardware vendors. Work is currently underway on AMD SEV and Intel SGX.
 
-In the meantime, please refer to the [project's documentation](https://github.com/enarx/enarx.github.io/wiki/Enarx-Introduction) for more information.
+We've known for a long time that we need encryption for data at rest and in transit: Enarx helps you do encryption for data as well as algorithms in use.
 
-# Setting up the Development Environment
+[Read more](https://github.com/enarx/enarx/wiki/Enarx-Introduction)
 
-## debian, Ubuntu
+## Project aim
+Create a way to create and run "private, fungible, serverless" applications using Trusted Execution Environments (TEEs). In other words, to provide a platform abstraction for TEEs.
+
+They should:
+
+ * be confidential from the host and other workloads;
+ * be able to run on
+   * multiple silicon architectures;
+   * multiple server types;
+   * public cloud or private cloud;
+ * employ serverless deployment and execution mechanisms.
+
+The mechanism itself should be capable of being FIPS-certified.
+
+## Getting Started
+
+For more information, please try our [wiki](https://github.com/enarx/enarx/wiki), which includes further details on how to get more information.  It's also where we plan to keep up-to-date project information.
+
+Building the various components of Enarx is currently complex: we are working on this.  Please contact us for help.
+
+(2020-01-01) It is also worth mentioning that it isn't yet possible to run Enarx.  We're working hard on it and we'd love people to work with us. We hope to be adding more information very soon, to allow you to get started.
+
+### Setting up the Development Environment
+
+#### Debian, Ubuntu
 
 Additional packages:
 * libssl-dev
 * musl-dev
 * musl-tools
 
-## Fedora
+#### Fedora
 
-`musl` is not in the standard repos, so you need to get them from a copr like
+`musl` is not in the standard repos, so you need to get it from a copr such as
  https://copr.fedorainfracloud.org/coprs/taocris/musl/
 
+To do so:
 ```bash
 # dnf copr enable taocris/musl
 # dnf install musl-devel musl-libc-static musl-gcc musl-clang 
 ```
 
-## Rust
+#### Rust
 
 ```bash
 $ rustup target add x86_64-unknown-linux-musl
 ```
+
+## Authors
+
+* **Mike Bursell** - *Initial work* - [MikeCamel](https://github.com/MikeCamel)
+  **Harald Hoyer** - *Technical details* - [haraldh](https://github.com/haraldh)
+
+See also the list of [people](https://github.com/orgs/enarx/people) who participate in this project.
+
+## License
+
+This project is licensed under the Apache 2.0 license - see the [LICENSE](LICENSE) file for details


### PR DESCRIPTION
Update README, using the one initially created for the enarx.github.io repo.
Closes #137.

There's also a PR to update the README in the other repo, enarx/enarx.github.io#25.