### PR TITLE
Add running SGX payload to test suite

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,6 +8,7 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
 	"enarx-keep-sgx",
 	"enarx-keep-sgx-shim",
 	"enumerate",
+	"integration-tests",
 	"intel-types",
 	"iocuddle",
 	"iocuddle-sgx",
@@ -63,6 +64,21 @@ command = "${CARGO_WORKSPACE_ROOT}/.tests/cargo-toml-package-license"
 
 [tasks.misc-licenses-crate]
 command = "${CARGO_WORKSPACE_ROOT}/.tests/misc-licenses-crate"
+
+[tasks.integration]
+workspace = false
+env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = "integration-tests" }
+run_task = { name = "integration-test", fork = true }
+
+[tasks.integration-test]
+command = "cargo"
+args = ["test"]
+
+[tasks.integration-ci]
+workspace = false
+run_task = [
+    { name = ["ci-flow", "integration"], fork = true },
+]
 
 # Add additional tests to the predefined 'ci-flow' target.
 [tasks.pre-ci-flow]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "integration-tests"
+version = "0.1.0"
+authors = ["Lily Sturmann <lsturman@redhat.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/integration-tests/LICENSE
+++ b/integration-tests/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/integration-tests/Makefile.toml
+++ b/integration-tests/Makefile.toml
@@ -1,0 +1,10 @@
+# `cargo make test` is disabled for this crate so that 
+# integration tests are not run with unit tests; specifically, tests
+# in this crate should only be run after builds have completed in all
+# other crates in the emuated workspace. 
+#
+# Tests in this crate can be invoked instead with `cargo make 
+# integration` at the top level, or simply by running `cargo test` 
+# inside this crate.
+[tasks.test]
+disabled = true

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    use std::path::Path;
+
+    if Path::new("/dev/sgx/enclave").exists() {
+        println!("cargo:rustc-cfg=has_sgx");
+    }
+}

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests
+
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+
+fn main() {}

--- a/integration-tests/tests/sgx_payload.rs
+++ b/integration-tests/tests/sgx_payload.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! This crate contains integration tests, including the SGX payload test.
+
+#![deny(clippy::all)]
+#![deny(missing_docs)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Finds an absolute file path for a file in a directory.
+#[cfg_attr(not(has_sgx), ignore)]
+fn find_filepath(dir: PathBuf, name: &str) -> Result<PathBuf, std::io::Error> {
+    let file = Command::new("find")
+        .current_dir(&dir)
+        .arg("-name")
+        .arg(name)
+        .output()
+        .expect("could not find file")
+        .stdout;
+
+    let path = dir.join(String::from_utf8(file).unwrap().trim());
+    Ok(std::fs::canonicalize(&path)?)
+}
+
+/// This test runs the payload in the SGX keep using the SGX shim.
+#[cfg_attr(not(has_sgx), ignore)]
+#[test]
+fn sgx_payload() {
+    // Define directories
+    let wksp_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let sgx_keep_dir = wksp_root.join("enarx-keep-sgx/target/");
+    let payload_dir = wksp_root.join("payload/target/x86_64-unknown-linux-musl/");
+    let sgx_shim_dir = wksp_root.join("enarx-keep-sgx-shim/target/x86_64-unknown-linux-musl/");
+
+    // Find the current SGX Keep, payload, and SGX shim
+    let keep = find_filepath(sgx_keep_dir, "enarx-keep-sgx").unwrap();
+    let payload = find_filepath(payload_dir, "payload").unwrap();
+    let shim = find_filepath(sgx_shim_dir, "enarx-keep-sgx-shim").unwrap();
+
+    // Run the test
+    let mut payload_test = Command::new(keep)
+        .current_dir(wksp_root)
+        .arg("--code")
+        .arg(payload)
+        .arg("--shim")
+        .arg(shim)
+        .spawn()
+        .expect("failed to run sgx payload test");
+
+    let ecode = payload_test.wait().expect("failed to wait on child");
+
+    assert!(ecode.success());
+}


### PR DESCRIPTION
It runs when ~~`cargo make test`~~ `cargo make integration` or ~~`cargo make ci-flow`~~ `cargo make integration-ci` are invoked.

Resolves #522 .

This PR does the following:
- Creates a new ~~`tests/`~~ `integration-tests/` crate for top-level tests for our emulated workspace. Currently there is one file included `sgx_payload.rs`, which checks for correct binary paths and runs the SGX payload.

- Adds new tasks to `Makefile.toml` to ensure that crates are built before the tests in ~~`tests/`~~ `integration-tests/` are run. Currently this means *all* tests run after all builds, as per [this discussion](https://github.com/sagiegurari/cargo-make/issues/429). ~~Some default `cargo make` tasks are overwritten here to ensure that `cargo make test` and `cargo make ci-flow` actually call our versions of those tasks, since our versions ensure that crates build first.~~

I tested this by:
- Adding the ~~`tests/`~~ `integration-tests/` crate as one of the first crates listed in the emulated workspace in `Makefile.toml` and running ~~`cargo make test`~~ `cargo make integration` and ~~`cargo make ci-flow`~~ `cargo make integration-ci` after a `cargo make clean`. 
- I also tested that if the `cfg` for the test itself in `sgx_payload.rs` is changed to `has_sgx` instead of `not(has_sgx)`, the test will in fact be ignored. I did not test on a non-SGX machine.