### PR TITLE
Update getuid syscall to use proxy

### DIFF
--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -242,7 +242,10 @@ impl<'a> Handler<'a> {
     pub fn getuid(&mut self) -> u64 {
         self.trace("getuid", 0);
 
-        unsafe { self.syscall(libc::SYS_getuid as u64, 0, 0, 0, 0, 0, 0) }
+        match unsafe { self.proxy(Request::new(libc::SYS_getuid as usize, &[])) } {
+            Ok(res) => res[0].raw() as u64,
+            Err(code) => code as u64,
+        }
     }
 
     /// Do a read() syscall


### PR DESCRIPTION
Related to #614 

I'm planning to pull the match statement in an upcoming PR after porting all the syscalls (because they all need to return the same value in `event()`, which right now is `u64` and later can be the `Result` type).