### PR TITLE
Enable and sanity-check Github Actions

### DIFF
--- a/.github/workflows/enarx-standard.yml
+++ b/.github/workflows/enarx-standard.yml
@@ -1,0 +1,12 @@
+name: Enarx Standard Tests
+# Automated testing run on all commits.
+
+on: [pull_request]
+
+jobs:
+  sanity-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Sanity-check test
+      run: true


### PR DESCRIPTION
This PR enables Github Actions by adding a basic workflow. For now, it runs two steps that succeed and fail, respectively (with the failure allowed). This is designed to sanity-check Actions' behavior before we begin migrating our full test suite over.

Resolves #235.