### PR TITLE
Measure SSA frame size in 4k pages

### DIFF
--- a/sgx-types/src/secs.rs
+++ b/sgx-types/src/secs.rs
@@ -7,7 +7,7 @@
 //! page created for any enclave. It is moved from a temporary buffer to an EPC
 //! by the means of ENCLS(ECREATE) leaf.
 
-use super::{attr, isv, misc::MiscSelect, sig::Contents};
+use super::{attr, isv, misc::MiscSelect, sig::Contents, ssa::StateSaveArea};
 use core::num::{NonZeroU32, NonZeroU64};
 
 /// An enclave's size specification
@@ -66,6 +66,15 @@ impl Spec {
         let res = unsafe { __cpuid_count(LEAF_MAX_ENCL_SIZE, SUBLEAF_MAX_ENCL_SIZE) };
         let max_size: u64 = 1 << (res.edx >> 8 as u8) as u64;
         Some(NonZeroU64::new(max_size).unwrap())
+    }
+}
+
+impl Default for Spec {
+    fn default() -> Self {
+        Self {
+            enc_size: Spec::max_enc_size().unwrap(),
+            ssa_size: StateSaveArea::frame_size(),
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #200 

@npmccallum Let me know what you think of this or if further changes are needed. 

I added the 4096 alignment requirement to `SSA` because the documentation says that the end of the `GPR` section (the last section in `SSA`) must be aligned to the end of a page. For this reason, if the size of `SSA` is not a multiple of 4096, `SSA::frame_size()` returns `None`.

I wasn't sure whether we want a `secs::Spec::ssa_size()` function, so I added one that just calls the one from `SSA`.

I also didn't see any code that uses the SSA frame size and explicitly expects it to be in bytes; if I missed any of these that you know of, please let me know and I'll update them. [This line](https://github.com/enarx/enarx/blob/master/iocuddle-sgx/src/lib.rs#L140) in `iocuddle-sgx/src/lib.rs` might be one, but it's an arbitrary value that seems like it could refer to pages as easily as bytes.