### PR TITLE
Run the shim

### DIFF
--- a/enarx-keep-sev/Cargo.toml
+++ b/enarx-keep-sev/Cargo.toml
@@ -8,13 +8,14 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bounds = { path = "../bounds" }
+enarx-keep-sev-shim = { path = "../enarx-keep-sev-shim" }
 kvm-bindings = "0.2.0"
 kvm-ioctls = "0.5.0"
 libc = "0.2.71"
 loader = { path = "../loader" }
 memory = { path = "../memory" }
 mmap = { path = "../mmap" }
-bounds = { path = "../bounds" }
 structopt = "0.3"
 units = { path = "../units" }
 x86_64 = { version = "0.11.0", default-features = false, features = ["stable"] }

--- a/enarx-keep-sev/src/main.rs
+++ b/enarx-keep-sev/src/main.rs
@@ -49,7 +49,7 @@ fn run(args: Args) -> Result<(), io::Error> {
         .load_code(code)?
         .build()?;
 
-    // TODO: Run the KVM VM + have event loop for servicing requests from the shim
+    vm.start()?;
 
     Ok(())
 }

--- a/enarx-keep-sev/src/main.rs
+++ b/enarx-keep-sev/src/main.rs
@@ -9,10 +9,11 @@
 mod vm;
 mod x86_64;
 
+use vm::builder::New;
+
 use loader::Component;
 use structopt::StructOpt;
 
-use std::fs::File;
 use std::io;
 use std::path::PathBuf;
 
@@ -40,14 +41,13 @@ fn main() {
 
 fn run(args: Args) -> Result<(), io::Error> {
     let shim = Component::from_path(&args.shim)?;
-    let _code = File::open(args.code)?;
+    let code = Component::from_path(&args.code)?;
 
-    let mut builder = vm::Builder::new()?;
-    let shim_entry = builder.load(&shim)?;
-
-    let _vm = builder.build();
-
-    // TODO: code loading
+    let vm = vm::Builder::<New>::new()?
+        .with_mem_size(units::bytes![1; GiB])?
+        .load_shim(shim)?
+        .load_code(code)?
+        .build()?;
 
     // TODO: Run the KVM VM + have event loop for servicing requests from the shim
 

--- a/enarx-keep-sev/src/main.rs
+++ b/enarx-keep-sev/src/main.rs
@@ -45,6 +45,7 @@ fn run(args: Args) -> Result<(), io::Error> {
 
     let vm = vm::Builder::<New>::new()?
         .with_mem_size(units::bytes![1; GiB])?
+        .component_sizes(shim.region(), code.region())?
         .load_shim(shim)?
         .load_code(code)?
         .build()?;

--- a/enarx-keep-sev/src/vm/builder.rs
+++ b/enarx-keep-sev/src/vm/builder.rs
@@ -215,7 +215,12 @@ impl Builder<Code> {
             kvm: self.data.kvm.unwrap(),
             fd: self.data.fd.unwrap(),
             address_space: self.data.address_space.unwrap(),
+            cpus: vec![],
         };
+
+        // Create startup CPU
+        let vcpu = vm.fd.create_vcpu(0)?;
+        vm.add_vcpu(vcpu, self.data.shim_entry.unwrap())?;
 
         Ok(vm)
     }

--- a/enarx-keep-sev/src/vm/builder.rs
+++ b/enarx-keep-sev/src/vm/builder.rs
@@ -145,7 +145,7 @@ impl Builder<New> {
 /// shim may be loaded into it.
 impl Builder<AddressSpace> {
     pub fn load_shim(mut self, mut shim: Component) -> Result<Builder<Shim>, io::Error> {
-        self.load_component(&mut shim, units::bytes!(4; MiB))?;
+        self.load_component(&mut shim, units::bytes!(1; MiB))?;
         self.data.shim_entry = Some(PhysAddr::new(shim.entry as _));
 
         Ok(Builder {

--- a/enarx-keep-sev/src/vm/cpu.rs
+++ b/enarx-keep-sev/src/vm/cpu.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::x86_64::*;
+
+use kvm_ioctls::VcpuFd;
+use x86_64::registers::control::{Cr0Flags, Cr4Flags};
+use x86_64::registers::model_specific::EferFlags;
+use x86_64::PhysAddr;
+
+use std::io;
+
+pub fn set_gen_regs(vcpu: &VcpuFd, entry: PhysAddr) -> Result<(), io::Error> {
+    let mut regs = vcpu.get_regs()?;
+
+    regs.rip = entry.as_u64();
+    regs.rflags |= 0x2;
+
+    vcpu.set_regs(&regs)?;
+    Ok(())
+}
+
+pub fn set_special_regs(vcpu: &VcpuFd) -> Result<(), io::Error> {
+    let mut sregs = vcpu.get_sregs()?;
+
+    let cs = KvmSegment {
+        base: 0,
+        limit: 0xFFFFF,
+        selector: 8,
+        type_: 11,
+        present: 1,
+        dpl: 0,
+        db: 0,
+        s: 1,
+        l: 1,
+        g: 1,
+        avl: 0,
+        unusable: 0,
+        padding: 0,
+    };
+
+    sregs.cs = cs;
+
+    sregs.efer = (EferFlags::LONG_MODE_ENABLE | EferFlags::LONG_MODE_ACTIVE).bits();
+    sregs.cr0 = (Cr0Flags::PROTECTED_MODE_ENABLE
+        | Cr0Flags::NUMERIC_ERROR
+        | Cr0Flags::PAGING
+        | Cr0Flags::MONITOR_COPROCESSOR)
+        .bits();
+    sregs.cr3 = PML4_START.as_u64();
+    sregs.cr4 = (Cr4Flags::PHYSICAL_ADDRESS_EXTENSION).bits();
+
+    vcpu.set_sregs(&sregs)?;
+    Ok(())
+}

--- a/enarx-keep-sev/src/vm/cpu.rs
+++ b/enarx-keep-sev/src/vm/cpu.rs
@@ -19,7 +19,7 @@ pub fn set_gen_regs(vcpu: &VcpuFd, entry: PhysAddr) -> Result<(), io::Error> {
     Ok(())
 }
 
-pub fn set_special_regs(vcpu: &VcpuFd) -> Result<(), io::Error> {
+pub fn set_special_regs(vcpu: &VcpuFd, cr3: u64) -> Result<(), io::Error> {
     let mut sregs = vcpu.get_sregs()?;
 
     let cs = KvmSegment {
@@ -46,7 +46,7 @@ pub fn set_special_regs(vcpu: &VcpuFd) -> Result<(), io::Error> {
         | Cr0Flags::PAGING
         | Cr0Flags::MONITOR_COPROCESSOR)
         .bits();
-    sregs.cr3 = PML4_START.as_u64();
+    sregs.cr3 = cr3;
     sregs.cr4 = (Cr4Flags::PHYSICAL_ADDRESS_EXTENSION).bits();
 
     vcpu.set_sregs(&sregs)?;

--- a/enarx-keep-sev/src/vm/mod.rs
+++ b/enarx-keep-sev/src/vm/mod.rs
@@ -41,9 +41,9 @@ impl VirtualMachine {
         Ok(())
     }
 
-    fn add_vcpu(&mut self, vcpu: VcpuFd, entry: PhysAddr) -> Result<(), io::Error> {
+    fn add_vcpu(&mut self, vcpu: VcpuFd, entry: PhysAddr, cr3: u64) -> Result<(), io::Error> {
         cpu::set_gen_regs(&vcpu, entry)?;
-        cpu::set_special_regs(&vcpu)?;
+        cpu::set_special_regs(&vcpu, cr3)?;
         vcpu.set_cpuid2(&self.kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)?)?;
 
         self.cpus.push(vcpu);

--- a/enarx-keep-sev/src/vm/mod.rs
+++ b/enarx-keep-sev/src/vm/mod.rs
@@ -10,7 +10,7 @@ use mem::Region;
 use kvm_ioctls::{Kvm, VmFd};
 
 pub struct VirtualMachine {
-    _kvm: Kvm,
-    _fd: VmFd,
+    kvm: Kvm,
+    fd: VmFd,
     address_space: Region,
 }

--- a/enarx-keep-sev/src/vm/mod.rs
+++ b/enarx-keep-sev/src/vm/mod.rs
@@ -1,16 +1,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod builder;
+mod cpu;
 mod mem;
 
 pub use builder::Builder;
-
 use mem::Region;
 
-use kvm_ioctls::{Kvm, VmFd};
+use kvm_ioctls::{Kvm, VcpuFd, VmFd};
+use x86_64::PhysAddr;
+
+use kvm_bindings::KVM_MAX_CPUID_ENTRIES;
+
+use std::io;
 
 pub struct VirtualMachine {
     kvm: Kvm,
     fd: VmFd,
     address_space: Region,
+    cpus: Vec<VcpuFd>,
+}
+
+impl VirtualMachine {
+    pub fn start(&self) -> Result<(), io::Error> {
+        let cpu0 = self.cpus.first().unwrap();
+
+        Ok(())
+    }
+
+    fn add_vcpu(&mut self, vcpu: VcpuFd, entry: PhysAddr) -> Result<(), io::Error> {
+        cpu::set_gen_regs(&vcpu, entry)?;
+        cpu::set_special_regs(&vcpu)?;
+        vcpu.set_cpuid2(&self.kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)?)?;
+
+        self.cpus.push(vcpu);
+        Ok(())
+    }
 }

--- a/enarx-keep-sev/src/x86_64.rs
+++ b/enarx-keep-sev/src/x86_64.rs
@@ -1,27 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use kvm_bindings::kvm_segment as KvmSegment;
+use memory::Page;
 use x86_64::structures::paging::page_table::PageTable;
-use x86_64::PhysAddr;
-
-/// The *guest* physical address of the root page table structure.
-pub const PML4_START: PhysAddr = PhysAddr::new_truncate(0x9000);
-
-/// The first page table entry.
-pub const PDPTE_START: PhysAddr = PhysAddr::new_truncate(0xA000);
-
-/// The *guest* physical address of the shared syscall page.
-pub const BOOT_INFO_START: PhysAddr = PhysAddr::new_truncate(0x1000);
 
 #[repr(C)]
-pub struct PageTables {
+pub struct VMSetup {
+    pub zero_page: Page,
+    pub shared_page: Page,
     pub pml4t: PageTable,
     pub pml3t_ident: PageTable,
 }
 
-impl Default for PageTables {
+impl Default for VMSetup {
     fn default() -> Self {
-        PageTables {
+        VMSetup {
+            zero_page: Page::default(),
+            shared_page: Page::default(),
             pml4t: PageTable::new(),
             pml3t_ident: PageTable::new(),
         }

--- a/enarx-keep-sev/src/x86_64.rs
+++ b/enarx-keep-sev/src/x86_64.rs
@@ -10,6 +10,9 @@ pub const PML4_START: PhysAddr = PhysAddr::new_truncate(0x9000);
 /// The first page table entry.
 pub const PDPTE_START: PhysAddr = PhysAddr::new_truncate(0xA000);
 
+/// The *guest* physical address of the shared syscall page.
+pub const BOOT_INFO_START: PhysAddr = PhysAddr::new_truncate(0x1000);
+
 #[repr(C)]
 pub struct PageTables {
     pub pml4t: PageTable,

--- a/enarx-keep-sev/src/x86_64.rs
+++ b/enarx-keep-sev/src/x86_64.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+pub use kvm_bindings::kvm_segment as KvmSegment;
 use x86_64::structures::paging::page_table::PageTable;
 use x86_64::PhysAddr;
 


### PR DESCRIPTION
Related: #313 

Proxying the write syscall will be in the next PR once this lands.

This PR adds a type-state machine builder pattern to cleanly separate VM construction stages and to make sure all operations are performed in the correct order at compile time. It also performs the necessary setup to allow the shim to run :-)

```
$  ./enarx-keep-sev/target/debug/enarx-keep-sev \
 --shim ./enarx-keep-sev-shim/target/x86_64-unknown-linux-musl/debug/enarx-keep-sev-shim \
 --code ./payload/target/x86_64-unknown-linux-musl/debug/payload
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
IoOut: received 2 bytes from port 255
Shutdown
Ok(kvm_regs { rax: 254, rbx: 18446743523953737728, rcx: 18446743523955044353, rdx: 18446743523954800672, rsi: 1, rdi: 18446743523955122176, rsp: 18446743523955112536, rbp: 0, r8: 18446743523954862096, r9: 0, r10: 18446743523955113456, r11: 231, r12: 0, r13: 0, r14: 0, r15: 18446743523953737728, rip: 18446743523954820330, rflags: 65606 })
Ok(kvm_sregs { cs: kvm_segment { base: 0, limit: 0, selector: 8, type_: 9, present: 1, dpl: 0, db: 0, s: 1, l: 1, g: 0, avl: 0, unusable: 0, padding: 0 }, ds: kvm_segment { base: 0, limit: 4294967295, selector: 0, type_: 0, present: 0, dpl: 0, db: 1, s: 0, l: 0, g: 1, avl: 0, unusable: 1, padding: 0 }, es: kvm_segment { base: 0, limit: 4294967295, selector: 0, type_: 0, present: 0, dpl: 0, db: 1, s: 0, l: 0, g: 1, avl: 0, unusable: 1, padding: 0 }, fs: kvm_segment { base: 0, limit: 4294967295, selector: 0, type_: 0, present: 0, dpl: 0, db: 1, s: 0, l: 0, g: 1, avl: 0, unusable: 1, padding: 0 }, gs: kvm_segment { base: 0, limit: 4294967295, selector: 0, type_: 0, present: 0, dpl: 0, db: 1, s: 0, l: 0, g: 1, avl: 0, unusable: 1, padding: 0 }, ss: kvm_segment { base: 0, limit: 4294967295, selector: 0, type_: 0, present: 0, dpl: 0, db: 1, s: 0, l: 0, g: 1, avl: 0, unusable: 1, padding: 0 }, tr: kvm_segment { base: 18446743523954876417, limit: 103, selector: 40, type_: 11, present: 1, dpl: 0, db: 0, s: 0, l: 0, g: 0, avl: 0, unusable: 0, padding: 0 }, ldt: kvm_segment { base: 0, limit: 65535, selector: 0, type_: 2, present: 1, dpl: 0, db: 0, s: 0, l: 0, g: 0, avl: 0, unusable: 0, padding: 0 }, gdt: kvm_dtable { base: 18446743523954876536, limit: 63, padding: [0, 0, 0] }, idt: kvm_dtable { base: 0, limit: 0, padding: [0, 0, 0] }, cr0: 2147483697, cr2: 0, cr3: 1376256, cr4: 329248, cr8: 0, efer: 3329, apic_base: 4276095232, interrupt_bitmap: [0, 0, 0, 0] })
```