### PR TITLE
Add stubs for rt_sigaction and rt_sigprocmask in SGX syscall handler

### DIFF
--- a/enarx-keep-sgx-shim/src/event.rs
+++ b/enarx-keep-sgx-shim/src/event.rs
@@ -28,6 +28,8 @@ pub extern "C" fn event(
                 SysCall::GETUID => h.getuid(),
                 SysCall::EXIT => h.exit(None),
                 SysCall::EXIT_GROUP => h.exit_group(None),
+                SysCall::RT_SIGACTION => h.rt_sigaction(),
+                SysCall::RT_SIGPROCMASK => h.rt_sigprocmask(),
                 _ => h.exit(254),
             };
 

--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -191,4 +191,16 @@ impl<'a> Handler<'a> {
             ret
         }
     }
+
+    /// rt_sigaction() syscall stub
+    /// TODO: Implement correct behavior for this function.
+    pub fn rt_sigaction(&mut self) -> u64 {
+        0
+    }
+
+    /// rt_sigprocmask() syscall stub
+    /// TODO: Implement correct behavior for this function.
+    pub fn rt_sigprocmask(&mut self) -> u64 {
+        0
+    }
 }


### PR DESCRIPTION
Resolves #403 

Related debt issue is #405 