### PR TITLE
Implement issue templates for "Tech" and "Questions"

### DIFF
--- a/.github/ISSUE_TEMPLATE/conferences.md
+++ b/.github/ISSUE_TEMPLATE/conferences.md
@@ -1,6 +1,6 @@
 ---
-name: Conferences
-about: tracking conferences with issues
+name: Conference
+about: Submit a conference for the Enarx project to present at.
 title: Event name - date
 labels: conferences
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Have a question about the project? Ask it here!
+title: What are you wondering about?
+labels: question
+assignees: ''
+
+---
+**Question**
+What are you wondering about? Provide as much detail as you feel is necessary. We'll try and answer within our abilities to do so!

--- a/.github/ISSUE_TEMPLATE/technical.md
+++ b/.github/ISSUE_TEMPLATE/technical.md
@@ -1,0 +1,17 @@
+---
+name: Tech
+about: A task, enhancement idea, or bug report related to the technical aspects of the project.
+title: Description of the the issue
+labels: ''
+assignees: ''
+
+---
+**Description**
+What needs to be improved? What should be done? Has there been any related work before? Any relevant links or material?
+
+**Organization**
+If you have the appropriate repo permissions, please don't forget:
+- Properly label your issue and place it in the appropriate project.
+- If you assign yourself or someone else, please ensure the project status is updated to "Assigned".
+
+Finally, please delete any template boilerplate before submitting!


### PR DESCRIPTION
Create basic templates for asking questions and submitting technical issues. For now, there's little structure enforced, but this can change as we recognize potential automation opportunities.

For Tech issues, I've included some boilerplate reminders about project organization. These can be removed if we find a better solution -- I was thinking it would make sense to link to an "Issue etiquette" section of the wiki from the issue creation screen. See #155 for more.

The PR also includes a small formatting/description fix to make the Conferences template feel consistent with the rest.

Resolves #38.

