### PR TITLE
Use the new Version struct exported by sev-types

### DIFF
--- a/sev/Cargo.toml
+++ b/sev/Cargo.toml
@@ -13,3 +13,4 @@ dangerous_tests = []
 openssl = { version = "0.10", optional = true, features = [ "vendored" ] }
 bitflags = "1.2.1"
 codicon = "2.1.0"
+sev-types = { path = "../sev-types" }

--- a/sev/src/certs/sev/cert/v1/body/mod.rs
+++ b/sev/src/certs/sev/cert/v1/body/mod.rs
@@ -2,12 +2,14 @@
 
 pub mod key;
 
+use sev_types::platform;
+
 use super::*;
 
 #[repr(C, packed)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Data {
-    pub firmware: crate::Version,
+    pub firmware: platform::Version,
     pub reserved: u16,
     pub key: key::PubKey,
 }

--- a/sev/src/firmware/linux.rs
+++ b/sev/src/firmware/linux.rs
@@ -5,6 +5,8 @@ use std::mem::{size_of_val, MaybeUninit};
 use std::os::raw::{c_int, c_ulong};
 use std::os::unix::io::AsRawFd;
 
+use sev_types::platform;
+
 use super::*;
 use crate::certs::sev::Certificate;
 
@@ -76,7 +78,7 @@ impl Firmware {
 
         Ok(Status {
             build: Build {
-                version: Version {
+                version: platform::Version {
                     major: i.api_major,
                     minor: i.api_minor,
                 },

--- a/sev/src/launch.rs
+++ b/sev/src/launch.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use sev_types::platform;
+
 use super::*;
 use bitflags::bitflags;
 
@@ -19,7 +21,7 @@ bitflags! {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct Policy {
     pub flags: PolicyFlags,
-    pub minfw: Version,
+    pub minfw: platform::Version,
 }
 
 #[repr(C)]

--- a/sev/src/lib.rs
+++ b/sev/src/lib.rs
@@ -5,6 +5,8 @@
 #![allow(clippy::identity_op)]
 #![allow(clippy::unreadable_literal)]
 
+use sev_types::platform;
+
 pub mod certs;
 pub mod firmware;
 pub mod launch;
@@ -13,21 +15,8 @@ pub mod session;
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Version {
-    pub major: u8,
-    pub minor: u8,
-}
-
-impl std::fmt::Display for Version {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}.{}", self.major, self.minor)
-    }
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Build {
-    pub version: Version,
+    pub version: platform::Version,
     pub build: u8,
 }
 

--- a/sev/src/session/mod.rs
+++ b/sev/src/session/mod.rs
@@ -173,7 +173,8 @@ impl Session<Verified> {
 #[cfg(test)]
 mod initialized {
     use super::*;
-    use crate::{launch, session::Session, Build, Version};
+    use crate::{launch, session::Session, Build};
+    use sev_types::platform::Version;
 
     #[test]
     fn session() {

--- a/sev/tests/api.rs
+++ b/sev/tests/api.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use sev::{certs::sev::Usage, firmware::Firmware, Build, Version};
+use sev_types::platform::Version;
+
+use sev::{certs::sev::Usage, firmware::Firmware, Build};
 
 #[cfg_attr(not(all(has_sev, feature = "dangerous_tests")), ignore)]
 #[test]


### PR DESCRIPTION
The first type that went into `sev-types` was the firmware version struct and so a debt issue was filed to update `sev` to use the definition exported by `sev-types`.

Closes #323.