### PR TITLE
Validate that infrastructure PRs are correctly labeled

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,3 +1,16 @@
 version: 2
 mergeable:
   - when: pull_request.*
+    validate:
+      - do: project
+        must_include:
+          regex: 'Infrastructure'
+          message: 'PR is in the Infrastructure project.'
+      - do: label
+        must_exclude:
+          regex: 'infrastructure'
+          message: 'PR does not have the Infrastructure label.'
+
+    pass:
+      - do: labels
+        labels: [ 'infrastructure' ]


### PR DESCRIPTION
This is WIP, but could be a cool use case if we can flesh it out.

When filing this PR, I only assigned it a project, and not a label. If this works, it should automatically get the label.

Edited to re-trigger Mergeable, again, and again.