### PR TITLE
enarx-keep-sev-shim: fix const `ALIGN_SECTION` for release

### DIFF
--- a/enarx-keep-sev-shim/src/lib.rs
+++ b/enarx-keep-sev-shim/src/lib.rs
@@ -50,7 +50,7 @@ const ALIGN_SECTION: usize = bytes!(1; MiB);
 
 #[cfg(not(debug_assertions))]
 #[allow(clippy::integer_arithmetic)]
-const REGION_ALIGN: usize = bytes!(4; KiB);
+const ALIGN_SECTION: usize = bytes!(4; KiB);
 
 #[inline(always)]
 #[allow(clippy::integer_arithmetic)]


### PR DESCRIPTION
The IDE refactor rename didn't catch the release version of `ALIGN_SECTION`.