### PR TITLE
Add issues to projects when labeled

### DIFF
--- a/.automation/add-to-project-when-labeled
+++ b/.automation/add-to-project-when-labeled
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import sys
+from github import Github
+
+# A mapping between labels and projects to add when they're applied.
+LABEL_PROJECTS = {
+    "infrastructure": "Infrastructure",
+    "amd sev": "SEV",
+    "intel sgx": "SGX",
+    "wasm": "WebAssembly",
+}
+
+# Get inputs from shell
+(token, repository, path) = sys.argv[1:4]
+
+# Initialize repo
+repo = Github(token).get_repo(repository)
+
+# Open Github event JSON
+with open(path) as f:
+    event = json.load(f)
+
+# Determine whether the labels were added or removed
+action = event["action"]
+
+# Get the name of the label
+label_name = event["label"]["name"]
+
+# Determine content type: issue or PR, as well as content ID
+try:
+    content_type = "Issue"
+    content_id = event["issue"]["id"]
+except KeyError:
+    content_type = "PullRequest"
+    content_id = event["pull_request"]["id"]
+
+# Fetch the project we want to add to or remove from
+project = [p for p in repo.get_projects() if p.name == LABEL_PROJECTS[label_name]][1]
+
+# If the label was added, we want to add to the project. If removed, we want to
+# remove from the project.
+if action == "labeled":
+    project_column = project.get_columns()[1]
+    project_column.create_card(content_id=content_id, content_type=content_type)
+elif action == "unlabeled":
+    for column in project.get_columns():
+        for card in column.get_cards():
+            if card.get_content() is not None and card.get_content().id == content_id:
+                card.delete()

--- a/.github/workflows/automation-label.yml
+++ b/.github/workflows/automation-label.yml
@@ -1,0 +1,17 @@
+name: automation-label
+
+on:
+    issues:
+        types:
+            - labeled
+            - unlabeled
+
+jobs:
+  add-to-project-when-labeled:
+    runs-on: ubuntu-latest
+    container: quay.io/enarx/fedora-test
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: add-to-project-when-labeled
+      run: .automation/add-to-project-when-labeled ${{ secrets.GITHUB_TOKEN }} $GITHUB_REPOSITORY $GITHUB_EVENT_PATH


### PR DESCRIPTION
This action expands on the groundwork laid in #360. It acts on the `labeled` event (currently only for `issues`) and adds to a project based on the label added. Here's the mapping I've proposed:

```
"infrastructure": "Infrastructure",
"amd sev": "SEV",
"intel sgx": "SGX",
"wasm": "WebAssembly",
```

This is related to #377, but it doesn't implement this functionality on PRs yet (currently blocked by the `GITHUB_TOKEN` behavior on PR events). When that's done, #377 can be considered closed.