### PR TITLE
makefile changes

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,5 +1,5 @@
 [env]
-CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = "true"
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 CARGO_MAKE_WORKSPACE_EMULATION = true
 CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
 	"bounds",
@@ -28,27 +28,27 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
 	"units",
 	"vdso"
 ]
+ENARX_TEST_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests"
 
 [tasks.deny]
-install_crate = "cargo-deny"
 command = "cargo"
 args = ["deny", "check", "licenses"]
 
 [tasks.misc-lints-missing-docs]
-command = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests/misc-lints-missing-docs"
+command = "${ENARX_TEST_DIR}/misc-lints-missing-docs"
 
 [tasks.cargo-toml-package-edition]
-install_script = [''' which toml || cargo install toml-cli ''']
-command = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests/cargo-toml-package-edition"
+install_crate = { crate_name = "toml-cli", binary = "toml", test_arg = "--help" }
+command = "${ENARX_TEST_DIR}/cargo-toml-package-edition"
 
 [tasks.misc-lints-clippy-all]
-command = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests/misc-lints-clippy-all"
+command = "${ENARX_TEST_DIR}/misc-lints-clippy-all"
 
 [tasks.misc-licenses-rs-spdx]
-command = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests/misc-licenses-rs-spdx"
+command = "${ENARX_TEST_DIR}/misc-licenses-rs-spdx"
 
 [tasks.misc-licenses-asm-spdx]
-command = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests/misc-licenses-asm-spdx"
+command = "${ENARX_TEST_DIR}/misc-licenses-asm-spdx"
 
 [tasks.misc-diagrams]
 workspace = false
@@ -57,13 +57,13 @@ workspace = false
 # detect whether we're in a crate directory and if we are, this test
 # will be skipped. It doesn't make sense to run inside a crate directory.
 condition = { env_not_set = ["CARGO_MAKE_CRATE_NAME"]}
-command = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests/misc-diagrams"
+command = "${ENARX_TEST_DIR}/misc-diagrams"
 
 [tasks.cargo-toml-package-license]
-command = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests/cargo-toml-package-license"
+command = "${ENARX_TEST_DIR}/cargo-toml-package-license"
 
 [tasks.misc-licenses-crate]
-command = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests/misc-licenses-crate"
+command = "${ENARX_TEST_DIR}/misc-licenses-crate"
 
 [tasks.integration]
 workspace = false


### PR DESCRIPTION
i looked at the workspace emulation usage and saw few things that can be improved in the makefile.

* bool env vars can be just true/false, no need to make them strings
* new env var for test scripts dir location, so make tasks smaller and more readable.
* removed ```install_crate = "cargo-deny"``` as cargo make knows that automatically 
* replaced shell script 
```install_script = [''' which toml || cargo install toml-cli ''']```
with toml
```toml
install_crate = { crate_name = "toml-cli", binary = "toml", test_arg = "--help" }
```
which is multi platform

