### PR TITLE
Migrate cargo-audit testing to GH Actions

### DIFF
--- a/.github/workflows/enarx-rust.yml
+++ b/.github/workflows/enarx-rust.yml
@@ -28,3 +28,12 @@ jobs:
     # Run any specified Rust tests.
     - name: Run tests
       run: cargo test
+
+  # Vulnerability check with cargo audit.
+  cargo-audit:
+    runs-on: ubuntu-latest
+    container: quay.io/enarx/fedora-test
+    steps:
+    - uses: actions/checkout@v1
+    - name: cargo-audit
+      run: cargo audit

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,6 @@ matrix:
     - rust: nightly
   fast_finish: true
   include:
-    - name: "cargo audit"
-      rust: stable
-      install:
-        - cargo install --force cargo-audit
-      script: ./hooks/pre-push.d/cargo-audit --force
     - name: "sev"
       rust: stable
       script:

--- a/hooks/pre-push.d/cargo-audit
+++ b/hooks/pre-push.d/cargo-audit
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-[[ -n "$TRAVIS" && "$1" != "--force" ]] && exit 0
-cargo audit


### PR DESCRIPTION
Checks off `cargo-audit` in #246.