### PR TITLE
Fix shell scripts

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,2 +1,9 @@
-#!/bin/bash -e
-for f in $0.d/*; do $f; done
+#!/bin/bash
+set -o pipefail
+
+ret=0
+while read -r f; do
+  "$f"
+  ((ret+=$?))
+done < <(find "${0}.d" -type f -perm /u+x,g+x)
+exit $ret

--- a/hooks/pre-push.d/cargo-edition-test
+++ b/hooks/pre-push.d/cargo-edition-test
@@ -1,13 +1,15 @@
 #!/bin/bash -e
-top=`git rev-parse --show-toplevel`
+set -o pipefail
+
+top=$(git rev-parse --show-toplevel)
 status=0
-for file in $(find "$top" -name Cargo.toml); do
+while read -r file; do
     [ "$(toml get "$file" package)" == "null" ] && continue
 
     if [ "$(toml get "$file" package.edition)" != '"2018"' ]; then
-        echo "$file is not using edition = "2018"."
+        echo "$file is not using edition = \"2018\"."
         echo "Please ensure the field is present and includes the correct Rust edition."        
         status=1
     fi
-done
+done < <(find "$top" -name Cargo.toml)
 exit $status

--- a/hooks/pre-push.d/crate-license-test
+++ b/hooks/pre-push.d/crate-license-test
@@ -1,17 +1,19 @@
 #!/bin/bash -e
-top=`git rev-parse --show-toplevel`
+set -o pipefail
+
+top=$(git rev-parse --show-toplevel)
 status=0
-for file in $(find "$top" -name Cargo.toml | sed 's|Cargo.toml|LICENSE|'); do
+while read -r file; do
     if [ ! -f "$file" ]; then
         echo "$file does not exist. Please ensure an Apache 2.0 license is present."
         status=1
     else
-        if ! diff -Buw $top/LICENSE $file; then
+        if ! diff -Buw "$top/LICENSE" "$file"; then
             echo
             echo "$file does not match $top/LICENSE!"
             echo
             status=1
         fi
     fi
-done
+done < <(find "$top" -name Cargo.toml | sed 's|/Cargo.toml$|/LICENSE|')
 exit $status

--- a/hooks/pre-push.d/eof-newline-test
+++ b/hooks/pre-push.d/eof-newline-test
@@ -1,10 +1,12 @@
-#!/bin/bash
-top=`git rev-parse --show-toplevel`
+#!/bin/bash -e
+set -o pipefail
+
+top=$(git rev-parse --show-toplevel)
 status=0
-for file in $(find "$top" -path "$top"/target -prune -o -type f -name "*.rs" -print -o -type f -name "*.toml" -print); do
-    if [ ! $(tail -c 1 "$file") = $'\n' ]; then
+while read -r file; do
+    if [[ $(tail -c 1 "$file") ]]; then
         echo "$file does not have a newline at EOF. Please ensure it has one."
         status=1
     fi
-done
+done < <(find "$top" -path "$top"/target -prune -o -type f -name "*.rs" -print -o -type f -name "*.toml" -print)
 exit $status

--- a/hooks/pre-push.d/rs-spdx-license-test
+++ b/hooks/pre-push.d/rs-spdx-license-test
@@ -1,11 +1,12 @@
 #!/bin/bash -e
-top=`git rev-parse --show-toplevel`
+set -o pipefail
+
+top=$(git rev-parse --show-toplevel)
 status=0
-for file in $(find "$top" -path "$top"/target -prune -o -name "*.rs" -type f -print); do
-    if ! awk '/\/\/ SPDX-License-Identifier: Apache-2.0$/ { exit 0 } { exit 1 }' $file; then
+while read -r file; do
+    if ! awk '/\/\/ SPDX-License-Identifier: Apache-2.0$/ { exit 0 } { exit 1 }' "$file"; then
         echo "$file does not have an Apache 2.0 SPDX ID on the first line of the file."
-        echo "Please add one."
         status=1
     fi
-done
+done < <(find "$top" -path "$top"/target -prune -o -name "*.rs" -type f -print)
 exit $status

--- a/hooks/pre-push.d/toml-license-field-test
+++ b/hooks/pre-push.d/toml-license-field-test
@@ -1,7 +1,9 @@
 #!/bin/bash -e
-top=`git rev-parse --show-toplevel`
+set -o pipefail
+
+top=$(git rev-parse --show-toplevel)
 status=0
-for file in $(find "$top" -name Cargo.toml); do
+while read -r file; do
     [ "$(toml get "$file" package)" == "null" ] && continue
 
     if [ "$(toml get "$file" package.license)" != "\"Apache-2.0\"" ]; then
@@ -9,5 +11,5 @@ for file in $(find "$top" -name Cargo.toml); do
         echo "Please ensure the field is present and includes an Apache license."
         status=1
     fi
-done
+done < <(find "$top" -name Cargo.toml)
 exit $status


### PR DESCRIPTION
- harden against whitespaces in path names
- fixed eof-newline check
- run all tests in `pre-push`
- set -o pipefail

Still fails for newline in path names, but that is crazy. :-P