### PR TITLE
Inform users of `cargo make` when `cargo build/test` is used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "enarx"
+version = "0.1.0"
+authors = ["Nathaniel McCallum <npmccallum@redhat.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,24 @@
+// Let people using the standard `cargo x` syntax 
+fn main() {
+    
+    panic!("
+    
+    Enarx uses `cargo-make` to build and run its code:
+    https://github.com/sagiegurari/cargo-make
+
+    To build Enarx:
+
+    1. Install cargo-make.
+    $ cargo install cargo-make
+
+    2. Build Enarx.
+    $ cargo make build
+
+    3. You can optionally run tests.
+    $ cargo make test
+
+    For more information, see:
+    https://github.com/enarx/enarx/wiki/How-to-contribute-code#enarx-development-environment-set-up
+    
+    ");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,1 @@
+// Enarx uses `cargo-make` to build and run its code; see /build.rs for details


### PR DESCRIPTION
Display a quick error message whenever `cargo build`, `cargo test` or similar is invoked. Links back to the `cargo-make` repo and lists a few basic `cargo make` commands.

Resolves #598.