### PR TITLE
Create enarx-keep-sev-shim binary crate

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,6 +4,7 @@ CARGO_MAKE_WORKSPACE_EMULATION = true
 CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
 	"crt0stack",
 	"enarx-keep-sev",
+	"enarx-keep-sev-shim",
 	"enarx-keep-sgx",
 	"enarx-keep-sgx-shim",
 	"enumerate",

--- a/enarx-keep-sev-shim/.cargo/config
+++ b/enarx-keep-sev-shim/.cargo/config
@@ -1,0 +1,6 @@
+[build]
+target = "x86_64-unknown-linux-musl"
+rustflags = [
+    "-C", "relocation-model=pic",
+    "-C", "linker=../cc",
+]

--- a/enarx-keep-sev-shim/Cargo.toml
+++ b/enarx-keep-sev-shim/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "enarx-keep-sev-shim"
+version = "0.1.0"
+authors = ["Harald Hoyer <harald@redhat.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+
+[build-dependencies]
+cc = "1.0.37"
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/enarx-keep-sev-shim/LICENSE
+++ b/enarx-keep-sev-shim/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/enarx-keep-sev-shim/asm/rcrt1.c
+++ b/enarx-keep-sev-shim/asm/rcrt1.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+
+// Taken from rcrt1.c musl libc and reduced to x86_64
+// with custom arguments.
+
+#include <stddef.h>
+
+#define R_X86_64_RELATIVE   8
+#define REL_RELATIVE    R_X86_64_RELATIVE
+
+
+#define DT_RELA   7
+#define DT_RELASZ 8
+#define DT_REL    17
+#define DT_RELSZ  18
+#define DYN_CNT   (DT_RELSZ+1) // last DT_* + 1
+
+#define R_TYPE(x) ((x)&0x7fffffff)
+
+#define IS_RELATIVE(x, s) (R_TYPE(x) == REL_RELATIVE)
+
+__attribute__((__visibility__("hidden")))
+void _dyn_reloc(size_t *dynv, size_t base) {
+    size_t i, dyn[DYN_CNT];
+    size_t *rel;
+    size_t rel_size;
+
+    for (i = 0; i < DYN_CNT; i++)
+        dyn[i] = 0;
+
+    for (i = 0; dynv[i]; i += 2)
+        if (dynv[i] < DYN_CNT)
+            dyn[dynv[i]] = dynv[i + 1];
+
+    rel = (void *) (base + dyn[DT_REL]);
+    rel_size = dyn[DT_RELSZ];
+
+    for (; rel_size; rel += 2, rel_size -= 2 * sizeof(size_t)) {
+        if (!IS_RELATIVE(rel[1], 0))
+            continue;
+        size_t *rel_addr = (void *) (base + rel[0]);
+        *rel_addr += base;
+    }
+
+    rel = (void *) (base + dyn[DT_RELA]);
+    rel_size = dyn[DT_RELASZ];
+
+    for (; rel_size; rel += 3, rel_size -= 3 * sizeof(size_t)) {
+        if (!IS_RELATIVE(rel[1], 0))
+            continue;
+        size_t *rel_addr = (void *) (base + rel[0]);
+        *rel_addr = base + rel[2];
+    }
+}
+

--- a/enarx-keep-sev-shim/asm/start.S
+++ b/enarx-keep-sev-shim/asm/start.S
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! This is the elf entry point called by enarx-keep-sev
+//!
+//! It sets up essential registers, page tables and jumps in shim virtual address space
+//! to the `_start_main` rust function.
+//!
+//! Arguments expected from the hypervisor:
+//! %rdi  = address of SYSCALL_PAGE (boot_info)
+//! %rsi  = shim load offset
+
+// maximum offset for the offset page table
+// gives the shim immediate 512GB addressable physical memory
+#define SHIM_OFFSET 0xFFFFFF8000000000
+
+#define SIZE_OF_INITIAL_STACK 0x10000
+
+.section .text
+.global _start
+.hidden _DYNAMIC
+.code64
+.p2align 4
+
+# Arguments expected from the hypervisor:
+# arg1 %rdi  = address of SYSCALL_PAGE (boot_info)
+# arg2 %rsi  = shim load offset
+_start:
+    # setup CR4
+    mov    %cr4, %rax
+    # FIXME: what about already set bits?
+    or     $0x50620, %rax    # set FSGSBASE | PAE | OSFXSR | OSXMMEXCPT | OSXSAVE
+    mov    %rax, %cr4
+
+    # setup CR0
+    mov    %cr0, %rax
+    and    $0x60050009, %eax # mask EMULATE_COPROCESSOR | MONITOR_COPROCESSOR
+    or     $0x80000021, %eax # set  PROTECTED_MODE_ENABLE | NUMERIC_ERROR | PAGING
+    mov    %rax, %cr0
+
+    # setup EFER
+    # EFER |= LONG_MODE_ACTIVE | LONG_MODE_ENABLE | NO_EXECUTE_ENABLE | SYSTEM_CALL_EXTENSIONS
+    # FIXME: what about already set bits?
+    mov    $0xc0000080, %ecx
+    rdmsr
+    or     $0xd01, %eax
+    mov    $0xc0000080, %ecx
+    wrmsr
+
+    # Setup the pagetables
+    # done dynamically, otherwise we would have to correct the dynamic symbols twice
+    lea  PML4T(%rip), %rax
+
+    lea  PDPT_OFFSET(%rip), %rbx
+    or   $0b11, %rbx    # (WRITABLE | PRESENT)
+    # store PDPT_OFFSET table in PML4T in the correct slot
+    # for SHIM_OFFSET
+    mov  %rbx, (((SHIM_OFFSET & 0xFFFFFFFFFFFF) >> 39)*8)(%rax)
+
+    lea  PDPT_IDENT(%rip), %rbx
+
+    lea  PDT_IDENT(%rip), %rcx
+    or   $0b111, %rcx   # (USER_ACCESSIBLE | WRITABLE | PRESENT)
+    # store PDT_IDENT table in PDPT_IDENT in the correct slot
+    # 0x0 - 0x4000_0000
+    mov  %rcx, (%rbx)
+
+    or   $0b111, %rbx   # (USER_ACCESSIBLE | WRITABLE | PRESENT)
+    # store PDPT_IDENT table in PML4T in the correct slot
+    # 0x0 - ...
+    mov  %rbx, (%rax)
+
+    mov %rax, %cr3
+
+    # jump to RIP + SHIM_OFFSET
+    lea _trampoline(%rip),%rax
+    mov $SHIM_OFFSET, %rbx
+    adox %rbx, %rax
+    jmp *%rax
+_trampoline:
+
+    mov $SHIM_OFFSET, %r15
+    #  add SHIM_OFFSET to shim load offset
+    adox %r15, %rsi
+    # add SHIM_OFFSET to SYSCALL_PAGE
+    adox %r15, %rdi
+
+    # load stack in shim virtual address space
+    lea _initial_shim_stack(%rip), %rsp
+    # sub 8 because we push 8 bytes later and want 16 bytes align
+    add $(SIZE_OF_INITIAL_STACK-8), %rsp
+
+    # save arg1
+    push %rdi
+
+    lea _DYNAMIC(%rip),%rdi
+    # %rdi - _DYNAMIC + SHIM_OFFSET
+    # %rsi - shim load offset + SHIM_OFFSET
+    # correct dynamic symbols with shim load offset + SHIM_OFFSET
+    .hidden _dyn_reloc
+    call _dyn_reloc
+
+    # restore arg1
+    pop %rdi
+
+    # jump to _start_main
+    xor %rbp,%rbp
+    jmp *_start_main_l(%rip)
+
+.L100:  # some paranoid code preventing speculative execution
+    hlt
+    jmp .L100
+
+.section .bss
+.align 4096
+_initial_shim_stack:
+.space SIZE_OF_INITIAL_STACK
+
+.section .data
+.align 8
+_start_main_l:
+.quad   _start_main
+.global _start_main
+
+#
+# # Page Tables:
+#
+# * PDPT_IDENT: an identity mapped one for 0x0 - 0x40_0000
+# * PDPT_OFFSET: an offset page table with offset $SHIM_OFFSET
+
+# The root table of the 4-Level Paging
+# Intel Vol 3A - 4.5
+# will contain:
+#       [0] PDPT_IDENT:  0x0                   - 0x80_0000_0000
+# [1..=510] empty for now
+#     [511] PDPT_OFFSET: 0xFFFF_FF80_0000_0000 - 0xFFFF_FFFF_FFFF_FFFF
+.section .bss
+.align  4096
+PML4T:
+.space 4096
+
+# Offset Page-Directory-Pointer Table
+# with pointers to Huge Pages, mapping 38bit of addresses to
+# SHIM_OFFSET + x, making the translation of shim virtual address space
+# to physical address space easy, by substracting SHIM_OFFSET.
+# This also enables mapping user space below SHIM_OFFSET and use the same
+# CR3 for shim and user space.
+.section .data
+.align  4096
+PDPT_OFFSET:
+# helper macro to calculate PDPT_OFFSET entries
+.macro  QUAD from,count,step
+.set    offset,0
+.rept   \count
+.quad   (\from + offset)
+.set    offset,offset+\step
+.endr
+.endm
+# fill in PDPT_OFFSET entries with 0x83 flags (HUGE_PAGE | WRITABLE | PRESENT)
+# and calculated offsets
+QUAD    0x83,512,0x40000000
+
+# Identity Page-Directory-Pointer Table
+# will contain a pointer to a Identity Page-Directory Table
+#      [0] PDT_IDENT:  0x0                   - 0x4000_0000
+# [1..512] empty for now
+.section .bss
+.align  4096
+PDPT_IDENT:
+.space  4096
+
+# Identity Page-Directory Table
+# with 2 pointers to 2MB Huge Pages
+#  [0..=1] 0x0 - 0x40_0000
+# [1..512] empty for now
+.section .data
+.align  4096
+PDT_IDENT:
+.quad   0x000083  # 0x00_0000 - 0x20_0000 (HUGE_PAGE | WRITABLE | PRESENT)
+.quad   0x200083  # 0x20_0000 - 0x40_0000 (HUGE_PAGE | WRITABLE | PRESENT)
+.space  4080

--- a/enarx-keep-sev-shim/asm/utils.s
+++ b/enarx-keep-sev-shim/asm/utils.s
@@ -1,0 +1,26 @@
+# This function is just for testing purposes and will be removed in the future
+.section .text, "ax"
+.global _enarx_asm_ud2
+.type _enarx_asm_ud2, @function
+.p2align 4
+_enarx_asm_ud2:
+    ud2
+    ret
+
+# This function is just for testing purposes and will be removed in the future
+.global _enarx_asm_io_hello_world
+.type _enarx_asm_io_hello_world, @function
+.p2align 4
+_enarx_asm_io_hello_world:
+    movw $0x2f8, %dx
+    movb $'H', %al
+    outb %al, %dx
+    ret
+
+# This function is just for testing purposes and will be removed in the future
+.global _x86_64_asm_hlt
+.type _x86_64_asm_hlt, @function
+.p2align 4
+_x86_64_asm_hlt:
+    hlt
+    ret

--- a/enarx-keep-sev-shim/build.rs
+++ b/enarx-keep-sev-shim/build.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+extern crate cc;
+use std::ffi::OsString;
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap();
+    let manifest_dir = manifest_dir.to_string_lossy();
+
+    let mut asm_dir = PathBuf::from(manifest_dir.as_ref());
+    asm_dir.push("asm");
+    let entries = fs::read_dir(&asm_dir)
+        .unwrap()
+        .filter_map(|f| {
+            f.ok().and_then(|e| {
+                let path = e.path();
+                match path.extension() {
+                    Some(ext) if ext.eq(&OsString::from("c")) => Some(path),
+                    Some(ext) if ext.eq(&OsString::from("s")) => Some(path),
+                    Some(ext) if ext.eq(&OsString::from("S")) => Some(path),
+                    _ => None,
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    cc::Build::new()
+        .no_default_flags(true)
+        .flag("-O2")
+        // Optimize for AMD Zen 2
+        .flag("-mtune=znver2")
+        .files(&entries)
+        .static_flag(true)
+        .shared_flag(false)
+        .compile("asm");
+
+    for e in entries {
+        println!("cargo:rerun-if-changed={}", e.to_str().unwrap());
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=layout.ld");
+}

--- a/enarx-keep-sev-shim/link.json
+++ b/enarx-keep-sev-shim/link.json
@@ -1,0 +1,24 @@
+{
+    "build": {
+        "prepend": [
+            "-static-pie"
+        ],
+
+        "replace": {
+            ".*/crt.\\.o": [],
+            "-no-pie": []
+        },
+
+        "append-target-rlib": ["libc"],
+
+        "debug": false
+    },
+
+    "test": {
+        "replace": {
+            "-lasm": []
+        },
+
+        "debug": false
+    }
+}

--- a/enarx-keep-sev-shim/src/asm.rs
+++ b/enarx-keep-sev-shim/src/asm.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// This function is just for testing purposes and will be removed in the future
+#[inline(always)]
+pub fn hlt_loop() -> ! {
+    loop {
+        unsafe {
+            _x86_64_asm_hlt();
+        }
+    }
+}
+
+extern "C" {
+    // This function is just for testing purposes and will be removed in the future
+    pub fn _enarx_asm_ud2();
+    // This function is just for testing purposes and will be removed in the future
+    pub fn _enarx_asm_io_hello_world();
+    // This function is just for testing purposes and will be removed in the future
+    pub fn _x86_64_asm_hlt();
+}

--- a/enarx-keep-sev-shim/src/main.rs
+++ b/enarx-keep-sev-shim/src/main.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! enarx-keep-sev-shim
+//!
+//! document
+
+#![no_std]
+#![deny(clippy::all)]
+#![deny(missing_docs)]
+#![cfg_attr(not(test), no_main)]
+
+#[cfg(test)]
+fn main() {}
+
+mod asm;
+mod no_std;
+
+/// Defines the entry point function.
+///
+/// The function must have the signature `fn(&'static ())) -> !`.
+///
+/// This macro just creates a function named `_start_main`, which the assembler
+/// stub will use as the entry point. The advantage of using this macro instead
+/// of providing an own `_start_main` function is that the macro ensures that the
+/// function and argument types are correct.
+macro_rules! entry_point {
+    ($path:path) => {
+        #[allow(missing_docs)]
+        #[export_name = "_start_main"]
+        pub extern "C" fn __impl_start(boot_info: &'static ()) -> ! {
+            // validate the signature of the program entry point
+            let f: fn(&'static ()) -> ! = $path;
+            f(boot_info)
+        }
+    };
+}
+
+entry_point!(kernel_main);
+
+fn kernel_main(_boot_info: &'static ()) -> ! {
+    use asm::{_enarx_asm_io_hello_world, _enarx_asm_ud2, hlt_loop};
+
+    // Just some test code for now to trigger output
+    unsafe { _enarx_asm_io_hello_world() };
+    unsafe { _enarx_asm_ud2() };
+    hlt_loop()
+}

--- a/enarx-keep-sev-shim/src/no_std.rs
+++ b/enarx-keep-sev-shim/src/no_std.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/// _Unwind_Resume is only needed in the `debug` profile
+///
+/// even though this project has `panic=abort`
+/// it seems like the debug libc.rlib has some references
+/// with unwinding
+/// See also: https://github.com/rust-lang/rust/issues/47493
+#[cfg(not(test))]
+#[cfg(debug_assertions)]
+#[no_mangle]
+extern "C" fn _Unwind_Resume() {
+    unimplemented!();
+}
+
+/// rust_eh_personality is only needed in the `debug` profile
+///
+/// even though this project has `panic=abort`
+/// it seems like the debug libc.rlib has some references
+/// with unwinding
+/// See also: https://github.com/rust-lang/rust/issues/47493
+#[cfg(not(test))]
+#[cfg(debug_assertions)]
+#[no_mangle]
+pub extern "C" fn rust_eh_personality() {
+    unimplemented!();
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+#[allow(clippy::empty_loop)]
+#[allow(missing_docs)]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    use crate::asm::hlt_loop;
+    hlt_loop()
+}
+
+#[cfg(not(target_feature = "crt-static"))]
+#[allow(missing_docs)]
+fn __check_for_static_linking() {
+    compile_error!("shim is not statically linked");
+}


### PR DESCRIPTION
Boot to rust in kernel virtual address space with the important
registers initialized.

This just adds the crate as a basis for the rest of the code that is transitioning off of demo2020. The keep is pretty much a "stub" for now, but following PRs will add more functionality.