### PR TITLE
Add clippy hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,6 @@ matrix:
         - cargo test --manifest-path sev/Cargo.toml --verbose --features=openssl
 install:
   - rustup component add rustfmt
+  - rustup component add clippy
   - rustup target add x86_64-unknown-linux-musl
 script: ./hooks/pre-push

--- a/hooks/pre-push.d/cargo-clippy
+++ b/hooks/pre-push.d/cargo-clippy
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for f in `dirname $0`/../../*/Cargo.toml; do
+    cargo clippy --manifest-path=$f
+done

--- a/linux-errno/src/lib.rs
+++ b/linux-errno/src/lib.rs
@@ -14,6 +14,7 @@
 
 //! errno type and constants for various architectures
 #![no_std]
+#![deny(clippy::all)]
 
 /// x86 errno
 pub mod x86_64;

--- a/linux-syscall/src/lib.rs
+++ b/linux-syscall/src/lib.rs
@@ -14,6 +14,7 @@
 
 //! syscall type and constants for various architectures
 #![no_std]
+#![deny(clippy::all)]
 
 /// x86_64 syscalls
 pub mod x86_64;

--- a/sev/src/certs/ca/cert/v1.rs
+++ b/sev/src/certs/ca/cert/v1.rs
@@ -138,7 +138,7 @@ macro_rules! traits {
                     if let Err(e) = reader.read_exact(&mut signature[..]) {
                         if e.kind() != ErrorKind::UnexpectedEof
                             && preamble != NAPLES_ARK {
-                            Err(e)?
+                            return Err(e);
                         }
 
                         signature[..].copy_from_slice(NAPLES_ARK_SIG);
@@ -164,7 +164,7 @@ pub union Certificate {
 impl std::fmt::Debug for Certificate {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if unsafe { self.preamble.data.psize != self.preamble.data.msize } {
-            Err(std::fmt::Error)?
+            return Err(std::fmt::Error);
         }
 
         match u32::from_le(unsafe { self.preamble.data.msize }) {

--- a/sev/src/certs/ca/mod.rs
+++ b/sev/src/certs/ca/mod.rs
@@ -36,7 +36,7 @@ impl TryFrom<super::Usage> for Usage {
         Ok(match value {
             super::Usage::ARK => Usage::ARK,
             super::Usage::ASK => Usage::ASK,
-            _ => Err(())?,
+            _ => return Err(()),
         })
     }
 }

--- a/sev/src/certs/mod.rs
+++ b/sev/src/certs/mod.rs
@@ -100,7 +100,7 @@ impl std::fmt::Display for Usage {
                 Usage::ARK => "ARK",
                 Usage::ASK => "ASK",
                 Usage::INV => "INV",
-                _ => Err(std::fmt::Error)?,
+                _ => return Err(std::fmt::Error),
             }
         )
     }

--- a/sev/src/certs/sev/mod.rs
+++ b/sev/src/certs/sev/mod.rs
@@ -40,7 +40,7 @@ impl TryFrom<super::Usage> for Usage {
             super::Usage::CEK => Usage::CEK,
             super::Usage::PEK => Usage::PEK,
             super::Usage::PDH => Usage::PDH,
-            _ => Err(())?,
+            _ => return Err(()),
         })
     }
 }

--- a/sev/src/certs/util.rs
+++ b/sev/src/certs/util.rs
@@ -64,6 +64,7 @@ impl IntoLe<[u8; 512]> for openssl::bn::BigNumRef {
 
 pub trait TypeLoad: Read {
     fn load<T: Sized + Copy>(&mut self) -> Result<T> {
+        #[allow(clippy::uninit_assumed_init)]
         let mut t = unsafe { MaybeUninit::uninit().assume_init() };
         let p = &mut t as *mut T as *mut u8;
         let s = unsafe { from_raw_parts_mut(p, size_of::<T>()) };

--- a/sev/src/firmware/linux.rs
+++ b/sev/src/firmware/linux.rs
@@ -81,6 +81,7 @@ impl Firmware {
             guest_count: u32,
         }
 
+        #[allow(clippy::uninit_assumed_init)]
         let i: Info = self.cmd(Code::PlatformStatus, unsafe {
             MaybeUninit::uninit().assume_init()
         })?;
@@ -99,7 +100,7 @@ impl Firmware {
                 0 => State::Uninitialized,
                 1 => State::Initialized,
                 2 => State::Working,
-                _ => Err(Indeterminate::Unknown)?,
+                _ => return Err(Indeterminate::Unknown),
             },
         })
     }
@@ -116,6 +117,7 @@ impl Firmware {
             len: u32,
         }
 
+        #[allow(clippy::uninit_assumed_init)]
         let mut pek: Certificate = unsafe { MaybeUninit::uninit().assume_init() };
 
         self.cmd(
@@ -143,7 +145,9 @@ impl Firmware {
             chain_size: u32,
         }
 
+        #[allow(clippy::uninit_assumed_init)]
         let mut chain: [Certificate; 3] = unsafe { MaybeUninit::uninit().assume_init() };
+        #[allow(clippy::uninit_assumed_init)]
         let mut pdh: Certificate = unsafe { MaybeUninit::uninit().assume_init() };
 
         self.cmd(
@@ -200,6 +204,7 @@ impl Firmware {
         #[repr(C, packed)]
         struct Ids([u8; 64], [u8; 64]);
 
+        #[allow(clippy::uninit_assumed_init)]
         let ids: Ids = self.cmd(Code::GetIdentifier, unsafe {
             MaybeUninit::uninit().assume_init()
         })?;

--- a/sev/src/lib.rs
+++ b/sev/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(clippy::all)]
+#![deny(clippy::all)]
 #![allow(unknown_lints)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::unreadable_literal)]

--- a/sgx-show/src/data/cpuid.rs
+++ b/sgx-show/src/data/cpuid.rs
@@ -34,21 +34,23 @@ pub trait Leaf: std::fmt::Display {
 
 pub struct CpuId<T: Leaf>(pub u128, PhantomData<T>);
 
+#[allow(clippy::identity_op)]
+#[allow(clippy::erasing_op)]
 impl<T: Leaf> CpuId<T> {
     pub fn eax(&self) -> u32 {
-        (self.0 >> 3 * 32) as u32
+        (self.0 >> (3 * 32)) as u32
     }
 
     pub fn ebx(&self) -> u32 {
-        (self.0 >> 2 * 32) as u32
+        (self.0 >> (2 * 32)) as u32
     }
 
     pub fn ecx(&self) -> u32 {
-        (self.0 >> 1 * 32) as u32
+        (self.0 >> (1 * 32)) as u32
     }
 
     pub fn edx(&self) -> u32 {
-        (self.0 >> 0 * 32) as u32
+        (self.0 >> (0 * 32)) as u32
     }
 }
 

--- a/sgx-show/src/exec.rs
+++ b/sgx-show/src/exec.rs
@@ -41,7 +41,7 @@ impl<T, U: TryFrom<T>> Executor for Test<T, U> {
 
         if success {
             if let Some(t) = self.data.data() {
-                if let Some(u) = U::try_from(t).ok() {
+                if let Ok(u) = U::try_from(t) {
                     if self.sink.test(&u) {
                         data = Some(u);
                     }

--- a/sgx-show/src/main.rs
+++ b/sgx-show/src/main.rs
@@ -23,6 +23,10 @@
 //!
 //! There is currently only one data source (CPUID).
 
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![allow(clippy::unreadable_literal)]
+
 mod data;
 mod exec;
 mod sink;


### PR DESCRIPTION
This addresses one part of https://github.com/enarx/enarx/issues/153 . It doesn't turn on `#![deny(missing_docs)]` because I don't have the necessary context to add all the missing docs.