### PR TITLE
move Build struct to sev-types

### DIFF
--- a/sev-types/src/lib.rs
+++ b/sev-types/src/lib.rs
@@ -16,22 +16,9 @@
 //! the SEV API specification document version; the specification publication
 //! date; the link to the SEV API specification.
 
+#![no_std]
 #![deny(missing_docs)]
 #![deny(clippy::all)]
-#![allow(missing_docs)]
 
 pub mod command;
 pub mod platform;
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Build {
-    pub version: platform::Version,
-    pub build: u8,
-}
-
-impl std::fmt::Display for Build {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}.{}", self.version, self.build)
-    }
-}

--- a/sev-types/src/lib.rs
+++ b/sev-types/src/lib.rs
@@ -16,9 +16,22 @@
 //! the SEV API specification document version; the specification publication
 //! date; the link to the SEV API specification.
 
-#![no_std]
 #![deny(missing_docs)]
 #![deny(clippy::all)]
+#![allow(missing_docs)]
 
 pub mod command;
 pub mod platform;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Build {
+    pub version: platform::Version,
+    pub build: u8,
+}
+
+impl std::fmt::Display for Build {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}.{}", self.version, self.build)
+    }
+}

--- a/sev-types/src/platform.rs
+++ b/sev-types/src/platform.rs
@@ -21,3 +21,20 @@ impl core::fmt::Display for Version {
         write!(f, "{}.{}", self.major, self.minor)
     }
 }
+
+/// The firmware 'Build' is the Build ID for a particular API version.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Build {
+    /// The firmware's version.
+    pub version: Version,
+
+    ///  Build ID.
+    pub build: u8,
+}
+
+impl core::fmt::Display for Build {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}.{}", self.version, self.build)
+    }
+}

--- a/sev/src/lib.rs
+++ b/sev/src/lib.rs
@@ -9,7 +9,7 @@
 #![allow(missing_docs)]
 
 use sev_types::platform;
-use sev_types::Build;
+use sev_types::platform::Build;
 
 pub mod certs;
 pub mod firmware;

--- a/sev/src/lib.rs
+++ b/sev/src/lib.rs
@@ -9,22 +9,10 @@
 #![allow(missing_docs)]
 
 use sev_types::platform;
+use sev_types::Build;
 
 pub mod certs;
 pub mod firmware;
 pub mod launch;
 #[cfg(feature = "openssl")]
 pub mod session;
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Build {
-    pub version: platform::Version,
-    pub build: u8,
-}
-
-impl std::fmt::Display for Build {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}.{}", self.version, self.build)
-    }
-}

--- a/sev/tests/api.rs
+++ b/sev/tests/api.rs
@@ -2,7 +2,9 @@
 
 use sev_types::platform::Version;
 
-use sev::{certs::sev::Usage, firmware::Firmware, Build};
+use sev::{certs::sev::Usage, firmware::Firmware};
+
+use sev_types::Build;
 
 #[cfg_attr(not(all(has_sev, feature = "dangerous_tests")), ignore)]
 #[test]

--- a/sev/tests/api.rs
+++ b/sev/tests/api.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use sev_types::platform::Version;
+use sev_types::platform::{Build, Version};
 
 use sev::{certs::sev::Usage, firmware::Firmware};
-
-use sev_types::Build;
 
 #[cfg_attr(not(all(has_sev, feature = "dangerous_tests")), ignore)]
 #[test]


### PR DESCRIPTION
Move Build struct from 'sev' into 'sev-types' 

Closes #446