### PR TITLE
use musl as default build target via .cargo/config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-musl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ rust:
   - stable
   - beta
   - nightly
+addons:
+  apt:
+    packages: libssl-dev musl-dev musl-tools
 matrix:
   allow_failures:
     - rust: nightly
@@ -34,4 +37,5 @@ matrix:
         - cargo test --manifest-path sev/Cargo.toml --verbose --features=openssl
 install:
   - rustup component add rustfmt
+  - rustup target add x86_64-unknown-linux-musl
 script: ./hooks/pre-push

--- a/README.md
+++ b/README.md
@@ -4,3 +4,28 @@ A client for deploying WebAssembly applications into Enarx Keeps.
 This is currently a placeholder repository.
 
 In the meantime, please refer to the [project's documentation](https://github.com/enarx/enarx.github.io/wiki/Enarx-Introduction) for more information.
+
+# Setting up the Development Environment
+
+## debian, Ubuntu
+
+Additional packages:
+* libssl-dev
+* musl-dev
+* musl-tools
+
+## Fedora
+
+`musl` is not in the standard repos, so you need to get them from a copr like
+ https://copr.fedorainfracloud.org/coprs/taocris/musl/
+
+```bash
+# dnf copr enable taocris/musl
+# dnf install musl-devel musl-libc-static musl-gcc musl-clang 
+```
+
+## Rust
+
+```bash
+$ rustup target add x86_64-unknown-linux-musl
+```

--- a/iocuddle-sgx/Cargo.toml
+++ b/iocuddle-sgx/Cargo.toml
@@ -13,5 +13,5 @@ sgx-types = { path = "../sgx-types" }
 
 [dev-dependencies]
 sgx-crypto = { path = "../sgx-crypto" }
-openssl = "0.10.26"
+openssl = { version = "0.10.26", features = [ "vendored" ] }
 rstest = "0.5.2"

--- a/sev/Cargo.toml
+++ b/sev/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 default = []
 
 [dependencies]
-openssl = { version = "0.10.26", optional = true }
+openssl = { version = "0.10.26", optional = true, features = [ "vendored" ] }
 bitflags = "1.2.1"
 codicon = "2.1.0"

--- a/sgx-crypto/Cargo.toml
+++ b/sgx-crypto/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 sgx-types = { path = "../sgx-types" }
-openssl = "0.10.26"
+openssl = { version = "0.10.26", features = [ "vendored" ] }


### PR DESCRIPTION
for openssl, turn on the vendored feature, which propagated to
openssl-sys

Fixes https://github.com/enarx/enarx/issues/6