### PR TITLE
Add quote module to sgx-types

### DIFF
--- a/attestation-types/Cargo.toml
+++ b/attestation-types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "attestation-types"
+version = "0.1.0"
+authors = ["Nathaniel McCallum <npmccallum@redhat.com>", "Lily Sturmann <lsturman@redhat.com>"]
+license = "Apache-2.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+testing  = { path = "../testing" }
+sgx-types = { path = "../sgx-types" }

--- a/attestation-types/LICENSE
+++ b/attestation-types/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/attestation-types/src/lib.rs
+++ b/attestation-types/src/lib.rs
@@ -4,16 +4,9 @@
 //! Section references in further documentation refer to this document.
 //! https://www.intel.com/content/dam/www/public/emea/xe/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3d-part-4-manual.pdf
 
-#![no_std]
 #![deny(clippy::all)]
 #![allow(clippy::identity_op)]
 #![deny(missing_docs)]
 
-pub mod attr;
-pub mod isv;
-pub mod misc;
-pub mod page;
-pub mod secs;
-pub mod sig;
-pub mod ssa;
-pub mod tcs;
+pub mod report;
+pub mod ti;

--- a/attestation-types/src/lib.rs
+++ b/attestation-types/src/lib.rs
@@ -8,5 +8,6 @@
 #![allow(clippy::identity_op)]
 #![deny(missing_docs)]
 
+pub mod quote;
 pub mod report;
 pub mod ti;

--- a/attestation-types/src/quote.rs
+++ b/attestation-types/src/quote.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! The Quote structure is used to provide proof to an off-platform entity that an application
+//! enclave is running with Intel SGX protections on a trusted Intel SGX enabled platform.
+//! See Section A.4 in the following link for all types in this module:
+//! https://download.01.org/intel-sgx/dcap-1.0/docs/SGX_ECDSA_QuoteGenReference_DCAP_API_Linux_1.0.pdf
+
+use super::report::Body;
+use std::vec::Vec;
+use testing::testaso;
+
+/// The Quote version for DCAP is 3. Must be 2 bytes.
+pub const VERSION: u16 = 3;
+
+/// The length of an ECDSA signature is 64 bytes. This value must be 4 bytes.
+pub const ECDSASIGLEN: u32 = 64;
+
+/// Intel's Vendor ID, as specified in A.4, Table 3. Must be 16 bytes.
+pub const INTELVID: [u8; 16] = [
+    0x93, 0x9A, 0x72, 0x33, 0xF7, 0x9C, 0x4C, 0xA9, 0x94, 0x0A, 0x0D, 0xB3, 0x95, 0x7F, 0x06, 0x07,
+];
+
+/// Section A.4, Table 9
+#[repr(u16)]
+pub enum CertDataType {
+    /// Byte array that contains concatenation of PPID, CPUSVN,
+    /// PCESVN (LE), PCEID (LE)
+    PpidPlaintext = 1,
+
+    /// Byte array that contains concatenation of PPID encrypted
+    /// using RSA-2048-OAEP, CPUSVN,  PCESVN (LE), PCEID (LE)
+    PpidRSA2048OAEP = 2,
+
+    /// Byte array that contains concatenation of PPID encrypted
+    /// using RSA-3072-OAEP, CPUSVN, PCESVN (LE), PCEID (LE)
+    PpidRSA3072OAEP = 3,
+
+    /// PCK Leaf Certificate
+    PCKLeafCert = 4,
+
+    /// Concatenated PCK Cert Chain  (PEM formatted).
+    /// PCK Leaf Cert||Intermediate CA Cert||Root CA Cert
+    PCKCertChain = 5,
+
+    /// Intel SGX Quote (not supported).
+    Quote = 6,
+
+    /// Platform Manifest (not supported).
+    Manifest = 7,
+}
+
+impl Default for CertDataType {
+    fn default() -> Self {
+        Self::PCKCertChain
+    }
+}
+
+/// ECDSA  signature, the r component followed by the
+/// s component, 2 x 32 bytes.
+/// A.4, Table 6
+#[derive(Default)]
+#[repr(C)]
+pub struct ECDSAP256Sig {
+    /// r component
+    pub r: [u8; 32],
+
+    /// s component
+    pub s: [u8; 32],
+}
+
+/// EC KT-I Public Key, the x-coordinate followed by
+/// the y-coordinate (on the RFC 6090P-256 curve),
+/// 2 x 32 bytes.
+/// A.4, Table 7
+#[derive(Default)]
+#[repr(C)]
+pub struct ECDSAPubKey {
+    /// x coordinate
+    pub x: [u8; 32],
+
+    /// y coordinate
+    pub y: [u8; 32],
+}
+
+/// A.4, Table 4
+#[derive(Default)]
+#[repr(C)]
+pub struct SigData {
+    isv_enclave_report_sig: ECDSAP256Sig,
+    ecdsa_attestation_key: ECDSAPubKey,
+    qe_report: Body,
+    qe_report_sig: ECDSAP256Sig,
+    qe_auth: Vec<u8>,
+    qe_cert_data_type: CertDataType,
+    qe_cert_data: Vec<u8>,
+}
+
+/// The type of Attestation Key used to sign the Report.
+#[repr(u16)]
+pub enum AttestationKeyType {
+    /// ECDSA-256-with-P-256 curve
+    ECDSA256P256 = 2,
+
+    /// ECDSA-384-with-P-384 curve; not supported
+    ECDSA384P384 = 3,
+}
+
+impl Default for AttestationKeyType {
+    fn default() -> Self {
+        AttestationKeyType::ECDSA256P256
+    }
+}
+
+/// Unlike the other parts of the Quote, this structure
+/// is transparent to the user.
+/// Section A.4, Table 3
+#[repr(C)]
+pub struct QuoteHeader {
+    /// Version of Quote structure, 3 in the ECDSA case.
+    pub version: u16,
+
+    /// Type of attestation key used. Only one type is currently supported:
+    /// 2 (ECDSA-256-with-P-256-curve).
+    pub att_key_type: AttestationKeyType,
+
+    /// Reserved.
+    reserved: u32,
+
+    /// Security version of the QE.
+    pub qe_svn: u16,
+
+    /// Security version of the Provisioning Cerfitication Enclave.
+    pub pce_svn: u16,
+
+    /// ID of the QE vendor.
+    pub qe_vendor_id: [u8; 16],
+
+    /// Custom user-defined data. For the Intel DCAP library, the first 16 bytes
+    /// contain a QE identifier used to link a PCK Cert to an Enc(PPID). This
+    /// identifier is consistent for every quote generated with this QE on this
+    /// platform.
+    pub user_data: [u8; 20],
+}
+
+impl Default for QuoteHeader {
+    fn default() -> Self {
+        Self {
+            version: VERSION,
+            att_key_type: Default::default(),
+            reserved: Default::default(),
+            qe_svn: Default::default(),
+            pce_svn: Default::default(),
+            qe_vendor_id: INTELVID,
+            user_data: [0u8; 20],
+        }
+    }
+}
+
+/// Section A.4
+/// All integer fields are in little endian.
+#[repr(C, align(4))]
+pub struct Quote {
+    /// Header for Quote structure; transparent to the user.
+    pub header: QuoteHeader,
+
+    /// Report of the atteste enclave.
+    isv_enclave_report: Body,
+
+    /// Size of the Signature Data field.
+    sig_data_len: u32,
+
+    /// Variable-length data containing the signature and
+    /// supporting data.
+    sig_data: SigData,
+}
+
+impl Default for Quote {
+    fn default() -> Self {
+        Self {
+            header: Default::default(),
+            isv_enclave_report: Default::default(),
+            sig_data_len: ECDSASIGLEN,
+            sig_data: Default::default(),
+        }
+    }
+}
+
+testaso! {
+    struct QuoteHeader: 4, 48 => {
+        version: 0,
+        att_key_type: 2,
+        reserved: 4,
+        qe_svn: 8,
+        pce_svn: 10,
+        qe_vendor_id: 12,
+        user_data: 28
+    }
+}

--- a/attestation-types/src/report.rs
+++ b/attestation-types/src/report.rs
@@ -3,7 +3,7 @@
 //! Section 38.15
 //! The REPORT structure is the output of the EREPORT instruction, and must be 512-Byte aligned.
 
-use super::{attr::Attributes, isv, misc::MiscSelect};
+use sgx_types::{attr::Attributes, isv, misc::MiscSelect};
 #[cfg(test)]
 use testing::testaso;
 

--- a/attestation-types/src/ti.rs
+++ b/attestation-types/src/ti.rs
@@ -4,7 +4,7 @@
 //! The Target Info is used to identify the target enclave that will be able to cryptographically
 //! verify the REPORT structure returned by the EREPORT leaf. Must be 512-byte aligned.
 
-use super::{attr::Attributes, misc::MiscSelect};
+use sgx_types::{attr::Attributes, misc::MiscSelect};
 #[cfg(test)]
 use testing::testaso;
 


### PR DESCRIPTION
A few notes about the tricky parts of implementing the `Quote` struct:

- According to the documentation ([A.4, Table 8](https://download.01.org/intel-sgx/dcap-1.0/docs/SGX_ECDSA_QuoteGenReference_DCAP_API_Linux_1.0.pdf)),The `QEAuth` portion has 1) a `size` field and 2) a `data` [field](https://github.com/enarx/enarx/compare/master...lkatalin:quote-type?expand=1#diff-e7fe996c9d1d239623aac2a380efaa54R38) whose size is determined by the `size` field. I couldn't find a way to do this without making the size a `const`. Currently it's set to `0`, a valid value. 
   - Maybe the `data` field should be a vector, with a method that checks that the length of the vector matches the `size` field?
- It's clear that the `vendor ID` used in this `Quote` struct (`939A7233F79C4CA9940A0DB3957F0607` for Intel) is different from the `vendor ID` used in `SIGSTRUCT` (`0x8086` for Intel). However, it's not clear whether the "QE Identifier" required as part of the `user_data` field is the same as the `vendor ID`, though they are both 16 bytes. I have assumed they are the same and [copied it](https://github.com/enarx/enarx/compare/master...lkatalin:quote-type?expand=1#diff-e7fe996c9d1d239623aac2a380efaa54R191) into `user_data`.
- The endianness of integers is specified as LE; but the endianness of byte arrays is not specified. So copying the `vendor ID` into the `user_data` with `copy_from_slice` may not have the correct layout.
- The `QECert.certdata` [field](https://github.com/enarx/enarx/compare/master...lkatalin:quote-type?expand=1#diff-e7fe996c9d1d239623aac2a380efaa54R90) should be large enough to hold a concatenated PCK Cert Chain (PEM formatted): `PCK Leaf Cert||Intermediate CA Cert||Root CA Cert`. However, it's not clear that this chain will always be a predictable length. I've made the field `4096` bytes for the moment.

Fixes #107 