### PR TITLE
Map kvm_ioctl::Errors into io::Errors

### DIFF
--- a/enarx-keep-sev/Cargo.toml
+++ b/enarx-keep-sev/Cargo.toml
@@ -16,3 +16,6 @@ span = { path = "../span" }
 structopt = "0.3"
 units = { path = "../units" }
 x86_64 = { version = "0.11.0", default-features = false, features = ["stable"] }
+
+[patch.crates-io]
+vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util.git", rev = "80abb6f" }

--- a/enarx-keep-sev/src/main.rs
+++ b/enarx-keep-sev/src/main.rs
@@ -11,8 +11,8 @@ mod x86_64;
 
 use structopt::StructOpt;
 
-use std::error::Error;
 use std::fs::File;
+use std::io;
 use std::path::PathBuf;
 
 #[derive(StructOpt, Debug)]
@@ -37,7 +37,7 @@ fn main() {
     }
 }
 
-fn run(args: Args) -> Result<(), Box<dyn Error>> {
+fn run(args: Args) -> Result<(), io::Error> {
     let _kernel = File::open(args.shim)?;
     let _code = File::open(args.code)?;
 

--- a/enarx-keep-sev/src/vm.rs
+++ b/enarx-keep-sev/src/vm.rs
@@ -12,10 +12,10 @@ use x86_64::VirtAddr;
 const DEFAULT_MEM_SIZE: usize = units::bytes!(1; GiB);
 
 pub struct VirtualMachine {
-    kvm: Kvm,
-    fd: VmFd,
-    address_space: Vec<MemoryRegion>,
-    mmap_handles: Vec<mmap::Unmap>,
+    _kvm: Kvm,
+    _fd: VmFd,
+    _address_space: Vec<MemoryRegion>,
+    _mmap_handles: Vec<mmap::Unmap>,
 }
 
 impl VirtualMachine {
@@ -71,10 +71,10 @@ impl VirtualMachine {
         }
 
         Ok(Self {
-            kvm,
-            fd,
-            address_space: vec![region],
-            mmap_handles: vec![unmap],
+            _kvm: kvm,
+            _fd: fd,
+            _address_space: vec![region],
+            _mmap_handles: vec![unmap],
         })
     }
 }

--- a/enarx-keep-sev/src/vm.rs
+++ b/enarx-keep-sev/src/vm.rs
@@ -2,7 +2,7 @@
 
 use crate::x86_64::*;
 
-use std::error::Error;
+use std::io;
 
 use kvm_bindings::kvm_userspace_memory_region as MemoryRegion;
 use kvm_ioctls::{Kvm, VmFd};
@@ -19,7 +19,7 @@ pub struct VirtualMachine {
 }
 
 impl VirtualMachine {
-    pub fn new() -> Result<Self, Box<dyn Error>> {
+    pub fn new() -> Result<Self, io::Error> {
         // Create a KVM context
         let kvm = Kvm::new()?;
         let fd = kvm.create_vm()?;

--- a/enarx-keep-sev/src/x86_64.rs
+++ b/enarx-keep-sev/src/x86_64.rs
@@ -1,23 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use x86_64::structures::paging::page_table::PageTable;
+use x86_64::PhysAddr;
 
 /// The *guest* physical address of the root page table structure.
-pub const PML4_START: u64 = 0x9000;
+pub const PML4_START: PhysAddr = PhysAddr::new_truncate(0x9000);
 
 /// The first page table entry.
-pub const PDPTE_START: u64 = 0xA000;
-
-// The one provided by x86_64 understandably does not impl std::error::Error.
-#[derive(Copy, Clone, Debug)]
-pub struct PhysAddrNotValid(pub u64);
-impl std::error::Error for PhysAddrNotValid {}
-
-impl std::fmt::Display for PhysAddrNotValid {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}({:#x})", "PhysAddrNotValid", self.0)
-    }
-}
+pub const PDPTE_START: PhysAddr = PhysAddr::new_truncate(0xA000);
 
 #[repr(C)]
 pub struct PageTables {


### PR DESCRIPTION
In doing so, we can avoid returning a `Result` whose `Err` type is a heap-allocated trait object.

This PR also updates some of the guest physical address constants to being `PhysAddr` types so we don't have to `try_new`/`try_from` them with the possibility of an Error.

While we're in there, acknowledge some compiler warnings about unused variables. They'll be used in future PRs.

Closes #556