### PR TITLE
Run cargo test with SEV-specific features

### DIFF
--- a/.github/workflows/enarx-rust.yml
+++ b/.github/workflows/enarx-rust.yml
@@ -29,6 +29,10 @@ jobs:
     - name: Run tests
       run: cargo test
 
+    # Run Rust tests with OpenSSL-specific features enabled for SEV.
+    - name: Run tests (SEV-specific)
+      run: cargo test --manifest-path sev/Cargo.toml --verbose --features=openssl
+
   # Vulnerability check with cargo audit.
   cargo-audit:
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
-  include:
-    - name: "sev"
-      rust: stable
-      script:
-        - cargo test --manifest-path sev/Cargo.toml --verbose --features=openssl
 install:
   - rustup component add rustfmt
   - rustup component add clippy


### PR DESCRIPTION
Adds another step to GHA's Rust build-test step with SEV-specific features.

Related: #246