### PR TITLE
Test consistency of linked issues between commits and PR

### DIFF
--- a/.github/workflows/miscellaneous.yml
+++ b/.github/workflows/miscellaneous.yml
@@ -30,6 +30,17 @@ jobs:
     # Ensure all diagrams are up-to-date.
     - name: All diagrams are up-to-date
       run: .tests/misc-diagrams
+  
+  misc-consistent-linked-issues:
+    runs-on: ubuntu-latest
+    container: quay.io/enarx/fedora-test
+    steps:
+    - uses: actions/checkout@v2
+    
+    # Ensure issues mentioned in commits are also present in the PR description
+    # and properly linked.
+    - name: Linked issues are consistent between commits and PR description
+      run: .tests/misc-consistent-linked-issues ${{ secrets.GITHUB_TOKEN }} $GITHUB_REPOSITORY $GITHUB_EVENT_PATH
 
   # Ensure required lints are enabled.
   misc-lints-clippy-all:

--- a/.tests/misc-consistent-linked-issues
+++ b/.tests/misc-consistent-linked-issues
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import re
+import sys
+import textwrap
+from github import Github
+
+# Regex to pick out closing keywords.
+LINKED_ISSUES = re.compile("(close[sd]?|fix|fixe[sd]?|resolve[sd]?)\s*:?\s+#(\d+)", re.I)
+
+# Returns a pull request extracted from Github's event JSON.
+def get_pr(event):
+    # --- Extract issue from event JSON ---
+    # `pull_request` directly refers the the PR number in the event JSON.
+    # Extract that number and use it to grab the PR.
+    pr_number = event["number"]
+
+    # Grab the PR from the number and return
+    return repo.get_pull(pr_number)
+
+# Extract all associated issues from PR commit messages
+def get_linked_issues_commits(pr):
+    for c in pr.get_commits():
+        for verb, num in LINKED_ISSUES.findall(c.commit.message):
+            yield num
+
+# Extract all associated issues linked in PR description
+def get_linked_issues_body(pr):
+    # Extract all associated issues from closing keyword in PR
+    for verb, num in LINKED_ISSUES.findall(pr.body):
+        yield num
+
+# Get inputs from shell
+(token, repository, path) = sys.argv[1:4]
+
+# Initialize repo
+repo = Github(token).get_repo(repository)
+
+# Open Github event JSON
+with open(path) as f:
+    event = json.load(f)
+
+# Get the PR we're working on.
+pr = get_pr(event)
+
+commits_issues = set(get_linked_issues_commits(pr))
+description_issues = set(get_linked_issues_body(pr))
+unlinked_issues = commits_issues - description_issues
+
+if len(unlinked_issues) > 0:
+    print("""
+Your PR contains one or more commit messages that refer to closing issues, but
+those issues are not linked in your pull request description. Please include the
+following in your PR description:
+""")
+    for n in unlinked_issues:
+        print("Resolves: #%s" % n)
+    print("""
+You may use any of Github's supported closing keywords in place of 'Resolves':
+https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+""")
+    exit(1)


### PR DESCRIPTION
Github currently does not link issues when referred to in commit messages, even if it uses the same [closing keyword syntax](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) as in a PR description.

To ensure all issues that a PR's author meant to be linked get linked, this test ensures that any issues linked to in commits are also linked in the PR description. If there are any missing, it'll tell the author how to link them.

Resolves: #428