### PR TITLE
containers/fedora: add ccache

### DIFF
--- a/containers/fedora/Dockerfile
+++ b/containers/fedora/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf -y install procps iproute findutils man file diffutils
 RUN dnf -y install git git-subtree vim gdb lldb valgrind strace diffstat patch hub
 
 # Install C Development Environment
-RUN dnf -y install gcc clang make
+RUN dnf -y install gcc clang make ccache
 
 # Install Build Dependencies
 RUN dnf -y install glibc-static clang-devel llvm-devel openssl-devel

--- a/enarx-keep-sgx/Cargo.toml
+++ b/enarx-keep-sgx/Cargo.toml
@@ -19,7 +19,7 @@ span = { path = "../span" }
 vdso = { path = "../vdso" }
 structopt = { version = "0.3", default-features = false }
 bitflags = "1.2"
-openssl = "0.10"
+openssl = "=0.10.29"
 libc = "0.2.68"
 mmap = { path = "../mmap" }
 

--- a/iocuddle-sgx/Cargo.toml
+++ b/iocuddle-sgx/Cargo.toml
@@ -14,7 +14,7 @@ memory = { path = "../memory" }
 bitflags = "1.2"
 
 [dev-dependencies]
-openssl = { version = "0.10", features = [ "vendored" ] }
+openssl = { version = "=0.10.29", features = [ "vendored" ] }
 sgx-crypto = { path = "../sgx-crypto" }
 span = { path = "../span" }
 rstest = "0.6"

--- a/sev/Cargo.toml
+++ b/sev/Cargo.toml
@@ -10,8 +10,11 @@ default = []
 dangerous_tests = []
 
 [dependencies]
-openssl = { version = "0.10", optional = true, features = [ "vendored" ] }
+openssl = { version = "=0.10.29", optional = true, features = [ "vendored" ] }
 bitflags = "1.2.1"
 codicon = "2.1.0"
 bitfield = "0.13"
 iocuddle = { path = "../iocuddle" }
+
+[patch.crates-io]
+openssl = { git = 'https://github.com/npmccallum/rust-openssl', branch='patch' }

--- a/sgx-crypto/Cargo.toml
+++ b/sgx-crypto/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-openssl = { version = "0.10", features = [ "vendored" ] }
+openssl = { version = "=0.10.29", features = [ "vendored" ] }
 sgx-types = { path = "../sgx-types" }
 memory = { path = "../memory" }
 


### PR DESCRIPTION
Because openssl is compiled multiple times, this will speed up the CI.