### PR TITLE
Implement Rust testing in a container on Github Actions

### DIFF
--- a/.github/workflows/enarx-rust.yml
+++ b/.github/workflows/enarx-rust.yml
@@ -1,0 +1,30 @@
+name: Enarx Rust Tests
+# Automated testing specific to Enarx's Rust code.
+
+on: [pull_request]
+
+jobs:
+  # Ensure all Rust code is properly formatted with `rustfmt`.
+  rust-formatting:
+    runs-on: ubuntu-latest
+    container: quay.io/enarx/fedora-test
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: rustfmt
+      run: cargo fmt -- --check
+
+  # Build and test the Enarx workspace.
+  rust-build-test:
+    runs-on: ubuntu-latest
+    container: quay.io/enarx/fedora-test
+    steps:
+    - uses: actions/checkout@v1
+    
+    # Ensure the project builds correctly.
+    - name: Build
+      run: cargo build
+    
+    # Run any specified Rust tests.
+    - name: Run tests
+      run: cargo test

--- a/hooks/pre-push.d/cargo-fmt
+++ b/hooks/pre-push.d/cargo-fmt
@@ -1,2 +1,0 @@
-#!/bin/bash -e
-cargo fmt -- --check

--- a/hooks/pre-push.d/cargo-test
+++ b/hooks/pre-push.d/cargo-test
@@ -1,2 +1,0 @@
-#!/bin/bash -e
-cargo test


### PR DESCRIPTION
This PR holds our first substantive migration of CI testing from Travis to Github Actions. The `enarx-rust.yml` workflow will hold all our Rust testing; currently, it runs `cargo fmt` and `cargo test`. Those same tests have been removed from Travis' testing loadout.

@npmccallum and I have also written and deployed a testing container to [quay.io](https://quay.io/repository/enarx/fedora-test) that this config makes use of. All tests are run inside the container.

Part of the point of this PR is to understand how Actions behaves when dealing with our contribution workflow: making a pull request from a personal fork. Have a look around and see how the tests behave!

Resolves #244 and resolves #245.