### PR TITLE
keep-runtime: update to wasmtime 0.18 API

### DIFF
--- a/keep-runtime/Cargo.toml
+++ b/keep-runtime/Cargo.toml
@@ -8,13 +8,15 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasmtime = "0.16.0"
-wasmtime-wasi = "0.16.0"
-wasi-common = "0.16.0"
-wat = "1.0"
+wasmtime = "0.18.0"
+wasmtime-wasi = "0.18.0"
+wasi-common = "0.18.0"
 
 env_logger = "0.7"
 log = "0.4"
+
+[build-dependencies]
+wat = "1.0"
 
 [profile.release]
 incremental = false

--- a/keep-runtime/build.rs
+++ b/keep-runtime/build.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+fn main() {
+    let in_dir = Path::new("fixtures");
+    let out_dir =
+        std::env::var_os("OUT_DIR").expect("The OUT_DIR environment variable must be set");
+    let out_dir = Path::new(&out_dir).join("fixtures");
+    std::fs::create_dir_all(&out_dir).expect("Can't create output directory");
+
+    for entry in in_dir.read_dir().unwrap() {
+        if let Ok(entry) = entry {
+            let wat = entry.path();
+            if wat.extension().unwrap() == "wat" {
+                let wasm = out_dir
+                    .join(wat.file_name().unwrap())
+                    .with_extension("wasm");
+                let binary = wat::parse_file(&wat).expect("Can't parse wat file");
+                std::fs::write(wasm, &binary).expect("Can't write wasm file");
+                println!("cargo:rerun-if-changed={}", &wat.display());
+            }
+        }
+    }
+}

--- a/keep-runtime/src/main.rs
+++ b/keep-runtime/src/main.rs
@@ -8,7 +8,7 @@
 //! ## Example invocation
 //!
 //! ```console
-//! $ RUST_LOG=keep_runtime=info RUST_BACKTRACE=1 cargo run fixtures/return_1.wasm
+//! $ RUST_LOG=keep_runtime=info RUST_BACKTRACE=1 cargo run target/debug/fixtures/return_1.wasm
 //!    Compiling keep-runtime v0.1.0 (/home/steveej/src/job-redhat/enarx/github_enarx_enarx/keep-runtime)
 //!     Finished dev [unoptimized + debuginfo] target(s) in 4.36s
 //!      Running `target/debug/keep-runtime`


### PR DESCRIPTION
The new API no longer transparently handles the text format (.wat) WebAssembly files.  This converts the .wat files in our examples to the binary format (.wasm) at build time.

See also #570.