### PR TITLE
sev: Porting over the sev functionality from ketuvim

### DIFF
--- a/sev/src/firmware/linux/ioctl.rs
+++ b/sev/src/firmware/linux/ioctl.rs
@@ -5,8 +5,8 @@ use std::mem::{size_of_val, MaybeUninit};
 use std::os::raw::{c_int, c_ulong};
 use std::os::unix::io::AsRawFd;
 
-use super::*;
 use crate::certs::sev::Certificate;
+use crate::firmware::*;
 
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/sev/src/firmware/linux/ioctl/wrapper.rs
+++ b/sev/src/firmware/linux/ioctl/wrapper.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryInto;
+use std::io::Error;
+use std::marker::PhantomData;
+use std::os::raw::{c_int, c_uint, c_ulong, c_void};
+use std::os::unix::io::AsRawFd;
+use std::ptr::null;
+
+extern "C" {
+    pub fn ioctl(fd: c_int, request: c_ulong, ...) -> c_int;
+}
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Code {
+    Init = 0,
+    EsInit,
+
+    LaunchStart,
+    LaunchUpdateData,
+    LaunchUpdateVmsa,
+    LaunchSecret,
+    LaunchMeasure,
+    LaunchFinish,
+
+    SendStart,
+    SendUpdateData,
+    SendUpdateVmsa,
+    SendFinish,
+
+    ReceiveStart,
+    ReceiveUpdateData,
+    ReceiveUpdateVmsa,
+    ReceiveFinish,
+
+    GuestStatus,
+    DebugDecrypt,
+    DebugEncrypt,
+    CertExport,
+}
+
+#[repr(C)]
+pub struct Command {
+    pub code: Code,
+    pub data: u64,
+    pub error: u32,
+    pub fd: u32,
+}
+
+pub trait Ioctl {
+    const REQUEST: c_ulong;
+
+    fn ioctl(&self, fd: &impl AsRawFd) -> std::io::Result<c_uint> {
+        let r = unsafe {
+            ioctl(
+                fd.as_raw_fd(),
+                Self::REQUEST,
+                self as *const _,
+                null::<c_void>(),
+            )
+        };
+
+        r.try_into().or_else(|_| Err(Error::last_os_error()))
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct EncryptOp<'a>(u64, PhantomData<&'a ()>);
+
+impl<'a> Ioctl for EncryptOp<'a> {
+    const REQUEST: c_ulong = 3221794490;
+}
+
+impl<'a> EncryptOp<'a> {
+    pub fn new(cmd: &'a Command) -> Self {
+        EncryptOp(cmd as *const _ as _, PhantomData)
+    }
+}

--- a/sev/src/firmware/linux/mod.rs
+++ b/sev/src/firmware/linux/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod ioctl;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum State {
+    Uninitialized,
+    Initialized,
+    Working,
+}

--- a/sev/src/firmware/mod.rs
+++ b/sev/src/firmware/mod.rs
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(target_os = "linux")]
-mod linux;
+pub mod linux;
 
 use super::*;
 use std::fmt::Debug;
 
 use bitflags::bitflags;
-
-#[cfg(target_os = "linux")]
-pub use linux::Firmware;
 
 #[derive(Debug)]
 pub enum Indeterminate<T: Debug> {

--- a/sev/tests/api.rs
+++ b/sev/tests/api.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use sev::{certs::sev::Usage, firmware::Firmware, Build, Version};
+use sev::{certs::sev::Usage, firmware::linux::ioctl::Firmware, Build, Version};
 
 #[cfg_attr(not(all(has_sev, feature = "dangerous_tests")), ignore)]
 #[test]

--- a/sevctl/src/main.rs
+++ b/sevctl/src/main.rs
@@ -11,7 +11,8 @@ use clap::ArgMatches;
 use codicon::*;
 
 use ::sev::certs::*;
-use ::sev::firmware::{Firmware, Status};
+use ::sev::firmware::linux::ioctl::Firmware;
+use ::sev::firmware::Status;
 
 use std::fs::File;
 use std::process::exit;


### PR DESCRIPTION
1. vm and fd in struct Launch are changed to AsRawFd type

2. I changed the ioctl interface to something we have in sgx-sys/src/ioctl/mod.rs
   I moved enum Code and struct Command from sev.rs to ioctl/run.rs
   Then I created a new struct EncryptOp which takes struct Command and casts
   it as u64.

3. I changed the implementation of Launch to match the new format where
   vm and fw are set to AsRawFd

Related: #180 

Signed-off-by: Bandan Das <bsd@redhat.com>

Resolves #180.