### PR TITLE
Fix build in the container

### DIFF
--- a/cc
+++ b/cc
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # This file MUST NOT be named `ld`, otherwise Rust will try to outsmart us.
 

--- a/enarx-keep-sgx/src/main.rs
+++ b/enarx-keep-sgx/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
         // Get the arguments.
         let mut args = std::env::args();
         let shim = args.nth(1).expect(USAGE);
-        let code = args.nth(0).expect(USAGE);
+        let code = args.next().expect(USAGE);
 
         // Parse the shim and code and validate assumptions.
         let shim = component::Component::from_path(shim).expect("Unable to parse shim");


### PR DESCRIPTION
Fedora now ships the naked python command in a separate package. We'll just
name the version explicitly.