### PR TITLE
Ensure diagrams are always up-to-date

### DIFF
--- a/.github/workflows/miscellaneous.yml
+++ b/.github/workflows/miscellaneous.yml
@@ -26,3 +26,12 @@ jobs:
     # Ensure all .rs files have an Apache 2.0 SPDX license ID.
     - name: All .rs files have SPDX IDs
       run: .tests/misc-licenses-rs-spdx
+
+  misc-diagrams:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Ensure all diagrams are up-to-date.
+    - name: All diagrams are up-to-date
+      run: .tests/misc-diagrams

--- a/.tests/misc-diagrams
+++ b/.tests/misc-diagrams
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+diagram_dir="./docs/attestation/"
+diagrams=$(make --quiet -C "$diagram_dir" diagrams)
+
+status=0
+for diagram in $diagrams ; do
+	# Truncate the file extension (.png, .svg, etc)
+	source=${diagram%????}
+
+	source_date=$(git log -1 --date=unix --format="%cd" -- "$diagram_dir$source")
+	diagram_date=$(git log -1 --date=unix --format="%cd" -- "$diagram_dir$diagram")
+
+	if [[ $diagram_date -lt $source_date ]]; then
+		echo "This diagram is out-of-date: $diagram_dir$diagram. Please generate an"`
+		      `" updated diagram and commit it to include it with your pull request."
+		status=1
+	fi
+done
+exit $status

--- a/docs/attestation/Makefile
+++ b/docs/attestation/Makefile
@@ -1,7 +1,18 @@
-all: amd/sev/certchain.dot.png amd/sev/process.msc.png ibm/pef/certchain.dot.png ibm/pef/process.msc.png
+DIAGRAMS := \
+	amd/sev/certchain.dot.png \
+	amd/sev/process.msc.png \
+	ibm/pef/certchain.dot.png \
+	ibm/pef/process.msc.png
+
+all: $(DIAGRAMS)
 
 %.dot.png: %.dot
 	dot -T png -o $@ $<
 
 %.msc.png: %.msc
 	mscgen -T png -o $@ $<
+
+.PHONY: diagrams
+
+diagrams:
+	echo $(DIAGRAMS)


### PR DESCRIPTION
Closes #256 

This pull request adds a test to our GitHub Actions suite to confirm that the diagrams in a pull request are always up-to-date.

This ended up being a little more complex than I initially thought, due to how certain approaches made the test quite brittle.

**Idea:** just compare the (c/m)times of the files
**Why doesn't it work:** Git doesn't necessarily track this ([and after Googling why](https://stackoverflow.com/questions/1964470/whats-the-equivalent-of-use-commit-times-for-git/1964508#1964508), I tend to agree with that decision). So, when our CI clones the repo to check out the files, the (c/m)times are simply the time of the clone, and if all the times are the same, then this test wouldn't make sense.

**Idea:** force `make` to regenerate the diagrams, and if the binary output changes, then obviously the diagram sources have changed and the contributor forgot to commit them!
**Why doesn't it work:** It kind of worked! However, when `dot` generates the .PNGs, the binary output changes each time even if the source remains the same. It must be putting a timestamp somewhere, so it would fail every time. When I switched the file types to .svg, this approach _did_ work; however, that is not the form this pull request has taken, as I do not want to tightly couple the test to the image format of our diagrams.

Finally, here's the approach I _did_ take for this PR:

**Idea:** Query the Makefile for the diagrams that _should_ be tested (this allows us to avoid globbing for file extensions or duplicating the list of files somewhere else). If the commit date of the diagram is older than its source, then the test fails. The commit date is converted to UTC and is the seconds past the epoch.