### PR TITLE
Fix build

### DIFF
--- a/iocuddle-sgx/Cargo.toml
+++ b/iocuddle-sgx/Cargo.toml
@@ -13,7 +13,7 @@ sgx-types = { path = "../sgx-types" }
 
 [dev-dependencies]
 sgx-crypto = { path = "../sgx-crypto" }
-openssl = "0.10.26"
+openssl = "0.10.27"
 rstest = "0.5.2"
 
 [patch.crates-io]

--- a/sev/Cargo.toml
+++ b/sev/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 default = []
 
 [dependencies]
-openssl = { version = "0.10.26", optional = true }
+openssl = { version = "0.10.27", optional = true }
 bitflags = "1.2.1"
 codicon = "2.1.0"

--- a/sgx-crypto/Cargo.toml
+++ b/sgx-crypto/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 sgx-types = { path = "../sgx-types" }
-openssl = "0.10.26"
+openssl = "0.10.27"
 
 [patch.crates-io]
 openssl = { git = 'https://github.com/npmccallum/rust-openssl', branch='patch' }


### PR DESCRIPTION
Upstream rust-openssl released a new release, which meant that our
patches were no longer applied. I have retarted the new release and
updated my patch branch.