### PR TITLE
Replace `colored` with MIT-licensed `colorful`

### DIFF
--- a/sev-show/Cargo.toml
+++ b/sev-show/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-colored = "1.9.1"
+colorful = "0.2.1"

--- a/sev-show/src/main.rs
+++ b/sev-show/src/main.rs
@@ -18,7 +18,7 @@ use show::*;
 /// Emits the results described in `tests` and prints them in a
 /// tree-like fashion.
 fn emit_results(tests: Vec<CompletedTest>, indent: usize) {
-    use colored::*;
+    use colorful::*;
 
     for test in tests {
         let icon = if test.passed() {

--- a/sgx-show/Cargo.toml
+++ b/sgx-show/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 [dependencies]
 sgx-types = { path = "../sgx-types" }
 bytesize = "1.0.0"
-colored = "1.9.1"
+colorful = "0.2.1"

--- a/sgx-show/src/exec.rs
+++ b/sgx-show/src/exec.rs
@@ -15,7 +15,7 @@ pub struct Test<T, U: TryFrom<T>> {
 
 impl<T, U: TryFrom<T>> Test<T, U> {
     fn dump(&self, indent: usize, data: Option<U>) {
-        use colored::*;
+        use colorful::*;
 
         let prefix = if data.is_some() {
             "✔".green()


### PR DESCRIPTION
Resolves #315. #297's dependency license check should be unblocked after this merge.