### PR TITLE
Add common code that is shared between SEV keep and shim

### DIFF
--- a/vmsyscall/Cargo.toml
+++ b/vmsyscall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmsyscall"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Harald Hoyer <harald@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -14,4 +14,3 @@ keywords = [
 ]
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/vmsyscall/src/bootinfo.rs
+++ b/vmsyscall/src/bootinfo.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `bootinfo` module includes the hard-coded memory layout and
+//! the `BootInfo` structure which is handed to the kernel.
+//!
+//! Initially copied from:
+//! https://github.com/rust-osdev/bootloader/blob/90f5b8910d146d6d489b70a6341d778253663cfa/src/bootinfo/mod.rs
+
+use crate::memory_map::Map;
+use core::fmt;
+
+/// This structure represents the information that the bootloader passes to the kernel.
+///
+/// The information is passed as an argument to the entry point:
+///
+/// ```ignore
+/// pub extern "C" fn _start(boot_info: &'static BootInfo) -> ! {
+///    // […]
+/// }
+/// ```
+///
+/// Note that no type checking occurs for the entry point function, so be careful to
+/// use the correct argument types. To ensure that the entry point function has the correct
+/// signature, use the [`entry_point`] macro.
+#[derive(Clone)]
+#[repr(C)]
+pub struct BootInfo {
+    /// A map of the physical memory regions of the underlying machine.
+    ///
+    /// The bootloader queries this information from the BIOS/UEFI firmware and translates this
+    /// information to Rust types. It also marks any memory regions that the bootloader uses in
+    /// the memory map before passing it to the kernel. Regions marked as usable can be freely
+    /// used by the kernel.
+    pub memory_map: Map,
+
+    /// Elf entry point of the ring3 executable
+    pub entry_point: *const u8,
+
+    /// Elf program headers of the ring3 executable
+    pub load_addr: *const u8,
+
+    /// Elf number of program headers of the ring3 executable
+    pub elf_phnum: usize,
+
+    /// Syscall trigger port
+    pub syscall_trigger_port: u16,
+}
+
+impl fmt::Debug for BootInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BootInfo")
+            .field("memory_map", &self.memory_map)
+            .field(
+                "entry_point",
+                &format_args!("{:#x}", self.entry_point as u64),
+            )
+            .field("load_addr", &format_args!("{:#x}", self.load_addr as u64))
+            .field("elf_phnum", &self.elf_phnum)
+            .field("syscall_trigger_port", &self.syscall_trigger_port)
+            .finish()
+    }
+}
+
+#[test]
+fn check_bootinfo_size() {
+    use crate::memory_map::PAGE_SIZE;
+    assert!(core::mem::size_of::<BootInfo>() <= (PAGE_SIZE as _));
+}

--- a/vmsyscall/src/lib.rs
+++ b/vmsyscall/src/lib.rs
@@ -1,94 +1,92 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! syscall serialize/deserialize
+//! This crate is the interface between the SEV hypervisor (keep) and
+//! microkernel (shim). It enables system call proxying to the host
+//! and serialization of system calls.
 //!
 //! Currently it uses a hard coded page and an I/O trigger.
 //! We might want to switch to MMIO.
 
 #![deny(missing_docs)]
 #![deny(clippy::all)]
+#![deny(improper_ctypes)]
 #![no_std]
 
-use serde::{Deserialize, Serialize};
+pub mod bootinfo;
+pub mod memory_map;
 
-/// The syscalls to be serialized/deserialized via serde
-/// for the Hypervisor <-> VM syscall proxy
-#[derive(Serialize, Deserialize, Debug)]
+use core::fmt::{Debug, Formatter};
+
+impl Debug for VmSyscall {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            VmSyscall::Read { .. } => f.write_str("read(2)"),
+            VmSyscall::Write { .. } => f.write_str("write(2)"),
+            VmSyscall::Madvise { .. } => f.write_str("madvise(2)"),
+            VmSyscall::Mmap { .. } => f.write_str("mmap(2)"),
+            VmSyscall::Mremap { .. } => f.write_str("mremap(2)"),
+            VmSyscall::Munmap { .. } => f.write_str("munmap(2)"),
+            VmSyscall::Mprotect { .. } => f.write_str("mprotect(2)"),
+        }
+    }
+}
+
+/// maximum length of write(2) buffer
+pub const WRITE_BUF_LEN: usize = 4000;
+
+/// The syscalls for the Hypervisor <-> VM syscall proxy
+#[allow(clippy::large_enum_variant, missing_docs)]
 pub enum VmSyscall {
-    /// int madvise(void *addr, size_t length, int advice);
+    Read {
+        fd: u32,
+        count: usize,
+    },
+    Write {
+        fd: u32,
+        count: usize,
+        data: [u8; WRITE_BUF_LEN],
+    },
     Madvise {
-        /// see madvise(2)
         addr: usize,
-        /// see madvise(2)
         length: usize,
-        /// see madvise(2)
         advice: i32,
     },
-    /// void *mmap(void *addr, size_t length, int prot, int flags, …);
     Mmap {
-        /// see mmap(2)
         addr: usize,
-        /// see mmap(2)
         length: usize,
-        /// see mmap(2)
         prot: i32,
-        /// see mmap(2)
         flags: i32,
     },
-    /// void *mremap(void *old_address, size_t old_size, size_t new_size, int flags, ... /* void *new_address */);
     Mremap {
-        /// see mremap(2)
         old_address: usize,
-        /// see mremap(2)
         old_size: usize,
-        /// see mremap(2)
         new_size: usize,
-        /// see mremap(2)
         flags: i32,
     },
-    /// int munmap(void *addr, size_t length);
     Munmap {
-        /// see munmap(2)
         addr: usize,
-        /// see munmap(2)
         length: usize,
     },
-    /// int mprotect(void *addr, size_t len, int prot);
     Mprotect {
-        /// see mprotect(2)
         addr: usize,
-        /// see mprotect(2)
         length: usize,
-        /// see mprotect(2)
         prot: i32,
     },
     // Todo: extend with needed hypervisor proxy syscalls
 }
 
+/// A Linux ErrNo (see libc crate)
+pub type ErrNo = i32;
+
 /// The return value of the syscalls to be serialized/deserialized via serde
 /// for the Hypervisor <-> VM syscall proxy
-#[derive(Serialize, Deserialize, Debug)]
+#[allow(clippy::large_enum_variant, missing_docs)]
 pub enum VmSyscallRet {
-    /// int madvise(void *addr, size_t length, int advice);
-    Madvise(Result<i32, Error>),
-    /// void *mmap(void *addr, size_t length, int prot, int flags, …);
-    Mmap(Result<usize, Error>),
-    /// void *mremap(void *old_address, size_t old_size, size_t new_size, int flags, ... /* void *new_address */);
-    Mremap(Result<usize, Error>),
-    /// int munmap(void *addr, size_t length);
-    Munmap(Result<i32, Error>),
-    /// int mprotect(void *addr, size_t len, int prot);
-    Mprotect(Result<i32, Error>),
-}
-
-/// The error codes of the syscalls to be serialized/deserialized via serde
-/// for the Hypervisor <-> VM syscall proxy
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub enum Error {
-    /// standard error
-    Errno(i64),
-    /// serialize error
-    SerializeError,
-    /// deserialize error
-    DeSerializeError,
+    Read(Result<(i32, [u8; WRITE_BUF_LEN]), ErrNo>),
+    Write(Result<i32, ErrNo>),
+    Madvise(Result<i32, ErrNo>),
+    Mmap(Result<usize, ErrNo>),
+    Mremap(Result<usize, ErrNo>),
+    Munmap(Result<i32, ErrNo>),
+    Mprotect(Result<i32, ErrNo>),
 }

--- a/vmsyscall/src/memory_map.rs
+++ b/vmsyscall/src/memory_map.rs
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `Map` describes the virtual machine address space.
+//!
+//! Initially copied from:
+//! https://github.com/rust-osdev/bootloader/blob/90f5b8910d146d6d489b70a6341d778253663cfa/src/bootinfo/memory_map.rs
+
+use core::cmp::Ordering;
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+
+pub(crate) const PAGE_SIZE: u64 = 4096;
+
+const MAX_MEMORY_MAP_SIZE: usize = 64;
+
+/// A map of the physical memory regions of the underlying machine.
+#[derive(Clone)]
+#[repr(C)]
+pub struct Map {
+    entries: [Region; MAX_MEMORY_MAP_SIZE],
+    // u64 instead of usize so that the structure layout is platform
+    // independent
+    next_entry_index: u64,
+}
+
+impl Map {
+    /// Produce an empty `Map`.
+    pub const fn new() -> Self {
+        Map {
+            entries: [Region::empty(); MAX_MEMORY_MAP_SIZE],
+            next_entry_index: 0,
+        }
+    }
+
+    /// Mark a region as usable.
+    pub fn set_region_type_usable(&mut self, region_type: RegionType) {
+        self.iter_mut()
+            .filter(|r| r.region_type == region_type)
+            .for_each(|r| r.region_type = RegionType::Usable);
+    }
+
+    /// Add a region to the `Map`.
+    pub fn add_region(&mut self, region: Region) {
+        if let Some(last_region) = self
+            .entries
+            .iter_mut()
+            .filter(|r| r.region_type == region.region_type)
+            .find(|r| r.contains(&region))
+        {
+            last_region.range.end_frame_number = region.range.end_frame_number;
+        }
+
+        assert!(
+            self.next_entry_index() < MAX_MEMORY_MAP_SIZE,
+            "too many memory regions in memory map"
+        );
+
+        self.entries[self.next_entry_index()] = region;
+        self.next_entry_index += 1;
+        self.sort();
+    }
+
+    /// Mark a region as allocated.
+    pub fn mark_allocated_region(&mut self, region: Region) {
+        let mut region = region;
+        for r in self.iter_mut() {
+            // New region inside region of same type
+            if r.region_type == region.region_type && r.contains(&region) {
+                return;
+            }
+
+            // New region extends old region
+            if r.region_type == region.region_type && region.extends(&r) {
+                region.range.start_frame_number = r.range.end_frame_number;
+            }
+
+            if region.behind(r) {
+                continue;
+            }
+            if region.ahead(r) {
+                continue;
+            }
+
+            if r.region_type != RegionType::Usable {
+                panic!(
+                    "region {:x?} overlaps with non-usable region {:x?}",
+                    region, r
+                );
+            }
+
+            let region_cmp = region
+                .range
+                .start_frame_number
+                .cmp(&r.range.start_frame_number);
+            match region_cmp {
+                Ordering::Equal => {
+                    if region.range.end_frame_number < r.range.end_frame_number {
+                        // Case: (r = `r`, R = `region`)
+                        // ----rrrrrrrrrrr----
+                        // ----RRRR-----------
+                        r.range.start_frame_number = region.range.end_frame_number;
+                        self.add_region(region);
+                    } else {
+                        // Case: (r = `r`, R = `region`)
+                        // ----rrrrrrrrrrr----
+                        // ----RRRRRRRRRRRRRR-
+                        *r = region;
+                    }
+                }
+                Ordering::Greater => {
+                    if region.range.end_frame_number < r.range.end_frame_number {
+                        // Case: (r = `r`, R = `region`)
+                        // ----rrrrrrrrrrr----
+                        // ------RRRR---------
+                        let mut behind_r = *r;
+                        behind_r.range.start_frame_number = region.range.end_frame_number;
+                        r.range.end_frame_number = region.range.start_frame_number;
+                        self.add_region(behind_r);
+                        self.add_region(region);
+                    } else {
+                        // Case: (r = `r`, R = `region`)
+                        // ----rrrrrrrrrrr----
+                        // -----------RRRR---- or
+                        // -------------RRRR--
+                        r.range.end_frame_number = region.range.start_frame_number;
+                        self.add_region(region);
+                    }
+                }
+                _ => {
+                    // Case: (r = `r`, R = `region`)
+                    // ----rrrrrrrrrrr----
+                    // --RRRR-------------
+                    r.range.start_frame_number = region.range.end_frame_number;
+                    self.add_region(region);
+                }
+            }
+
+            return;
+        }
+        panic!(
+            "region {:x?} is not a usable memory region\n{:#?}",
+            region, self
+        );
+    }
+
+    /// Sort the `Map` by region index.
+    pub fn sort(&mut self) {
+        self.entries.sort_unstable();
+        if let Some(first_zero_index) = self.entries.iter().position(|r| r.range.is_empty()) {
+            self.next_entry_index = first_zero_index as u64;
+        }
+    }
+
+    /// Peek the next index value.
+    fn next_entry_index(&self) -> usize {
+        self.next_entry_index as usize
+    }
+}
+
+impl Default for Map {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deref for Map {
+    type Target = [Region];
+
+    fn deref(&self) -> &Self::Target {
+        &self.entries[0..self.next_entry_index()]
+    }
+}
+
+impl DerefMut for Map {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let next_index = self.next_entry_index();
+        &mut self.entries[0..next_index]
+    }
+}
+
+impl fmt::Debug for Map {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+/// Represents a region of physical memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct Region {
+    /// The range of frames that belong to the region.
+    pub range: FrameRange,
+    /// The type of the region.
+    pub region_type: RegionType,
+}
+
+impl Region {
+    /// Produce an empty `Region`.
+    pub const fn empty() -> Self {
+        Region {
+            range: FrameRange {
+                start_frame_number: 0,
+                end_frame_number: 0,
+            },
+            region_type: RegionType::Empty,
+        }
+    }
+
+    /// Does this region contain the `other` region?
+    pub fn contains(&self, other: &Region) -> bool {
+        self.range.start_frame_number <= other.range.start_frame_number
+            && self.range.end_frame_number >= other.range.end_frame_number
+    }
+
+    /// Does this region extend the `other` region?
+    pub fn extends(&self, other: &Region) -> bool {
+        self.range.start_frame_number >= other.range.start_frame_number
+            && self.range.end_frame_number > other.range.end_frame_number
+    }
+
+    /// Is this region fully behind the `other` region with no overlap?
+    pub fn behind(&self, other: &Region) -> bool {
+        self.range.start_frame_number >= other.range.end_frame_number
+    }
+
+    /// Is this region fully ahead of the `other` region with no overlap?
+    pub fn ahead(&self, other: &Region) -> bool {
+        self.range.end_frame_number < other.range.start_frame_number
+    }
+}
+
+impl PartialOrd for Region {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Region {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.range.is_empty() {
+            Ordering::Greater
+        } else if other.range.is_empty() {
+            Ordering::Less
+        } else {
+            let ordering = self
+                .range
+                .start_frame_number
+                .cmp(&other.range.start_frame_number);
+            match ordering {
+                Ordering::Equal => self
+                    .range
+                    .end_frame_number
+                    .cmp(&other.range.end_frame_number),
+                _ => ordering,
+            }
+        }
+    }
+}
+
+/// A range of frames with an exclusive upper bound.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct FrameRange {
+    /// The frame _number_ of the first 4KiB frame in the region.
+    ///
+    /// This convert this frame number to a physical address, multiply it with the
+    /// page size (4KiB).
+    pub start_frame_number: u64,
+    /// The frame _number_ of the first 4KiB frame that does no longer belong to the region.
+    ///
+    /// This convert this frame number to a physical address, multiply it with the
+    /// page size (4KiB).
+    pub end_frame_number: u64,
+}
+
+impl FrameRange {
+    /// Create a new FrameRange from the passed start_addr and end_addr.
+    ///
+    /// The end_addr is exclusive.
+    pub fn new(start_addr: u64, end_addr: u64) -> Self {
+        let last_byte = end_addr - 1;
+        FrameRange {
+            start_frame_number: start_addr / PAGE_SIZE,
+            end_frame_number: (last_byte / PAGE_SIZE) + 1,
+        }
+    }
+
+    /// Returns true if the frame range contains no frames.
+    pub fn is_empty(&self) -> bool {
+        self.start_frame_number == self.end_frame_number
+    }
+
+    /// Length of the frame range
+    pub fn len(&self) -> u64 {
+        self.end_frame_number - self.start_frame_number
+    }
+
+    /// Returns the physical start address of the memory region.
+    pub fn start_addr(&self) -> u64 {
+        self.start_frame_number * PAGE_SIZE
+    }
+
+    /// Returns the physical end address of the memory region.
+    pub fn end_addr(&self) -> u64 {
+        self.end_frame_number * PAGE_SIZE
+    }
+}
+
+impl fmt::Debug for FrameRange {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "FrameRange({:#x}..{:#x})",
+            self.start_addr(),
+            self.end_addr()
+        )
+    }
+}
+
+/// Represents possible types for memory regions.
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum RegionType {
+    Usable,
+    InUse,
+    Reserved,
+    AcpiReclaimable,
+    AcpiNvs,
+    BadMemory,
+    Kernel,
+    App,
+    Bootloader,
+    FrameZero,
+    Empty,
+}


### PR DESCRIPTION
This will allow us to more easily parallelize our efforts to porting in Harald's work. There will be two projects consuming this common core:

* 'vmrun' AKA enarx-keep-sev
* 'kernel' AKA enarx-keep-sev-shim