### PR TITLE
hooks/pre-push: ignore all target directories

### DIFF
--- a/hooks/pre-push.d/eof-newline-test
+++ b/hooks/pre-push.d/eof-newline-test
@@ -8,5 +8,5 @@ while read -r file; do
         echo "$file does not have a newline at EOF. Please ensure it has one."
         status=1
     fi
-done < <(find "$top" -path "$top"/target -prune -o -type f -name "*.rs" -print -o -type f -name "*.toml" -print)
+done < <(find "$top" -regex '.*/target' -prune -o -type f -regex '.*\.\(rs\|toml|\)' -print)
 exit $status

--- a/hooks/pre-push.d/rs-spdx-license-test
+++ b/hooks/pre-push.d/rs-spdx-license-test
@@ -8,5 +8,5 @@ while read -r file; do
         echo "$file does not have an Apache 2.0 SPDX ID on the first line of the file."
         status=1
     fi
-done < <(find "$top" -path "$top"/target -prune -o -name "*.rs" -type f -print)
+done < <(find "$top" -regex '.*/target' -prune -o -type f -regex '.*rs' -print)
 exit $status


### PR DESCRIPTION
Tryting to run the hooks in a local development repository yielded
errors for dependency crates which reside in the individual crate's
target directory. This change makes the hook prune these directories.