### PR TITLE
Move vmsyscall changes from demo2020 into master

### DIFF
--- a/memory/src/page.rs
+++ b/memory/src/page.rs
@@ -3,7 +3,7 @@
 /// A single page of memory
 ///
 /// This type is page-aligned and page-sized.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(C, align(4096))]
 pub struct Page([[u64; 32]; 16]);
 

--- a/vmsyscall/Cargo.toml
+++ b/vmsyscall/Cargo.toml
@@ -15,3 +15,4 @@ keywords = [
 
 [dependencies]
 memory = { path = "../memory" }
+span = { path = "../span" }

--- a/vmsyscall/Cargo.toml
+++ b/vmsyscall/Cargo.toml
@@ -14,3 +14,4 @@ keywords = [
 ]
 
 [dependencies]
+memory = { path = "../memory" }

--- a/vmsyscall/Cargo.toml
+++ b/vmsyscall/Cargo.toml
@@ -14,4 +14,3 @@ keywords = [
 ]
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/vmsyscall/src/bootinfo.rs
+++ b/vmsyscall/src/bootinfo.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `bootinfo` module includes the hard-coded memory layout and
+//! the `BootInfo` structure which is handed to the kernel.
+//!
+//! Initially copied from:
+//! https://github.com/rust-osdev/bootloader/blob/90f5b8910d146d6d489b70a6341d778253663cfa/src/bootinfo/mod.rs
+
+use crate::memory_map::Map;
+use core::fmt;
+
+/// This structure represents the information that the bootloader passes to the kernel.
+///
+/// The information is passed as an argument to the entry point:
+///
+/// ```ignore
+/// pub extern "C" fn _start(boot_info: &'static BootInfo) -> ! {
+///    // […]
+/// }
+/// ```
+///
+/// Note that no type checking occurs for the entry point function, so be careful to
+/// use the correct argument types. To ensure that the entry point function has the correct
+/// signature, use the [`entry_point`] macro.
+#[derive(Clone)]
+#[repr(C)]
+pub struct BootInfo {
+    /// A map of the physical memory regions of the underlying machine.
+    ///
+    /// The bootloader queries this information from the BIOS/UEFI firmware and translates this
+    /// information to Rust types. It also marks any memory regions that the bootloader uses in
+    /// the memory map before passing it to the kernel. Regions marked as usable can be freely
+    /// used by the kernel.
+    pub memory_map: Map,
+
+    /// ELF entry point of the ring 3 executable
+    pub entry_point: *const u8,
+
+    /// ELF program headers of the ring 3 executable
+    pub load_addr: *const u8,
+
+    /// ELF number of program headers of the ring 3 executable
+    pub elf_phnum: usize,
+
+    /// Syscall trigger port
+    pub syscall_trigger_port: u16,
+}
+
+impl fmt::Debug for BootInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BootInfo")
+            .field("memory_map", &self.memory_map)
+            .field(
+                "entry_point",
+                &format_args!("{:#x}", self.entry_point as u64),
+            )
+            .field("load_addr", &format_args!("{:#x}", self.load_addr as u64))
+            .field("elf_phnum", &self.elf_phnum)
+            .field("syscall_trigger_port", &self.syscall_trigger_port)
+            .finish()
+    }
+}
+
+#[test]
+fn check_bootinfo_size() {
+    assert!(core::mem::size_of::<BootInfo>() <= (memory::Page::size() as _));
+}

--- a/vmsyscall/src/lib.rs
+++ b/vmsyscall/src/lib.rs
@@ -10,6 +10,8 @@
 #![deny(clippy::all)]
 #![no_std]
 
+pub mod memory_map;
+
 /// maximum length of write buffer
 pub const WRITE_BUF_LEN: usize = 4000;
 

--- a/vmsyscall/src/lib.rs
+++ b/vmsyscall/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(clippy::all)]
 #![no_std]
 
+pub mod bootinfo;
 pub mod memory_map;
 
 /// maximum length of write buffer

--- a/vmsyscall/src/lib.rs
+++ b/vmsyscall/src/lib.rs
@@ -44,6 +44,50 @@ pub enum VmSyscall {
     },
 }
 
+impl core::fmt::Debug for VmSyscall {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            VmSyscall::Madvise {
+                addr,
+                length,
+                advice,
+            } => write!(
+                f,
+                "madvise(addr={:#x}, length={}, advice={:#x})",
+                addr, length, advice
+            ),
+            VmSyscall::Mmap {
+                addr,
+                length,
+                prot,
+                flags,
+            } => write!(
+                f,
+                "mmap(addr={:#x}, length={}, prot={:#x}, flags={:#x})",
+                addr, length, prot, flags
+            ),
+            VmSyscall::Mremap {
+                old_address,
+                old_size,
+                new_size,
+                flags,
+            } => write!(
+                f,
+                "mremap(old_address={:#x}, old_size={}, new_size={}, flags={:#x})",
+                old_address, old_size, new_size, flags
+            ),
+            VmSyscall::Munmap { addr, length } => {
+                write!(f, "munmap(addr={:#x}, length={})", addr, length)
+            }
+            VmSyscall::Mprotect { addr, length, prot } => write!(
+                f,
+                "mprotect(addr={:#x}, length={}, prot={:#x})",
+                addr, length, prot
+            ),
+        }
+    }
+}
+
 #[allow(clippy::large_enum_variant, missing_docs)]
 pub enum VmSyscallRet {
     Madvise(Result<i32, ErrNo>),

--- a/vmsyscall/src/lib.rs
+++ b/vmsyscall/src/lib.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! syscall serialize/deserialize
-//!
 //! Currently it uses a hard coded page and an I/O trigger.
 //! We might want to switch to MMIO.
 
@@ -9,11 +7,9 @@
 #![deny(clippy::all)]
 #![no_std]
 
-use serde::{Deserialize, Serialize};
+/// A Linux ErrNo (see libc crate)
+pub type ErrNo = i32;
 
-/// The syscalls to be serialized/deserialized via serde
-/// for the Hypervisor <-> VM syscall proxy
-#[derive(Serialize, Deserialize, Debug)]
 pub enum VmSyscall {
     /// int madvise(void *addr, size_t length, int advice);
     Madvise {
@@ -65,30 +61,12 @@ pub enum VmSyscall {
     // Todo: extend with needed hypervisor proxy syscalls
 }
 
-/// The return value of the syscalls to be serialized/deserialized via serde
 /// for the Hypervisor <-> VM syscall proxy
-#[derive(Serialize, Deserialize, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum VmSyscallRet {
-    /// int madvise(void *addr, size_t length, int advice);
-    Madvise(Result<i32, Error>),
-    /// void *mmap(void *addr, size_t length, int prot, int flags, …);
-    Mmap(Result<usize, Error>),
-    /// void *mremap(void *old_address, size_t old_size, size_t new_size, int flags, ... /* void *new_address */);
-    Mremap(Result<usize, Error>),
-    /// int munmap(void *addr, size_t length);
-    Munmap(Result<i32, Error>),
-    /// int mprotect(void *addr, size_t len, int prot);
-    Mprotect(Result<i32, Error>),
-}
-
-/// The error codes of the syscalls to be serialized/deserialized via serde
-/// for the Hypervisor <-> VM syscall proxy
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub enum Error {
-    /// standard error
-    Errno(i64),
-    /// serialize error
-    SerializeError,
-    /// deserialize error
-    DeSerializeError,
+    Madvise(Result<i32, ErrNo>),
+    Mmap(Result<usize, ErrNo>),
+    Mremap(Result<usize, ErrNo>),
+    Munmap(Result<i32, ErrNo>),
+    Mprotect(Result<i32, ErrNo>),
 }

--- a/vmsyscall/src/lib.rs
+++ b/vmsyscall/src/lib.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! This crate is the interface between the SEV hypervisor (keep) and
+//! microkernel (shim). It enables system call proxying to the host.
+//!
 //! Currently it uses a hard coded page and an I/O trigger.
 //! We might want to switch to MMIO.
 
@@ -10,59 +13,38 @@
 /// A Linux ErrNo (see libc crate)
 pub type ErrNo = i32;
 
+/// System call requests originating from the microkernel.
+#[allow(clippy::large_enum_variant, missing_docs)]
 pub enum VmSyscall {
-    /// int madvise(void *addr, size_t length, int advice);
     Madvise {
-        /// see madvise(2)
         addr: usize,
-        /// see madvise(2)
         length: usize,
-        /// see madvise(2)
         advice: i32,
     },
-    /// void *mmap(void *addr, size_t length, int prot, int flags, …);
     Mmap {
-        /// see mmap(2)
         addr: usize,
-        /// see mmap(2)
         length: usize,
-        /// see mmap(2)
         prot: i32,
-        /// see mmap(2)
         flags: i32,
     },
-    /// void *mremap(void *old_address, size_t old_size, size_t new_size, int flags, ... /* void *new_address */);
     Mremap {
-        /// see mremap(2)
         old_address: usize,
-        /// see mremap(2)
         old_size: usize,
-        /// see mremap(2)
         new_size: usize,
-        /// see mremap(2)
         flags: i32,
     },
-    /// int munmap(void *addr, size_t length);
     Munmap {
-        /// see munmap(2)
         addr: usize,
-        /// see munmap(2)
         length: usize,
     },
-    /// int mprotect(void *addr, size_t len, int prot);
     Mprotect {
-        /// see mprotect(2)
         addr: usize,
-        /// see mprotect(2)
         length: usize,
-        /// see mprotect(2)
         prot: i32,
     },
-    // Todo: extend with needed hypervisor proxy syscalls
 }
 
-/// for the Hypervisor <-> VM syscall proxy
-#[allow(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant, missing_docs)]
 pub enum VmSyscallRet {
     Madvise(Result<i32, ErrNo>),
     Mmap(Result<usize, ErrNo>),

--- a/vmsyscall/src/memory_map.rs
+++ b/vmsyscall/src/memory_map.rs
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `Map` describes the virtual machine address space.
+//!
+//! Initially copied from:
+//! https://github.com/rust-osdev/bootloader/blob/90f5b8910d146d6d489b70a6341d778253663cfa/src/bootinfo/memory_map.rs
+
+use core::cmp::Ordering;
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+
+use memory::{Offset, Page};
+use span::{Contains, Empty, Line};
+
+const MAX_MEMORY_MAP_SIZE: usize = 64;
+
+/// A map of the physical memory regions of the underlying machine.
+#[derive(Clone)]
+#[repr(C)]
+pub struct Map {
+    entries: [Region; MAX_MEMORY_MAP_SIZE],
+    // u64 instead of usize so that the structure layout is platform
+    // independent
+    next_entry_index: u64,
+}
+
+impl Map {
+    /// Produce an empty `Map`.
+    pub fn new() -> Self {
+        Map {
+            entries: [Region::empty(); MAX_MEMORY_MAP_SIZE],
+            next_entry_index: 0,
+        }
+    }
+
+    /// Mark a region as usable.
+    pub fn set_region_type_usable(&mut self, region_type: RegionType) {
+        self.iter_mut()
+            .filter(|r| r.region_type == region_type)
+            .for_each(|r| r.region_type = RegionType::Usable);
+    }
+
+    /// Add a region to the `Map`.
+    pub fn add_region(&mut self, region: Region) {
+        if let Some(last_region) = self
+            .entries
+            .iter_mut()
+            .filter(|r| r.region_type == region.region_type)
+            .find(|r| r.contains(&region))
+        {
+            last_region.range.end = region.range.end;
+        }
+
+        assert!(
+            self.next_entry_index() < MAX_MEMORY_MAP_SIZE,
+            "too many memory regions in memory map"
+        );
+
+        self.entries[self.next_entry_index()] = region;
+        self.next_entry_index += 1;
+        self.sort();
+    }
+
+    /// Mark a region as allocated.
+    pub fn mark_allocated_region(&mut self, region: Region) {
+        let mut region = region;
+        for r in self.iter_mut() {
+            // New region inside region of same type
+            if r.region_type == region.region_type && r.contains(&region) {
+                return;
+            }
+
+            // New region extends old region
+            if r.region_type == region.region_type && region.extends(&r) {
+                region.range.start = r.range.end;
+            }
+
+            if region.behind(r) {
+                continue;
+            }
+            if region.ahead(r) {
+                continue;
+            }
+
+            if r.region_type != RegionType::Usable {
+                panic!(
+                    "region {:x?} overlaps with non-usable region {:x?}",
+                    region, r
+                );
+            }
+
+            let region_cmp = region.range.start.cmp(&r.range.start);
+            match region_cmp {
+                Ordering::Equal => {
+                    if region.range.end < r.range.end {
+                        // Case: (r = `r`, R = `region`)
+                        // ----rrrrrrrrrrr----
+                        // ----RRRR-----------
+                        r.range.start = region.range.end;
+                        self.add_region(region);
+                    } else {
+                        // Case: (r = `r`, R = `region`)
+                        // ----rrrrrrrrrrr----
+                        // ----RRRRRRRRRRRRRR-
+                        *r = region;
+                    }
+                }
+                Ordering::Greater => {
+                    if region.range.end < r.range.end {
+                        // Case: (r = `r`, R = `region`)
+                        // ----rrrrrrrrrrr----
+                        // ------RRRR---------
+                        let mut behind_r = *r;
+                        behind_r.range.start = region.range.end;
+                        r.range.end = region.range.start;
+                        self.add_region(behind_r);
+                        self.add_region(region);
+                    } else {
+                        // Case: (r = `r`, R = `region`)
+                        // ----rrrrrrrrrrr----
+                        // -----------RRRR---- or
+                        // -------------RRRR--
+                        r.range.end = region.range.start;
+                        self.add_region(region);
+                    }
+                }
+                _ => {
+                    // Case: (r = `r`, R = `region`)
+                    // ----rrrrrrrrrrr----
+                    // --RRRR-------------
+                    r.range.start = region.range.end;
+                    self.add_region(region);
+                }
+            }
+
+            return;
+        }
+        panic!(
+            "region {:x?} is not a usable memory region\n{:#?}",
+            region, self
+        );
+    }
+
+    /// Sort the `Map` by region index.
+    pub fn sort(&mut self) {
+        self.entries.sort_unstable();
+        if let Some(first_zero_index) = self.entries.iter().position(|r| r.range.is_empty()) {
+            self.next_entry_index = first_zero_index as u64;
+        }
+    }
+
+    /// Peek the next index value.
+    fn next_entry_index(&self) -> usize {
+        self.next_entry_index as usize
+    }
+}
+
+impl Default for Map {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deref for Map {
+    type Target = [Region];
+
+    fn deref(&self) -> &Self::Target {
+        &self.entries[0..self.next_entry_index()]
+    }
+}
+
+impl DerefMut for Map {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let next_index = self.next_entry_index();
+        &mut self.entries[0..next_index]
+    }
+}
+
+impl fmt::Debug for Map {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+/// Represents a region of physical memory.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct Region {
+    /// The range of frames that belong to the region.
+    pub range: Line<Offset<usize, Page>>,
+    /// The type of the region.
+    pub region_type: RegionType,
+}
+
+impl Region {
+    /// Produce an empty `Region`.
+    pub fn empty() -> Self {
+        Region {
+            range: Line {
+                start: Offset::from_items(0),
+                end: Offset::from_items(0),
+            },
+            region_type: RegionType::Empty,
+        }
+    }
+
+    /// Does this region contain the `other` region?
+    pub fn contains(&self, other: &Region) -> bool {
+        self.range.contains(&other.range)
+    }
+
+    /// Does this region extend the `other` region?
+    pub fn extends(&self, other: &Region) -> bool {
+        self.range.start >= other.range.start && self.range.end > other.range.end
+    }
+
+    /// Is this region fully behind the `other` region with no overlap?
+    pub fn behind(&self, other: &Region) -> bool {
+        self.range.start >= other.range.end
+    }
+
+    /// Is this region fully ahead of the `other` region with no overlap?
+    pub fn ahead(&self, other: &Region) -> bool {
+        self.range.end < other.range.start
+    }
+}
+
+impl PartialOrd for Region {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Region {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.range.is_empty() {
+            Ordering::Greater
+        } else if other.range.is_empty() {
+            Ordering::Less
+        } else {
+            let ordering = self.range.start.cmp(&other.range.start);
+            match ordering {
+                Ordering::Equal => self.range.end.cmp(&other.range.end),
+                _ => ordering,
+            }
+        }
+    }
+}
+
+impl core::fmt::Debug for Region {
+    fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Region")
+            .field(
+                "range",
+                &format_args!(
+                    "({:#x}..{:#x})",
+                    self.range.start.bytes(),
+                    self.range.end.bytes()
+                ),
+            )
+            .field("region_type", &self.region_type)
+            .finish()
+    }
+}
+
+/// Represents possible types for memory regions.
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum RegionType {
+    Usable,
+    InUse,
+    Reserved,
+    AcpiReclaimable,
+    AcpiNvs,
+    BadMemory,
+    Kernel,
+    App,
+    Bootloader,
+    FrameZero,
+    Empty,
+}


### PR DESCRIPTION
note: leaving this as a draft because I cherry-picked Nathaniel's commit from his other PR that contains the `Line` type to base this on for some changes to `memory_map.rs`; so once that type is concretely in the repo I can rebase.

edit: woops guess it's not a draft

This is the first of probably several PRs that will gradually move code off of the `demo2020` branch.

This contains all of the feedback in #366 sans a more generic `set_region_type` method.

Related: #371 
Related: #313 