### PR TITLE
Implement PLATFORM_STATUS as an iocuddle ioctl

### DIFF
--- a/sev/Cargo.toml
+++ b/sev/Cargo.toml
@@ -13,3 +13,5 @@ dangerous_tests = []
 openssl = { version = "0.10", optional = true, features = [ "vendored" ] }
 bitflags = "1.2.1"
 codicon = "2.1.0"
+bitfield = "0.13"
+iocuddle = { path = "../iocuddle" }

--- a/sev/src/firmware/linux/ioctl.rs
+++ b/sev/src/firmware/linux/ioctl.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! A collection of type-safe ioctl implementations for the AMD Secure Encrypted Virtualization
+//! (SEV) platform. These ioctls are exported by the Linux kernel.
+
+use crate::firmware::types::*;
+use iocuddle::*;
+
+use std::marker::PhantomData;
+
+/// The Linux kernel decides which SEV platform command to dispatch based
+/// on its own enumeration values of the SEV commands. This trait
+/// enforces that our type-safe ioctls also export the Linux
+/// kernel enum ordinal value.
+pub trait Code: 'static + Sized {
+    /// The integer value that corresponds to the Linux kernel's
+    /// enum value for a SEV ioctl.
+    const CODE: u32;
+}
+
+macro_rules! code {
+    (
+        $(
+            $iocty:ty = $val:expr
+        ),* $(,)*
+    ) => {
+        $(
+            impl $crate::firmware::linux::ioctl::Code for $iocty {
+                const CODE: u32 = $val;
+            }
+        )*
+    };
+}
+
+// These enum ordinal values are defined in the Linux kernel
+// source code: include/uapi/linux/psp-sev.h
+code! {
+    PlatformStatus = 1,
+}
+
+const SEV: Group = Group::new(b'S');
+
+/// Gathers a status report from the SEV firmware.
+pub const PLATFORM_STATUS: Ioctl<WriteRead, &Command<PlatformStatus>> =
+    unsafe { SEV.write_read(0) };
+
+/// The Rust-flavored, FFI-friendly version of `struct kvm_sev_cmd` which is
+/// used to pass arguments to the SEV ioctl implementation.
+///
+/// This struct is defined in the Linux kernel: include/uapi/linux/kvm.h
+#[repr(C, packed)]
+pub struct Command<'a, T: Code> {
+    code: u32,
+    data: u64,
+    error: u32,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T: Code> Command<'a, T> {
+    /// Create a new SEV command struct that encloses the lifetime of
+    /// its data arguments.
+    pub fn new(subcmd: &'a mut T) -> Self {
+        Command {
+            code: T::CODE,
+            data: subcmd as *mut T as u64,
+            error: 0,
+            _phantom: PhantomData,
+        }
+    }
+}

--- a/sev/src/firmware/mod.rs
+++ b/sev/src/firmware/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(target_os = "linux")]
 mod linux;
+mod types;
 
 use super::*;
 use std::fmt::Debug;

--- a/sev/src/firmware/types.rs
+++ b/sev/src/firmware/types.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Version;
+
+bitflags::bitflags! {
+    /// The platform's status flags.
+    #[derive(Default)]
+    pub struct PlatformStatusFlags: u8 {
+    /// If set, the platform is externally owned.
+    /// Else, it is self-owned (default state).
+        const OWNER = 1;
+    }
+}
+
+bitfield::bitfield! {
+    /// Contains information that describes how the
+    /// platform is currently configured.
+    #[derive(Clone, Copy, Default, PartialEq, Eq)]
+    pub struct PlatformStatusConfig(u32);
+    impl Debug;
+
+    /// If set, SEV-ES is initialized for the platform.
+    pub encrypted_state, _: 0, 0;
+    reserved, _: 23, 1;
+
+    /// The firmware build ID for this API version.
+    pub build, _: 31, 24;
+}
+
+/// Query SEV platform status.
+///
+/// (Chapter 5.6; Table 17)
+#[derive(Default)]
+#[repr(C, packed)]
+pub struct PlatformStatus {
+    /// The firmware version (major.minor)
+    pub version: Version,
+
+    /// The Platform State.
+    pub state: u8,
+
+    /// Right now the only flag that is communicated in
+    /// this single byte is whether the platform is self-
+    /// owned or not. If the first bit is set then the
+    /// platform is externally owned. If it is cleared, then
+    /// the platform is self-owned. Self-owned is the default
+    /// state.
+    pub flags: PlatformStatusFlags,
+
+    /// Contains configuration information about the platform.
+    pub config: PlatformStatusConfig,
+
+    /// The number of valid guests maintained by the SEV firmware.
+    pub guest_count: u32,
+}

--- a/sev/tests/api.rs
+++ b/sev/tests/api.rs
@@ -12,7 +12,7 @@ fn platform_reset() {
 #[cfg_attr(not(has_sev), ignore)]
 #[test]
 fn platform_status() {
-    let fw = Firmware::open().unwrap();
+    let mut fw = Firmware::open().unwrap();
     let status = fw.platform_status().unwrap();
     assert!(
         status.build


### PR DESCRIPTION
Related: #281
Related: #112 

This PR establishes a basis for additional types and ioctls to be implemented for SEV, with feedback addressed from #202 where applicable.

Tested on Rome:

```
[connorkuehl@rome sev]$ cargo test --all-features
   Compiling sev v0.1.0 (/home/connorkuehl/enarx/sev)
    Finished test [unoptimized + debuginfo] target(s) in 1.14s
     Running target/debug/deps/sev-ec0941895888abe8

running 4 tests
test session::key::mac ... ok
test session::key::derive ... ok
test session::initialized::verify ... ok
test session::initialized::session ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/api-4f359a7b11ad1be5

running 8 tests
test get_identifer ... ok
test pdh_generate ... ok
test pdh_cert_export ... ok
test pek_generate ... ok
test pek_csr ... ok
test platform_reset ... ok
test platform_status ... ok
test pek_cert_import ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/certs-2c5c598687002286

running 19 tests
test naples::ask::decode ... ok
test naples::cek::encode ... ok
test naples::ask::encode ... ok
test naples::cek::decode ... ok
test naples::ark::encode ... ok
test naples::ark::decode ... ok
test naples::oca::decode ... ok
test naples::pdh::encode ... ok
test naples::pek::decode ... ok
test naples::pdh::decode ... ok
test naples::oca::encode ... ok
test naples::pek::encode ... ok
test naples::cek::verify ... ok
test naples::ask::verify ... ok
test naples::ark::verify ... ok
test naples::oca::verify ... ok
test naples::pdh::verify ... ok
test naples::pek::verify ... ok
test naples::oca::create ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/session-aa172649cd11a6da

running 2 tests
test initialized::create ... ok
test initialized::start ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests sev

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```