### PR TITLE
Migrate rust-clippy test to GH Actions

### DIFF
--- a/.github/workflows/enarx-rust.yml
+++ b/.github/workflows/enarx-rust.yml
@@ -33,6 +33,15 @@ jobs:
     - name: Run tests (SEV-specific)
       run: cargo test --manifest-path sev/Cargo.toml --verbose --features=openssl
 
+  # Lint check with rust-clippy.
+  rust-clippy:
+    runs-on: ubuntu-latest
+    container: quay.io/enarx/fedora-test
+    steps:
+    - uses: actions/checkout@v2
+    - name: rust-clippy
+      run: cargo clippy
+      
   # Vulnerability check with cargo audit.
   cargo-audit:
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,5 @@ matrix:
   fast_finish: true
 install:
   - rustup component add rustfmt
-  - rustup component add clippy
   - rustup target add x86_64-unknown-linux-musl
 script: ./hooks/pre-push

--- a/hooks/pre-push.d/cargo-clippy
+++ b/hooks/pre-push.d/cargo-clippy
@@ -1,2 +1,0 @@
-#!/bin/bash
-cargo clippy


### PR DESCRIPTION
Checks off `cargo clippy` in #246.