### PR TITLE
Prepare for using Sallyport in SGX

### DIFF
--- a/enarx-keep-sgx-shim/Cargo.toml
+++ b/enarx-keep-sgx-shim/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 crt0stack = { path = "../crt0stack" }
 intel-types = { path = "../intel-types" }
+sallyport = { path = "../sallyport" }
 sgx-types = { path = "../sgx-types" }
 memory = { path = "../memory" }
 bounds = { path = "../bounds" }

--- a/enarx-keep-sgx-shim/src/event.rs
+++ b/enarx-keep-sgx-shim/src/event.rs
@@ -3,6 +3,7 @@
 use core::convert::TryInto;
 use intel_types::Exception;
 use memory::Register;
+use sallyport::Block;
 use sgx_types::ssa::StateSaveArea;
 
 use crate::handler::{Context, Handler};
@@ -15,7 +16,7 @@ const OP_CPUID: &[u8] = &[0x0f, 0xa2];
 
 #[no_mangle]
 pub extern "C" fn event(
-    _rdi: u64,
+    block: &mut Block,
     _rsi: u64,
     _rdx: u64,
     layout: &Layout,
@@ -24,7 +25,7 @@ pub extern "C" fn event(
     aex: &mut StateSaveArea,
     ctx: &Context,
 ) {
-    let mut h = Handler::new(layout, aex, ctx);
+    let mut h = Handler::new(layout, aex, ctx, block);
 
     // Exception Vector Table
     match h.aex.gpr.exitinfo.exception() {

--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -103,6 +103,25 @@ impl<'a> Handler<'a> {
         }
     }
 
+    #[inline(never)]
+    unsafe fn proxy(&mut self) -> u64 {
+        let ret = syscall(
+            self.block.msg.req.arg[0].raw() as u64, // rdi
+            self.block.msg.req.arg[1].raw() as u64, // rsi
+            self.block.msg.req.arg[2].raw() as u64, // rdx
+            self.aex,
+            self.block.msg.req.arg[4].raw() as u64, // r8
+            self.block.msg.req.arg[5].raw() as u64, // r9
+            self.block.msg.req.arg[3].raw() as u64, // r10
+            self.block.msg.req.num.raw() as u64,    // rax
+            self.ctx,
+        );
+
+        self.block.msg.rep = Ok([ret.into(), 0usize.into()]).into();
+
+        ret
+    }
+
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     unsafe fn syscall(

--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -3,6 +3,7 @@
 use crate::Layout;
 
 use bounds::{Contains, Line, Span};
+use sallyport::Block;
 use sgx_types::ssa::StateSaveArea;
 
 use core::fmt::Write;
@@ -47,6 +48,7 @@ pub struct Handler<'a> {
     pub aex: &'a mut StateSaveArea,
     layout: &'a Layout,
     ctx: &'a Context,
+    block: &'a mut Block,
 }
 
 impl<'a> Write for Handler<'a> {
@@ -87,8 +89,18 @@ impl<'a> Write for Handler<'a> {
 
 impl<'a> Handler<'a> {
     /// Create a new handler
-    pub fn new(layout: &'a Layout, aex: &'a mut StateSaveArea, ctx: &'a Context) -> Self {
-        Self { aex, ctx, layout }
+    pub fn new(
+        layout: &'a Layout,
+        aex: &'a mut StateSaveArea,
+        ctx: &'a Context,
+        block: &'a mut Block,
+    ) -> Self {
+        Self {
+            aex,
+            ctx,
+            layout,
+            block,
+        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/enarx-keep-sgx/Cargo.toml
+++ b/enarx-keep-sgx/Cargo.toml
@@ -10,6 +10,7 @@ goblin = "0.2.3"
 iocuddle-sgx = { path = "../iocuddle-sgx" }
 intel-types = { path = "../intel-types" }
 loader = { path = "../loader" }
+sallyport = { path = "../sallyport" }
 sgx-crypto = { path = "../sgx-crypto" }
 sgx-types = { path = "../sgx-types" }
 enumerate = { path = "../enumerate" }

--- a/sallyport/src/lib.rs
+++ b/sallyport/src/lib.rs
@@ -148,6 +148,17 @@ pub struct Block {
     pub buf: [u8; Block::buf_capacity()],
 }
 
+impl Default for Block {
+    fn default() -> Self {
+        Self {
+            msg: Message {
+                req: Request::default(),
+            },
+            buf: [0u8; Block::buf_capacity()],
+        }
+    }
+}
+
 impl Block {
     /// Returns the capacity of `Block.buf`
     pub const fn buf_capacity() -> usize {


### PR DESCRIPTION
This series of commits:
- Passes a sallyport Block into the enclave and shim's handler
- Creates a new syscall proxy function that reads arguments out of the handler's Block, but otherwise works the same way as the previous function

Related to #614 