### PR TITLE
crt0stack/src/lib.rs: fix `reader_real()` test

### DIFF
--- a/crt0stack/examples/reader.rs
+++ b/crt0stack/examples/reader.rs
@@ -8,7 +8,7 @@ fn main() {
     }
 
     let reader = unsafe { Reader::from_environ(&*environ) }.prev().prev();
-    assert_eq!(reader.count(), 1);
+    assert_eq!(reader.count(), std::env::args().count());
 
     let mut reader = reader.done();
     for arg in &mut reader {

--- a/crt0stack/src/lib.rs
+++ b/crt0stack/src/lib.rs
@@ -874,7 +874,7 @@ mod tests {
         }
 
         let reader = unsafe { Reader::from_environ(&*environ) }.prev().prev();
-        assert_eq!(reader.count(), 1);
+        assert_eq!(reader.count(), std::env::args().count());
 
         let mut reader = reader.done();
         for arg in &mut reader {


### PR DESCRIPTION
The test assumed the test has no arguments.
Check against the actual number of arguments.

```console
❯ cargo -v test -p crt0stack reader_real -- --nocapture --test-threads=1
       Fresh enumerate v0.1.0 (/home/harald/git/enarx/enarx/enumerate)
       Fresh crt0stack v0.6.0 (/home/harald/git/enarx/enarx/crt0stack)
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running `/home/harald/git/enarx/enarx/target/x86_64-unknown-linux-musl/debug/deps/crt0stack-0ca48c4154260701 reader_real --nocapture --test-threads=1`

running 1 test
test tests::reader_real ... thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `4`,
 right: `1`', crt0stack/src/lib.rs:877:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
FAILED

failures:

failures:
    tests::reader_real

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 10 filtered out

error: test failed, to rerun pass '-p crt0stack --lib'
```