### PR TITLE
Implement a template for meta issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/meta.md
+++ b/.github/ISSUE_TEMPLATE/meta.md
@@ -1,0 +1,31 @@
+---
+name: Meta
+about: For larger, medium/long-term tasks that should be broken into easily-digestible pieces.
+title: Description of the eventual goal
+labels: 'meta'
+assignees: ''
+
+---
+**Description**
+What needs to be improved? What should be done? Has there been any related work before? Any relevant links or material?
+
+Feel free to be verbose. These issues are meant to facilitate conversations.
+
+**To do**
+List the tasks that need to be completed using checkboxes. If there are relevant issues, please include them as well.
+
+Here's an example of how you should format this list:
+
+- [ ] Install Fedora
+    - [ ] Make an install drive (#xyz)
+    - [ ] Make sure WiFi works
+- [ ] Watch the IT Crowd
+    - [ ] Put this over with the rest of the fire 
+    - [ ] Turn it off and on again (#abc)
+
+**Organization**
+If you have the appropriate repo permissions, please don't forget:
+- Properly label your issue and place it in the appropriate project.
+- If you assign yourself or someone else, please ensure the project status is updated to "Assigned".
+
+Finally, please delete any template boilerplate before submitting!


### PR DESCRIPTION
This goes along with a new `meta` label.

Please pay _close_ attention to the `To do` section. We should be on the same page about the list formatting.

Resolves #199.