### PR TITLE
Test all Cargo.toml files for edition = "2018"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,5 @@ install:
   - rustup component add rustfmt
   - rustup component add clippy
   - rustup target add x86_64-unknown-linux-musl
+  - cargo install toml-cli
 script: ./hooks/pre-push

--- a/hooks/pre-push.d/cargo-edition-test
+++ b/hooks/pre-push.d/cargo-edition-test
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+top=`git rev-parse --show-toplevel`
+status=0
+for file in $(find "$top" -name Cargo.toml); do
+    if [ "$(toml get "$file" package.edition)" != '"2018"' ]; then
+        echo "$file is not using edition = "2018"."
+        echo "Please ensure the field is present and includes the correct Rust edition."        
+        status=1
+    fi
+done
+exit $status


### PR DESCRIPTION
Resolves #161.

An extension of the `Cargo.toml` license test from #162. If that changes upon merge, changes from it should be echoed here.