### PR TITLE
Create a Cargo feature enabling dangerous SEV hardware tests

### DIFF
--- a/sev/Cargo.toml
+++ b/sev/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [features]
 default = []
+dangerous_tests = []
 
 [dependencies]
 openssl = { version = "0.10", optional = true, features = [ "vendored" ] }

--- a/sev/tests/api.rs
+++ b/sev/tests/api.rs
@@ -2,7 +2,7 @@
 
 use sev::{certs::sev::Usage, firmware::Firmware, Build, Version};
 
-#[ignore]
+#[cfg_attr(not(all(has_sev, dangerous_tests)), ignore)]
 #[test]
 fn platform_reset() {
     let fw = Firmware::open().unwrap();
@@ -26,7 +26,7 @@ fn platform_status() {
     );
 }
 
-#[ignore]
+#[cfg_attr(not(all(has_sev, dangerous_tests)), ignore)]
 #[test]
 fn pek_generate() {
     let fw = Firmware::open().unwrap();
@@ -41,7 +41,7 @@ fn pek_csr() {
     assert_eq!(pek, Usage::PEK);
 }
 
-#[ignore]
+#[cfg_attr(not(all(has_sev, dangerous_tests)), ignore)]
 #[test]
 fn pdh_generate() {
     let fw = Firmware::open().unwrap();
@@ -66,7 +66,7 @@ fn pdh_cert_export() {
 }
 
 #[cfg(feature = "openssl")]
-#[ignore]
+#[cfg_attr(not(all(has_sev, dangerous_tests)), ignore)]
 #[test]
 fn pek_cert_import() {
     use sev::certs::{sev::Certificate, Signer, Verifiable};


### PR DESCRIPTION
Resolves #288. Checks off appropriate task in #105.

This feature is intended to be used for testing the SEV hardware platform only.