### PR TITLE
Implement an interim sev-show

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "sgx-crypto",
 
     "sev",
+    "sev-show",
 ]
 
 [patch.crates-io]

--- a/sev-show/Cargo.toml
+++ b/sev-show/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+colored = "1.9.1"

--- a/sev-show/Cargo.toml
+++ b/sev-show/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sev-show"
+version = "0.1.0"
+authors = ["Connor Kuehl <ckuehl@redhat.com>"]
+license = "Apache-2.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/sev-show/LICENSE
+++ b/sev-show/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -101,6 +101,14 @@ fn main() {
                         }),
                         dependents: vec![],
                     },
+                    Test {
+                        name: "C-bit location in page table entry",
+                        func: Box::new(move || {
+                            let field = enc_mem_caps.ebx & 0b01_1111;
+                            (Ok(()), Some(format!(": {}", field)))
+                        }),
+                        dependents: vec![],
+                    },
                 ],
             },
         ],

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -37,6 +37,7 @@ fn emit_results(tests: Vec<CompletedTest>, indent: usize) {
 
 fn main() {
     let cpuid = unsafe { __cpuid_count(0x0000_0000, 0x0000_0000) };
+    let enc_mem_caps = unsafe { __cpuid_count(0x8000_001f, 0x0000_0000) };
 
     let tests = vec![Test {
         name: "AMD CPU",
@@ -53,6 +54,18 @@ fn main() {
             }
         }),
         dependents: vec![
+            Test {
+                name: "SME support",
+                func: Box::new(move || {
+                    if (enc_mem_caps.eax & (1 << 0)) != 0 {
+                        (Ok(()), None)
+                    } else {
+                        (Err(()), None)
+                    }
+                }),
+                dependents: vec![
+                ],
+            },
         ],
     }];
 

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -175,6 +175,16 @@ fn main() {
                         }),
                         dependents: vec![],
                     },
+                    Test {
+                        name: "File is writable by user",
+                        func: Box::new(|| {
+                            match std::fs::OpenOptions::new().write(true).open("/dev/sev") {
+                                Ok(_) => (Ok(()), None),
+                                Err(e) => (Err(()), Some(format!(": {}", e))),
+                            }
+                        }),
+                        dependents: vec![],
+                    },
                 ],
             },
         ],

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -144,6 +144,17 @@ fn main() {
                 }),
                 dependents: vec![],
             },
+            Test {
+                name: "Page Flush MSR available",
+                func: Box::new(move || {
+                    if (enc_mem_caps.eax & (1 << 2)) != 0 {
+                        (Ok(()), None)
+                    } else {
+                        (Err(()), None)
+                    }
+                }),
+                dependents: vec![],
+            },
         ],
     }];
 

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -165,6 +165,16 @@ fn main() {
                     }
                 }),
                 dependents: vec![
+                    Test {
+                        name: "File is readable by user",
+                        func: Box::new(|| {
+                            match std::fs::OpenOptions::new().read(true).open("/dev/sev") {
+                                Ok(_) => (Ok(()), None),
+                                Err(e) => (Err(()), Some(format!(": {}", e))),
+                            }
+                        }),
+                        dependents: vec![],
+                    },
                 ],
             },
         ],

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -9,5 +9,38 @@
 //! Note: this will eventually be superseded by the consolidation
 //! of `sgx-show`-like utilities.
 
+mod show;
+
+use show::*;
+
+/// Emits the results described in `tests` and prints them in a
+/// tree-like fashion.
+fn emit_results(tests: Vec<CompletedTest>, indent: usize) {
+    use colored::*;
+
+    for test in tests {
+        let icon = if test.passed() {
+            "✔".green()
+        } else {
+            "✗".red()
+        };
+        let info = test.info.clone().unwrap_or("".to_string());
+
+        println!("{:>space$}{} {}{}", "", icon, test, info, space = indent);
+        if let Some(dependents) = test.dependents {
+            emit_results(dependents, indent + 2);
+        }
+    }
+}
+
 fn main() {
+    let tests = vec![Test {
+        name: "Stub",
+        func: Box::new(|| (Ok(()), None)),
+        dependents: vec![],
+    }];
+
+    let completed = tests.into_iter().map(|t| t.run()).collect();
+
+    emit_results(completed, 0);
 }

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -155,6 +155,18 @@ fn main() {
                 }),
                 dependents: vec![],
             },
+            Test {
+                name: "/dev/sev device special file exists",
+                func: Box::new(move || {
+                    if std::path::Path::new("/dev/sev").exists() {
+                        (Ok(()), None)
+                    } else {
+                        (Err(()), None)
+                    }
+                }),
+                dependents: vec![
+                ],
+            },
         ],
     }];
 

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -111,6 +111,18 @@ fn main() {
                     },
                 ],
             },
+            Test {
+                name: "SEV support",
+                func: Box::new(move || {
+                    if (enc_mem_caps.eax & (1 << 1)) != 0 {
+                        (Ok(()), None)
+                    } else {
+                        (Err(()), None)
+                    }
+                }),
+                dependents: vec![
+                ],
+            },
         ],
     }];
 

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -1,0 +1,11 @@
+//! This program performs various checks in the running system to
+//! discover hardware and kernel support for AMD Secure Encrypted
+//! Virtualization (SEV) technology. Like its counterpart, `sgx-show`,
+//! this program will create a tree-like hierarchy of tests to look
+//! for AMD SEV capabilities.
+//!
+//! Note: this will eventually be superseded by the consolidation
+//! of `sgx-show`-like utilities.
+
+fn main() {
+}

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -187,6 +187,25 @@ fn main() {
                     },
                 ],
             },
+            Test {
+                name: "SEV is enabled for kernel",
+                func: Box::new(move || {
+                    if std::path::Path::new("/sys/module/kvm_amd/parameters/sev").exists() {
+                        let param =
+                            std::fs::read_to_string("/sys/module/kvm_amd/parameters/sev").unwrap();
+                        let param = param.trim();
+
+                        if param == "1" {
+                            (Ok(()), None)
+                        } else {
+                            (Err(()), None)
+                        }
+                    } else {
+                        (Err(()), None)
+                    }
+                }),
+                dependents: vec![],
+            },
         ],
     }];
 

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -121,6 +121,11 @@ fn main() {
                     }
                 }),
                 dependents: vec![
+                    Test {
+                        name: "Number of encrypted guests supported simultaneously",
+                        func: Box::new(move || (Ok(()), Some(format!(": {}", enc_mem_caps.ecx)))),
+                        dependents: vec![],
+                    },
                 ],
             },
         ],

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -126,6 +126,11 @@ fn main() {
                         func: Box::new(move || (Ok(()), Some(format!(": {}", enc_mem_caps.ecx)))),
                         dependents: vec![],
                     },
+                    Test {
+                        name: "Minimum ASID value for SEV-enabled, SEV-ES disabled guest",
+                        func: Box::new(move || (Ok(()), Some(format!(": {}", enc_mem_caps.edx)))),
+                        dependents: vec![],
+                    },
                 ],
             },
         ],

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -93,6 +93,14 @@ fn main() {
                     }
                 }),
                 dependents: vec![
+                    Test {
+                        name: "Physical address bit reduction",
+                        func: Box::new(move || {
+                            let field = (enc_mem_caps.ebx & 0b1111_1100_0000) >> 6;
+                            (Ok(()), Some(format!(": {}", field)))
+                        }),
+                        dependents: vec![],
+                    },
                 ],
             },
         ],

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -133,6 +133,17 @@ fn main() {
                     },
                 ],
             },
+            Test {
+                name: "SEV-ES support",
+                func: Box::new(move || {
+                    if (enc_mem_caps.eax & (1 << 3)) != 0 {
+                        (Ok(()), None)
+                    } else {
+                        (Err(()), None)
+                    }
+                }),
+                dependents: vec![],
+            },
         ],
     }];
 

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! This program performs various checks in the running system to
 //! discover hardware and kernel support for AMD Secure Encrypted
 //! Virtualization (SEV) technology. Like its counterpart, `sgx-show`,

--- a/sev-show/src/show.rs
+++ b/sev-show/src/show.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+/// A yet-to-be-ran test
+pub struct Test {
+    /// A good description of what the test is for
+    pub name: &'static str,
+
+    /// A function or closure that will perform a single test. This returns
+    /// a tuple consisting of a Result that indicates if the test passed or
+    /// failed, as well as an optional string that can convey more information
+    /// in the test's output.
+    pub func: Box<dyn Fn() -> (Result<(), ()>, Option<String>)>,
+
+    /// Any dependent tests that may be ran if this parent test passes
+    /// (example: it doesn't make sense to run any AMD-specific tests if
+    /// running on an Intel chip)
+    pub dependents: Vec<Test>,
+}
+
+impl Test {
+    /// Consumes the `Test`, executes the test function and captures its
+    /// result. If this test passes, it will recursively kick off and subsequently
+    /// capture any of the child tests (and their child tests (and their child tests))
+    pub fn run(self) -> CompletedTest {
+        let (res, optional_info) = (self.func)();
+
+        let deps = match res {
+            Ok(_) => Some(self.dependents.into_iter().map(|d| d.run()).collect()),
+            Err(_) => None,
+        };
+
+        CompletedTest {
+            name: self.name,
+            info: optional_info,
+            dependents: deps,
+        }
+    }
+}
+
+/// A test which has been ran and its success or failure captured (as well as its
+/// child tests, if applicable)
+pub struct CompletedTest {
+    /// The original `Test` description
+    name: &'static str,
+
+    pub info: Option<String>,
+
+    /// If the test did not pass, then `dependents` will be `None`. Otherwise,
+    /// `dependents` will be `Some` and will contain a `Vec` of the child
+    /// `CompletedTest`s.
+    pub dependents: Option<Vec<CompletedTest>>,
+}
+
+impl CompletedTest {
+    pub fn passed(&self) -> bool {
+        self.dependents.is_some()
+    }
+}
+
+impl fmt::Display for CompletedTest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_leaves_of_a_failed_test_are_not_ran() {
+        let test = Test {
+            name: "Doomed to fail",
+            func: Box::new(|| (Err(()), None)),
+            dependents: vec![Test {
+                name: "Shouldn't reach here",
+                func: Box::new(|| (Ok(()), None)),
+                dependents: vec![],
+            }],
+        };
+
+        let completed = test.run();
+        assert!(completed.dependents.is_none());
+    }
+
+    #[test]
+    fn test_leaves_of_a_passing_test_are_ran() {
+        let test = Test {
+            name: "Vacuously true",
+            func: Box::new(|| (Ok(()), None)),
+            dependents: vec![Test {
+                name: "Also true",
+                func: Box::new(|| (Ok(()), None)),
+                dependents: vec![],
+            }],
+        };
+
+        let completed = test.run();
+        assert!(completed.dependents.is_some());
+    }
+}


### PR DESCRIPTION
Closes #205.

Although it's likely this kind of platform discovery will be consolidated in the future, we should have something like `sgx-show` for SEV.

I believe I captured all of the SEV-related information described in the AMD Developer's Manual, but if I've missed some I will go back and add them.

Quick example:

```
✔ AMD CPU
  ✔ Processor is known to have microcode that supports SEV: AMD EPYC 7251 8-Core Processor                 
  ✔ SME support
    ✔ Physical address bit reduction: 5
    ✔ C-bit location in page table entry: 15
  ✔ SEV support
    ✔ Number of encrypted guests supported simultaneously: 15
    ✔ Minimum ASID value for SEV-enabled, SEV-ES disabled guest: 1
  ✔ SEV-ES support
  ✔ Page Flush MSR available
  ✔ /dev/sev device special file exists
    ✔ File is readable by user
    ✔ File is writable by user
  ✔ SEV is enabled for kernel
```