### PR TITLE
Replace LICENSE files w/ Github-provided version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/enarx-keepmgr/LICENSE
+++ b/enarx-keepmgr/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/intel-types/LICENSE
+++ b/intel-types/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/iocuddle-sgx/LICENSE
+++ b/iocuddle-sgx/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/iocuddle/LICENSE
+++ b/iocuddle/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/linux-errno/LICENSE
+++ b/linux-errno/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/linux-syscall/LICENSE
+++ b/linux-syscall/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/sev/LICENSE
+++ b/sev/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/sgx-crypto/LICENSE
+++ b/sgx-crypto/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/sgx-show/LICENSE
+++ b/sgx-show/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/sgx-types/LICENSE
+++ b/sgx-types/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/testing/LICENSE
+++ b/testing/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/vmsyscall/LICENSE
+++ b/vmsyscall/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
The original crate-level license test was designed to ensure our license files matched the reference copy found at http://www.apache.org/licenses/LICENSE-2.0.txt.

However, we've since changed that test to only check against the top-level project license in #220. Additionally, as highlighted in #219, the `apache.org` reference version doesn't match the Github-provided Apache 2.0 on whitespace. This means that any Github-generated files will fail the test unnecessarily.

Since we're no longer checking against the reference license on `apache.org`, I've changed all our license files to match the one Github provides. This should mean any Github-generated Apache licenses shouldn't cause the test to fail.

Resolves #219.