### PR TITLE
Implement a rudimentary brk

### DIFF
--- a/enarx-keep-sgx-shim/src/event.rs
+++ b/enarx-keep-sgx-shim/src/event.rs
@@ -32,6 +32,7 @@ pub extern "C" fn event(
                 SysCall::ARCH_PRCTL => h.arch_prctl(),
                 SysCall::EXIT_GROUP => h.exit_group(None),
                 SysCall::SET_TID_ADDRESS => h.set_tid_address(),
+                SysCall::BRK => h.brk(),
                 _ => h.exit(254),
             };
 

--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -360,4 +360,27 @@ impl<'a> Handler<'a> {
 
         ret
     }
+
+    /// Do a brk() system call
+    pub fn brk(&mut self) -> u64 {
+        let mut ret: u64 = 0;
+        let address = self.aex.gpr.rdi;
+        unsafe {
+            static mut INDEX: u64 = 0;
+            let mut diff = 0;
+            static mut HEAP: core::ops::Range<u64> = core::ops::Range { start: 0, end: 0 };
+            let (lower, _upper) = HEAP.size_hint();
+            if address > INDEX {
+                diff = address - INDEX;
+            }
+            if lower as u64 >= diff {
+                if diff > 0 {
+                    HEAP.nth(diff as usize - 1);
+                }
+                INDEX += diff;
+                ret = INDEX;
+            }
+        }
+        ret
+    }
 }


### PR DESCRIPTION
Here's a first stab, not really sure if this is the right approach... Here are some notes:
1. Assuming that the array is a heap, all I am doing is incrementing index and keeping track of where we are. The index of the array is the *address* that the program is requesting but while incrementing the index, I am not rounding it to the nearest page size. Also, there's no state maintained to give memory back to the heap.
2. I am not sure if I am using size_hint() correctly - it actually returns the same value for upper and lower limit probably because HEAP is static ? It does solve my purpose of finding the upper bound though.
3. The function returns u64 but that probably ok for now since the call in the demo app won't fail ? (The man page says it should return -1)