### PR TITLE
Conditionally remove SGX shim entry point if not on SGX-enabled hardware

### DIFF
--- a/enarx-keep-sgx-shim/link.json
+++ b/enarx-keep-sgx-shim/link.json
@@ -14,7 +14,7 @@
 
     "test": {
         "replace": {
-            "-lstart": []
+            "-lasm": []
         },
 
         "debug": false


### PR DESCRIPTION
Otherwise the test suite will segfault and there's no real way to skip this since the shim presents itself as *the* entry point, even for `cargo test`

On non-Intel hardware:

Before the patch:

```bash
bash-5.0# cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running /root/enarx/target/x86_64-unknown-linux-musl/debug/deps/enarx_keep_sgx_shim-328c79c1e5d7f125
error: test failed, to rerun pass '--bin enarx-keep-sgx-shim'

Caused by:
  process didn't exit successfully: `/root/enarx/target/x86_64-unknown-linux-musl/debug/deps/enarx_keep_sgx_shim-328c79c1e5d7f125` (signal: 11, SIGSEGV: invalid memory reference)
```

After the patch:

```bash
bash-5.0# cargo test
   Compiling enarx-keep-sgx-shim v0.1.0 (/root/enarx/enarx-keep-sgx-shim)
    Finished test [unoptimized + debuginfo] target(s) in 0.57s
     Running /root/enarx/target/x86_64-unknown-linux-musl/debug/deps/enarx_keep_sgx_shim-328c79c1e5d7f125

running 3 tests
test libc::tests::bcmp ... ok
test libc::tests::memcpy ... ok
test libc::tests::memset ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Closes #358 