### PR TITLE
Fix a crasher

### DIFF
--- a/enarx-keep-sgx-shim/src/entry.rs
+++ b/enarx-keep-sgx-shim/src/entry.rs
@@ -10,14 +10,6 @@ extern "C" {
     fn exit(code: u8) -> !;
 }
 
-// There is a GPF for an unknown reason when the stack is aligned to anything
-// less than 32. The GPF occurs when trying to add Entry::Random. We should
-// investigate why. Work around it for now.
-//
-// https://github.com/enarx/enarx/issues/385
-#[repr(C, align(32))]
-struct Stack<T>(pub T);
-
 fn random() -> u64 {
     let mut r: u64 = 0;
 
@@ -77,9 +69,9 @@ pub extern "C" fn entry(_rdi: u64, _rsi: u64, _rdx: u64, layout: &Layout, _r8: u
     }
 
     // Prepare the crt0 stack.
-    let mut crt0 = Stack([0u8; 1024]);
+    let mut crt0 = [0u8; 1024];
     let space = random() as usize & 0xf0;
-    let handle = match crt0setup(layout, hdr, &mut crt0.0[space..]) {
+    let handle = match crt0setup(layout, hdr, &mut crt0[space..]) {
         Err(OutOfSpace) => unsafe { exit(1) },
         Ok(handle) => handle,
     };

--- a/enarx-keep-sgx-shim/src/start.S
+++ b/enarx-keep-sgx-shim/src/start.S
@@ -102,13 +102,12 @@ enclave:
     cmp     $0,                     %rax            # If CSSA > 0...
     jne     .Levent                                 # ... restore stack from AEX[CSSA-1].
 
-    # Set stack pointer, clear unused registers and xCPU state, and jump to Rust
-    mov     STACK(%rcx),            %rsp
-    zerop
-    zerot
-    zerox
-    xor     %rax,                   %rax
-    jmp     entry
+    mov     STACK(%rcx),            %rsp            # Set stack pointer
+    zerop                                           # Clear preserved registers
+    zerot                                           # Clear temporary registers
+    zerox                                           # Clear xCPU state
+    xor     %rax,                   %rax            # Clear %rax
+    call    entry                                   # Jump to Rust
 
 # CSSA != 0
 .Levent:


### PR DESCRIPTION
The stack was properly aligned. However, Rust presumed that the stack
was aligned before the call instruction was issued. Because we were
using jmp instead of call, this meant that the output from Rust made
incorrect assumptions about the stack alignment, leading to crashes
later. We solve this by using call rather than jmp so that the Rust
assumptions are correct. This removes the need for a manually aligned
crt0stack which worked around this issue.

There are still some other issues in the crt0stack that need to be
resolved (Harald has fixes for them). However, they don't currently
trigger crashes.

Fixes: #385