### PR TITLE
Sorting Hat: Copy labels to pull requests from linked issues

### DIFF
--- a/.automation/copy-issue-labels-to-pr
+++ b/.automation/copy-issue-labels-to-pr
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+import json
+import re
+import sys
+from github import Github
+
+# We don't want to copy all labels on linked issues; only those in this subset.
+COPYABLE_LABELS = {
+    "amd sev",
+    "documentation",
+    "ibm pef",
+    "infrastructure",
+    "intel sgx",
+    "wasm",
+}
+
+# Returns a pull request extracted from Github's event JSON.
+def get_pr(event):
+    # --- Extract PR from event JSON ---
+    # `check_run`/`check_suite` does not include any direct reference to the PR
+    # that triggered it in its event JSON. We have to extrapolate it using the head
+    # SHA that *is* there.
+
+    # Get head SHA from event JSON
+    pr_head_sha = event["check_suite"]["head_sha"]
+
+    # Find the repo PR that matches the head SHA we found
+    return {pr.head.sha: pr for pr in repo.get_pulls()}[pr_head_sha]
+
+# Get all issue numbers related to a PR.
+def get_related_issues(pr):
+    # Regex to pick out closing keywords.
+    regex = re.compile("(close[sd]?|fix|fixe[sd]?|resolve[sd]?)\s*:?\s+#(\d+)", re.I)
+
+    # Extract all associated issues from closing keyword in PR
+    for verb, num in regex.findall(pr.body):
+        yield int(num)
+
+    # Extract all associated issues from PR commit messages
+    for c in pr.get_commits():
+        for verb, num in regex.findall(c.commit.message):
+            yield int(num)
+
+# Get inputs from shell
+(token, repository, path) = sys.argv[1:4]
+
+# Initialize repo
+repo = Github(token).get_repo(repository)
+
+# Open Github event JSON
+with open(path) as f:
+    event = json.load(f)
+
+# Get the PR we're working on.
+pr = get_pr(event)
+pr_labels = {label.name for label in pr.labels}
+
+# Get every label on every linked issue.
+issues = get_related_issues(pr)
+issues_labels = [repo.get_issue(n).labels for n in issues]
+issues_labels = {l.name for l in itertools.chain(*issues_labels)}
+
+# Find the set of all labels we want to copy that aren't already set on the PR.
+unset_labels = COPYABLE_LABELS & issues_labels - pr_labels
+
+# If there are any labels we need to add, add them.
+if len(unset_labels) > 0:
+    pr.set_labels(*list(unset_labels))

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,6 +1,6 @@
 version: 2
 mergeable:
-  - when: pull_request.*
+  - when: pull_request.opened, pull_request.edited, pull_request.unlabeled, pull_request.synchronize
     validate:
       - do: title
         must_exclude:

--- a/.github/workflows/automation-pr.yml
+++ b/.github/workflows/automation-pr.yml
@@ -1,0 +1,19 @@
+# Automation that runs upon pull requests being submitted.
+name: automation-pr
+
+# Since pull requests from forks do not have repo write permission (for good
+# reason), we need to run on the `check_suite` trigger. This requires a non-
+# Github bot to be running on PRs to trigger the event.
+on:
+  check_suite:
+    types: [completed]
+
+jobs:
+  mirror-labels-to-pr:
+    runs-on: ubuntu-latest
+    container: quay.io/enarx/fedora-test
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: mirror-labels-to-pr
+      run: .automation/copy-issue-labels-to-pr ${{ secrets.GITHUB_TOKEN }} $GITHUB_REPOSITORY $GITHUB_EVENT_PATH


### PR DESCRIPTION
This pull request implements a bot that automatically copies labels to a pull request from a linked issue. It is meant to be the first step into a much larger automation framework for Enarx.

It uses the [`PyGithub`](https://github.com/PyGithub/PyGithub) library for the bulk of its logic. Scripts are run inside Enarx's testing container, and it uses the ephemeral [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) to make authenticated API v3 calls.

It will only mirror an approved subset of the labels present on the linked issue; currently, I've proposed this set as `["amd sev","documentation","ibm pef","infrastructure","intel sgx","wasm"]`. Comments welcome.

You can see an example run of the bot [here](https://github.com/mbestavros/actions-playground/pull/25).

Note that this bot is not currently live on the Enarx repo yet; the [`check_suite`](https://help.github.com/en/actions/reference/events-that-trigger-workflows#check-suite-event-check_suite) trigger only runs when in the `master` branch. When this is merged, you will begin to see its effects.

Resolves #63, and closes #325 (they accomplish the same thing, and this does it better).