### PR TITLE
Remove AsRef implementations

### DIFF
--- a/sgx-crypto/src/lib.rs
+++ b/sgx-crypto/src/lib.rs
@@ -64,7 +64,9 @@ impl Hasher {
             // Hash for the EADD instruction.
             self.0.update(&EADD.to_le_bytes());
             self.0.update(&(off as u64).to_le_bytes());
-            self.0.update(&secinfo.as_ref()[..48]);
+            self.0.update(unsafe {
+                std::slice::from_raw_parts(&secinfo as *const _ as *const u8, 48)
+            });
 
             // Hash for the EEXTEND instruction.
             if measure {

--- a/sgx-types/src/page.rs
+++ b/sgx-types/src/page.rs
@@ -78,17 +78,6 @@ impl core::fmt::Debug for SecInfo {
     }
 }
 
-impl AsRef<[u8]> for SecInfo {
-    fn as_ref(&self) -> &[u8] {
-        unsafe {
-            core::slice::from_raw_parts(
-                self as *const Self as *const u8,
-                core::mem::size_of_val(self),
-            )
-        }
-    }
-}
-
 impl SecInfo {
     /// Creates a SecInfo (page) of class type Regular.
     pub const fn reg(flags: Flags) -> Self {

--- a/sgx-types/src/ssa.rs
+++ b/sgx-types/src/ssa.rs
@@ -308,17 +308,6 @@ impl Default for StateSaveArea {
     }
 }
 
-impl AsRef<[u8]> for StateSaveArea {
-    fn as_ref(&self) -> &[u8] {
-        unsafe {
-            core::slice::from_raw_parts(
-                self as *const Self as *const u8,
-                core::mem::size_of_val(self),
-            )
-        }
-    }
-}
-
 impl StateSaveArea {
     /// Converts an internal fault type to a safe Rust enum describing the fault.
     pub fn fault(&self) -> Option<Fault> {

--- a/sgx-types/src/tcs.rs
+++ b/sgx-types/src/tcs.rs
@@ -72,17 +72,6 @@ impl Tcs {
     }
 }
 
-impl AsRef<[u8]> for Tcs {
-    fn as_ref(&self) -> &[u8] {
-        unsafe {
-            core::slice::from_raw_parts(
-                self as *const Self as *const u8,
-                core::mem::size_of_val(self),
-            )
-        }
-    }
-}
-
 #[cfg(test)]
 testaso! {
     struct Tcs: 4096, 4096 => {


### PR DESCRIPTION
We are going to move to a strategy of copying structs into page-aligned,
paged-size data types before loading. This means that we don't need to
serialize the types directly.