### PR TITLE
Long live the workspace!

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-musl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+members = [
+    "iocuddle",
+    "iocuddle-sgx",
+
+    "linux-syscall",
+    "linux-errno",
+    "vmsyscall",
+
+    "sgx-show",
+    "sgx-types",
+    "sgx-crypto",
+
+    "sev",
+]
+
+[patch.crates-io]
+openssl = { git = 'https://github.com/npmccallum/rust-openssl', branch='patch' }

--- a/hooks/pre-push.d/cargo-audit
+++ b/hooks/pre-push.d/cargo-audit
@@ -1,8 +1,3 @@
 #!/bin/bash -e
 [[ -n "$TRAVIS" && "$1" != "--force" ]] && exit 0
-
-for f in `dirname $0`/../../*/Cargo.toml; do
-    pushd `dirname $f`
-    cargo audit
-    popd
-done
+cargo audit

--- a/hooks/pre-push.d/cargo-clippy
+++ b/hooks/pre-push.d/cargo-clippy
@@ -1,5 +1,2 @@
 #!/bin/bash
-
-for f in `dirname $0`/../../*/Cargo.toml; do
-    cargo clippy --manifest-path=$f
-done
+cargo clippy

--- a/hooks/pre-push.d/cargo-edition-test
+++ b/hooks/pre-push.d/cargo-edition-test
@@ -2,6 +2,8 @@
 top=`git rev-parse --show-toplevel`
 status=0
 for file in $(find "$top" -name Cargo.toml); do
+    [ "$(toml get "$file" package)" == "null" ] && continue
+
     if [ "$(toml get "$file" package.edition)" != '"2018"' ]; then
         echo "$file is not using edition = "2018"."
         echo "Please ensure the field is present and includes the correct Rust edition."        

--- a/hooks/pre-push.d/cargo-fmt
+++ b/hooks/pre-push.d/cargo-fmt
@@ -1,5 +1,2 @@
 #!/bin/bash -e
-
-for f in `dirname $0`/../../*/Cargo.toml; do
-    cargo fmt --manifest-path=$f -- --check
-done
+cargo fmt -- --check

--- a/hooks/pre-push.d/cargo-test
+++ b/hooks/pre-push.d/cargo-test
@@ -1,6 +1,2 @@
 #!/bin/bash -e
-
-for f in `dirname $0`/../../*/Cargo.toml; do
-    realpath $f
-    cargo test --manifest-path=$f
-done
+cargo test

--- a/hooks/pre-push.d/toml-license-field-test
+++ b/hooks/pre-push.d/toml-license-field-test
@@ -2,6 +2,8 @@
 top=`git rev-parse --show-toplevel`
 status=0
 for file in $(find "$top" -name Cargo.toml); do
+    [ "$(toml get "$file" package)" == "null" ] && continue
+
     if [ "$(toml get "$file" package.license)" != "\"Apache-2.0\"" ]; then
         echo "$file does not include Apache-2.0 in its license field."
         echo "Please ensure the field is present and includes an Apache license."

--- a/iocuddle-sgx/Cargo.toml
+++ b/iocuddle-sgx/Cargo.toml
@@ -14,8 +14,5 @@ sgx-types = { path = "../sgx-types" }
 
 [dev-dependencies]
 sgx-crypto = { path = "../sgx-crypto" }
-openssl = "0.10.28"
+openssl = { version = "0.10", features = [ "vendored" ] }
 rstest = "0.5.2"
-
-[patch.crates-io]
-openssl = { git = 'https://github.com/npmccallum/rust-openssl', branch='patch' }

--- a/sev/Cargo.toml
+++ b/sev/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 default = []
 
 [dependencies]
-openssl = { version = "0.10.28", optional = true }
+openssl = { version = "0.10", optional = true, features = [ "vendored" ] }
 bitflags = "1.2.1"
 codicon = "2.1.0"

--- a/sgx-crypto/Cargo.toml
+++ b/sgx-crypto/Cargo.toml
@@ -9,7 +9,4 @@ edition = "2018"
 
 [dependencies]
 sgx-types = { path = "../sgx-types" }
-openssl = "0.10.28"
-
-[patch.crates-io]
-openssl = { git = 'https://github.com/npmccallum/rust-openssl', branch='patch' }
+openssl = { version = "0.10", features = [ "vendored" ] }


### PR DESCRIPTION
I've come up with a way to link a binary with custom entry point on musl
libc. So I think I've solved our linking problems for now. This means we
can have the workspace back and cargo should work out of the box like
normal.