### PR TITLE
Mark secs::Spec::max_enc_size() as safe

### DIFF
--- a/iocuddle-sgx/src/lib.rs
+++ b/iocuddle-sgx/src/lib.rs
@@ -128,7 +128,7 @@ mod test {
         const SSA_SIZE: u32 = 0x1000;
 
         let spec = secs::Spec {
-            enc_size: unsafe { secs::Spec::max_enc_size().unwrap() },
+            enc_size: secs::Spec::max_enc_size().unwrap(),
             ssa_size: NonZeroU32::new(SSA_SIZE).unwrap(),
         };
 

--- a/sgx-types/src/secs.rs
+++ b/sgx-types/src/secs.rs
@@ -26,9 +26,23 @@ impl Spec {
     /// For more on CPUID enumeration leaves, see 37.7.2 and Table 37-4.
     ///
     /// # Safety
-    /// This function is unsafe because it does not check if the `CPUID` instruction
-    /// is available before issuing it.
-    pub unsafe fn max_enc_size() -> Option<NonZeroU64> {
+    /// This function is technically unsafe because it does not check if the
+    /// `CPUID` instruction is available before issuing it. This could result
+    /// in a crash on some very old CPUs. However, the only modern context
+    /// where it could crash is environments like SGX or some virtualized
+    /// CPUs. But even in these contexts, it is common to trap and emulate the
+    /// instruction.
+    ///
+    /// Therefore, it is common practice to ignore the test to see if the
+    /// `CPUID` instruction is available and just issue it anyway. For this
+    /// reason, we are marking this function as safe. For more background to
+    /// the state of `CPUID` in Rust, see:
+    ///
+    /// https://github.com/rust-lang/rust/issues/60123
+    ///
+    pub fn max_enc_size() -> Option<NonZeroU64> {
+        use core::arch::x86_64::{__cpuid_count, __get_cpuid_max};
+
         const LEAF_MAX_PARAM: u32 = 0x0;
         const LEAF_SGX_SUPPORT: u32 = 0x07;
         const SUBLEAF_SGX_SUPPORT: u32 = 0x0;
@@ -36,20 +50,20 @@ impl Spec {
         const SUBLEAF_MAX_ENCL_SIZE: u32 = 0x0;
 
         // Test for max leaf size
-        let res = core::arch::x86_64::__get_cpuid_max(LEAF_MAX_PARAM);
+        let res = unsafe { __get_cpuid_max(LEAF_MAX_PARAM) };
         let max_leaf = res.0;
         if max_leaf < LEAF_SGX_SUPPORT || max_leaf < LEAF_MAX_ENCL_SIZE {
             return None;
         }
 
         // Test for SGX support
-        let res = core::arch::x86_64::__cpuid_count(LEAF_SGX_SUPPORT, SUBLEAF_SGX_SUPPORT);
+        let res = unsafe { __cpuid_count(LEAF_SGX_SUPPORT, SUBLEAF_SGX_SUPPORT) };
         if res.ebx & (1 << 2) == 0 {
             return None;
         }
 
         // Test for max enclave size
-        let res = core::arch::x86_64::__cpuid_count(LEAF_MAX_ENCL_SIZE, SUBLEAF_MAX_ENCL_SIZE);
+        let res = unsafe { __cpuid_count(LEAF_MAX_ENCL_SIZE, SUBLEAF_MAX_ENCL_SIZE) };
         let max_size: u64 = 1 << (res.edx >> 8 as u8) as u64;
         Some(NonZeroU64::new(max_size).unwrap())
     }


### PR DESCRIPTION
This function is technically unsafe because it does not check if the
instruction is available before issuing it. This could result in a crash
on some very old CPUs. However, the only modern context where it could
crash is environments like SGX or some virtualized CPUs. But even in
these contexts, it is common to trap and emulate the instruction.

Therefore, it is common practice to ignore the test to see if the
instruction is available and just issue it anyway. For this reason, we
are marking this function as safe. For more background to the state of
CPUID in Rust, see:

https://github.com/rust-lang/rust/issues/60123