### PR TITLE
keep-runtime: Prefer dynamic memory allocation in wasmtime

### DIFF
--- a/enarx-keep-sgx-shim/src/heap.rs
+++ b/enarx-keep-sgx-shim/src/heap.rs
@@ -151,8 +151,13 @@ impl Heap {
         // Find the brk page offset.
         let brk = self.offset_page_up(self.metadata.brk.end).unwrap();
 
+        let end = match self.pages.len().checked_sub(pages) {
+            Some(end) => end,
+            None => return -libc::ENOMEM as _,
+        };
+
         // Search for pages from the end to the front.
-        for i in (brk..=self.pages.len() - pages).rev() {
+        for i in (brk..=end).rev() {
             let range = i..i + pages;
 
             if !self.is_allocated_range(range.clone()) {

--- a/keep-runtime/src/workload.rs
+++ b/keep-runtime/src/workload.rs
@@ -32,7 +32,10 @@ pub fn run<T: AsRef<[u8]>, U: AsRef<[u8]>, V: std::borrow::Borrow<(U, U)>>(
     args: impl IntoIterator<Item = T>,
     envs: impl IntoIterator<Item = V>,
 ) -> Result<Box<[wasmtime::Val]>> {
-    let engine = wasmtime::Engine::default();
+    let mut config = wasmtime::Config::new();
+    // Prefer dynamic memory allocation style over static memory
+    config.static_memory_maximum_size(0);
+    let engine = wasmtime::Engine::new(&config);
     let store = wasmtime::Store::new(&engine);
 
     // Instantiate WASI


### PR DESCRIPTION
By default, wasmtime internally allocates 4GiB of memory once at the startup, which does not fit well in our SGX heap.  This configures wasmtime to only do dynamic memory allocation.

Related to #636.