### PR TITLE
Fix mmap flags for enarx-keep-sev

### DIFF
--- a/enarx-keep-sev/src/vm.rs
+++ b/enarx-keep-sev/src/vm.rs
@@ -30,8 +30,8 @@ impl VirtualMachine {
             mmap::map(
                 0,
                 mem_size,
-                libc::PROT_NONE,
-                libc::MAP_ANONYMOUS | libc::MAP_HUGE_2MB,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGE_2MB,
                 None,
                 0,
             )?


### PR DESCRIPTION
Foiled by my own hubris! I should have tested for this in my KVM PR after I switched up how the code called `mmap`.

MAP_PRIVATE or MAP_SHARED must be included in the mmap() flags otherwise it will return EINVAL.

We need at least PROT_WRITE to write the page tables into the mmap'd memory region.