### PR TITLE
wasm: update keep-libruntime and keep-runtime

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,6 +10,7 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
 	"intel-types",
 	"iocuddle",
 	"iocuddle-sgx",
+	"keep-runtime",
 	"memory",
 	"nolibc",
 	"payload",

--- a/deny.toml
+++ b/deny.toml
@@ -8,9 +8,13 @@ unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 allow = [
-    "MIT",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
     "BSD-3-Clause",
+    "CC0-1.0",
+    "MIT",
+    "Zlib",
 ]
 # Lint level for licenses considered copyleft
 copyleft = "deny"

--- a/keep-runtime/.cargo/config
+++ b/keep-runtime/.cargo/config
@@ -1,0 +1,6 @@
+[build]
+target = "x86_64-unknown-linux-musl"
+rustflags = [
+    "-C", "relocation-model=pic",
+    "-C", "linker=../cc",
+]

--- a/keep-runtime/Cargo.toml
+++ b/keep-runtime/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "keep-runtime"
+version = "0.1.0"
+authors = ["Stefan Junker <mail@stefanjunker.de>", "Daiki Ueno <dueno@redhat.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wasmtime = "0.16.0"
+wasmtime-wasi = "0.16.0"
+wasi-common = "0.16.0"
+wat = "1.0"
+
+env_logger = "0.7"
+log = "0.4"
+
+[profile.release]
+incremental = false
+codegen-units = 1
+lto = true

--- a/keep-runtime/LICENSE
+++ b/keep-runtime/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/keep-runtime/fixtures/no_export.wat
+++ b/keep-runtime/fixtures/no_export.wat
@@ -1,0 +1,5 @@
+;;; SPDX-License-Identifier: Apache-2.0
+
+(module
+  (func (export "no_export") (result i32)
+    i32.const 1))

--- a/keep-runtime/fixtures/return_1.wat
+++ b/keep-runtime/fixtures/return_1.wat
@@ -1,0 +1,5 @@
+;;; SPDX-License-Identifier: Apache-2.0
+
+(module
+  (func (export "") (result i32)
+    i32.const 1))

--- a/keep-runtime/fixtures/wasi_snapshot1.wat
+++ b/keep-runtime/fixtures/wasi_snapshot1.wat
@@ -1,0 +1,16 @@
+;;; SPDX-License-Identifier: Apache-2.0
+
+;;; Return the number of command-line arguments
+(module
+  (import "wasi_snapshot_preview1" "args_sizes_get"
+    (func $__wasi_args_sizes_get (param i32 i32) (result i32)))
+  (func (export "_start") (result i32)
+    (i32.store (i32.const 0) (i32.const 0))
+    (i32.store (i32.const 4) (i32.const 0))
+    (call $__wasi_args_sizes_get (i32.const 0) (i32.const 4))
+    drop
+    (i32.load (i32.const 0))
+  )
+  (memory 1)
+  (export "memory" (memory 0))
+)

--- a/keep-runtime/link.json
+++ b/keep-runtime/link.json
@@ -1,0 +1,18 @@
+{
+    "build": {
+        "prepend": [
+            "-static-pie"
+        ],
+
+        "replace": {
+            ".*/crt1.o": ["/usr/x86_64-linux-musl/lib64/rcrt1.o"],
+            "-no-pie": []
+        },
+
+        "debug": false
+    },
+
+    "test": {
+        "debug": false
+    }
+}

--- a/keep-runtime/src/main.rs
+++ b/keep-runtime/src/main.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! The Enarx Keep runtime binary.
+//!
+//! It can be used to run a Wasm file with given command-line
+//! arguments and environment variables.
+//!
+//! ## Example invocation
+//!
+//! ```console
+//! $ RUST_LOG=keep_runtime=info RUST_BACKTRACE=1 cargo run fixtures/return_1.wasm
+//!    Compiling keep-runtime v0.1.0 (/home/steveej/src/job-redhat/enarx/github_enarx_enarx/keep-runtime)
+//!     Finished dev [unoptimized + debuginfo] target(s) in 4.36s
+//!      Running `target/debug/keep-runtime`
+//! [2020-01-23T21:58:16Z INFO  keep_runtime] got result: [
+//!         I32(
+//!             1,
+//!         ),
+//!     ]
+//! ```
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+
+mod workload;
+
+use log::info;
+
+fn main() {
+    let _ = env_logger::try_init_from_env(env_logger::Env::default());
+
+    let mut args = std::env::args().skip(1);
+    let path = args.next().unwrap();
+    let vars = std::env::vars();
+
+    let bytes = std::fs::read(&path).expect("Unable to open file");
+
+    let result = workload::run(&bytes, args, vars).expect("Failed to run workload");
+
+    info!("got result: {:#?}", result);
+}

--- a/keep-runtime/src/workload.rs
+++ b/keep-runtime/src/workload.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/// The error codes of workload execution.
+#[derive(Debug)]
+pub enum Error {
+    /// import module not found
+    ImportModuleNotFound(String),
+    /// import field not found
+    ImportFieldNotFound(String, String),
+    /// export not found
+    ExportNotFound,
+    /// call failed
+    CallFailed,
+    /// runtime error
+    RuntimeError,
+    /// I/O error
+    IoError(std::io::Error),
+}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Self::IoError(err)
+    }
+}
+
+/// Result type used throughout the library.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Runs a WebAssembly workload.
+pub fn run<T: AsRef<[u8]>, U: AsRef<[u8]>, V: std::borrow::Borrow<(U, U)>>(
+    bytes: impl AsRef<[u8]>,
+    args: impl IntoIterator<Item = T>,
+    envs: impl IntoIterator<Item = V>,
+) -> Result<Box<[wasmtime::Val]>> {
+    let engine = wasmtime::Engine::default();
+    let store = wasmtime::Store::new(&engine);
+
+    // Instantiate WASI
+    let mut builder = wasi_common::WasiCtxBuilder::new();
+    builder.args(args).envs(envs);
+    let ctx = builder.build().or(Err(Error::RuntimeError))?;
+    let wasi_snapshot_preview1 = wasmtime_wasi::Wasi::new(&store, ctx);
+
+    let instance = {
+        let module = wasmtime::Module::new(&store, bytes).or(Err(Error::RuntimeError))?;
+        let imports = module
+            .imports()
+            .map(|import| {
+                let module_name = import.module();
+                let field_name = import.name();
+                let export = match module_name {
+                    "wasi_snapshot_preview1" => Ok(wasi_snapshot_preview1.get_export(field_name)),
+                    _ => Err(Error::ImportModuleNotFound(module_name.to_string())),
+                }?;
+
+                if let Some(export) = export {
+                    Ok(export.clone().into())
+                } else {
+                    Err(Error::ImportFieldNotFound(
+                        module_name.to_string(),
+                        field_name.to_string(),
+                    ))
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        wasmtime::Instance::new(&module, &imports).or(Err(Error::RuntimeError))?
+    };
+
+    let function = if instance.exports().any(|export| export.name().is_empty()) {
+        // Launch the default command export.
+        instance.get_func("")
+    } else {
+        // If the module doesn't have a default command
+        // export, launch the _start function if one is
+        // present, as a compatibility measure.
+        instance.get_func("_start")
+    }
+    .ok_or(Error::ExportNotFound)?;
+
+    // Invoke the function.
+    function.call(Default::default()).or(Err(Error::CallFailed))
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::workload;
+    use std::iter::empty;
+
+    #[test]
+    fn workload_run_return_1() {
+        let path = std::path::Path::new("fixtures").join("return_1.wat");
+
+        let bytes = wat::parse_file(&path).unwrap();
+
+        let results: Vec<i32> = workload::run(&bytes, empty::<&str>(), empty::<(&str, &str)>())
+            .unwrap()
+            .iter()
+            .map(|v| v.unwrap_i32())
+            .collect();
+
+        assert_eq!(results, vec![1]);
+    }
+
+    #[test]
+    fn workload_run_no_export() {
+        let path = std::path::Path::new("fixtures").join("no_export.wat");
+
+        let bytes = wat::parse_file(&path).unwrap();
+
+        match workload::run(&bytes, empty::<&str>(), empty::<(&str, &str)>()) {
+            Err(workload::Error::ExportNotFound) => {}
+            _ => panic!("unexpected error"),
+        };
+    }
+
+    #[test]
+    fn workload_run_wasi_snapshot1() {
+        let path = std::path::Path::new("fixtures").join("wasi_snapshot1.wat");
+
+        let bytes = wat::parse_file(&path).unwrap();
+
+        let results: Vec<i32> = workload::run(
+            &bytes,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            empty::<(&str, &str)>(),
+        )
+        .unwrap()
+        .iter()
+        .map(|v| v.unwrap_i32())
+        .collect();
+
+        assert_eq!(results, vec![3]);
+    }
+}


### PR DESCRIPTION
This is my attempt to follow up on #139. Besides the tooling updates and minor enhancements, I changed the workload format to be simpler (b6f7ce91ac127f7848ed3ab7042a3475e84c99f9), which might need some discussion around enarx/rfcs#17. Currently I am thinking to include the following in a workload package:
- a Wasm module
- command-line arguments
- environment variables
- assets that are stored in a fixed directory (within a Keep), which can be [preopened](https://docs.rs/wasmtime-wasi/0.16.0/wasmtime_wasi/struct.WasiCtxBuilder.html#method.preopened_dir) before calling the module