### PR TITLE
Don't negate syscall arguments

### DIFF
--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -66,8 +66,8 @@ impl<'a> Print<str> for Handler<'a> {
 
             // Do the syscall; replace encrypted memory with unencrypted memory.
             self.syscall(
-                -libc::SYS_write as u64,
-                -libc::STDERR_FILENO as u64,
+                libc::SYS_write as u64,
+                libc::STDERR_FILENO as u64,
                 map as _,
                 len,
                 0,
@@ -158,11 +158,11 @@ impl<'a> Handler<'a> {
     fn ualloc(&mut self, bytes: u64) -> Result<*mut u8, i64> {
         let ret = unsafe {
             self.syscall(
-                -libc::SYS_mmap as u64,
+                libc::SYS_mmap as u64,
                 0,
                 bytes,
-                -libc::PROT_READ as u64 | -libc::PROT_WRITE as u64,
-                -libc::MAP_PRIVATE as u64 | -libc::MAP_ANONYMOUS as u64,
+                libc::PROT_READ as u64 | libc::PROT_WRITE as u64,
+                libc::MAP_PRIVATE as u64 | libc::MAP_ANONYMOUS as u64,
                 !0,
                 0,
             )
@@ -186,7 +186,7 @@ impl<'a> Handler<'a> {
 
     /// Free a chunk of untrusted memory.
     unsafe fn ufree(&mut self, map: *mut u8, bytes: u64) -> u64 {
-        self.syscall(-libc::SYS_munmap as u64, map as _, bytes, 0, 0, 0, 0)
+        self.syscall(libc::SYS_munmap as u64, map as _, bytes, 0, 0, 0, 0)
     }
 
     fn trace(&mut self, name: &str, argc: usize) {
@@ -227,7 +227,7 @@ impl<'a> Handler<'a> {
             .map(|x| x.into())
             .unwrap_or_else(|| self.aex.gpr.rdi.raw());
         loop {
-            unsafe { self.syscall(-libc::SYS_exit as u64, code, 0, 0, 0, 0, 0) };
+            unsafe { self.syscall(libc::SYS_exit as u64, code, 0, 0, 0, 0, 0) };
         }
     }
 
@@ -244,7 +244,7 @@ impl<'a> Handler<'a> {
             .map(|x| x.into())
             .unwrap_or_else(|| self.aex.gpr.rdi.raw());
         loop {
-            unsafe { self.syscall(-libc::SYS_exit_group as u64, code, 0, 0, 0, 0, 0) };
+            unsafe { self.syscall(libc::SYS_exit_group as u64, code, 0, 0, 0, 0, 0) };
         }
     }
 
@@ -252,7 +252,7 @@ impl<'a> Handler<'a> {
     pub fn getuid(&mut self) -> u64 {
         self.trace("getuid", 0);
 
-        unsafe { self.syscall(-libc::SYS_getuid as u64, 0, 0, 0, 0, 0, 0) }
+        unsafe { self.syscall(libc::SYS_getuid as u64, 0, 0, 0, 0, 0, 0) }
     }
 
     /// Do a read() syscall
@@ -271,7 +271,7 @@ impl<'a> Handler<'a> {
 
         unsafe {
             // Do the syscall; replace encrypted memory with unencrypted memory.
-            let ret = self.syscall(-libc::SYS_read as u64, fd, map as _, size, 0, 0, 0);
+            let ret = self.syscall(libc::SYS_read as u64, fd, map as _, size, 0, 0, 0);
 
             // Copy the unencrypted input into encrypted memory.
             if ret <= ERRNO_BASE {
@@ -306,7 +306,7 @@ impl<'a> Handler<'a> {
             core::ptr::copy_nonoverlapping(buf, map, size as _);
 
             // Do the syscall; replace encrypted memory with unencrypted memory.
-            let ret = self.syscall(-libc::SYS_write as u64, fd, map as _, size, 0, 0, 0);
+            let ret = self.syscall(libc::SYS_write as u64, fd, map as _, size, 0, 0, 0);
             self.ufree(map, size);
 
             if ret <= ERRNO_BASE && ret > size {
@@ -398,7 +398,7 @@ impl<'a> Handler<'a> {
         // Do the syscall; replace encrypted memory with unencrypted memory.
         let ret = unsafe {
             self.syscall(
-                -libc::SYS_readv as u64,
+                libc::SYS_readv as u64,
                 fd,
                 untrusted.as_ptr() as _,
                 untrusted.len() as u64,
@@ -479,7 +479,7 @@ impl<'a> Handler<'a> {
         // Do the syscall; replace encrypted memory with unencrypted memory.
         let ret = unsafe {
             self.syscall(
-                -libc::SYS_writev as u64,
+                libc::SYS_writev as u64,
                 fd,
                 untrusted.as_ptr() as _,
                 untrusted.len() as u64,


### PR DESCRIPTION
Fixes #552

```
[connorkuehl@coffeelake enarx-keep-sgx]$ cargo run -- --shim ../enarx-keep-sgx-shim/target/x86_64-unknown-linux-musl/debug/enarx-keep-sgx-shim --code ../payload/target/x86_64-unknown-linux-musl/debug/payload
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/enarx-keep-sgx --shim ../enarx-keep-sgx-shim/target/x86_64-unknown-linux-musl/debug/enarx-keep-sgx-shim --code ../payload/target/x86_64-unknown-linux-musl/debug/payload`
arg: "/init"
env: "LANG=C"
aux: ExecFilename("/init")
aux: Platform("x86_64")
aux: Uid(1000)
aux: EUid(1000)
aux: Gid(1000)
aux: EGid(1000)
aux: PageSize(4096)
aux: Secure(false)
aux: ClockTick(100)
aux: Flags(0)
aux: HwCap(0)
aux: HwCap2(0)
aux: PHdr(35184376283200)
aux: PHent(56)
aux: PHnum(10)
aux: Random([4, 251, 33, 143, 229, 126, 201, 110, 77, 120, 87, 211, 202, 157, 58, 22])
```