### PR TITLE
Turn on LTO for the shims

### DIFF
--- a/enarx-keep-sev-shim/Cargo.toml
+++ b/enarx-keep-sev-shim/Cargo.toml
@@ -15,3 +15,6 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
+codegen-units = 1
+incremental = false
+lto = true

--- a/enarx-keep-sgx-shim/Cargo.toml
+++ b/enarx-keep-sgx-shim/Cargo.toml
@@ -21,3 +21,6 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
+codegen-units = 1
+incremental = false
+lto = true


### PR DESCRIPTION
Minimize the code size and maximize optimization for the shims.

enarx-keep-sgx-shim:
Binary size before (stripped): 316704
Binary size after  (stripped):  22112