### PR TITLE
Use upstream libc mmap flags

### DIFF
--- a/enarx-keep-sgx/Cargo.toml
+++ b/enarx-keep-sgx/Cargo.toml
@@ -16,7 +16,7 @@ vdso = { path = "../vdso" }
 bitflags = "1.2"
 openssl = "0.10"
 goblin = "0.2"
-libc = "0.2"
+libc = "0.2.68"
 
 [build-dependencies]
 cc = "1.0"

--- a/enarx-keep-sgx/src/builder.rs
+++ b/enarx-keep-sgx/src/builder.rs
@@ -58,7 +58,7 @@ impl Builder {
                 span.start,
                 span.count,
                 libc::PROT_NONE,
-                libc::MAP_SHARED | map::MAP_FIXED_NOREPLACE,
+                libc::MAP_SHARED | libc::MAP_FIXED_NOREPLACE,
                 Some(&file),
                 0,
             )?;

--- a/enarx-keep-sgx/src/map.rs
+++ b/enarx-keep-sgx/src/map.rs
@@ -6,10 +6,6 @@ use std::fs::File;
 use std::io::{Error, Result};
 use std::os::unix::io::AsRawFd;
 
-// FIXME: https://github.com/rust-lang/libc/pull/1658
-pub const MAP_SYNC: libc::c_int = libc::MAP_HUGETLB << 1;
-pub const MAP_FIXED_NOREPLACE: libc::c_int = MAP_SYNC << 1;
-
 /// Calls `munmap()` when going out of scope
 ///
 /// This simple type just tracks the lifespan of a region of memory.


### PR DESCRIPTION
Before this, libc did not export these flags for musl. Starting with libc 0.2.68 these flags are now exported.

Also, all I had to do to get these changes was run `cargo update` but I was expecting to see something change in a Cargo.lock... anyone have any thoughts? Otherwise people with this repo already checked out may need to run `cargo update` manually and if I had no background knowledge of this commit getting merged I would probably be confused.

Closes #239 
Closes #339 
