### PR TITLE
Add syscall clock_gettime

### DIFF
--- a/enarx-keep-sgx-shim/src/event.rs
+++ b/enarx-keep-sgx-shim/src/event.rs
@@ -49,7 +49,7 @@ pub extern "C" fn event(
                         libc::SYS_rt_sigprocmask => h.rt_sigprocmask(),
                         libc::SYS_sigaltstack => h.sigaltstack(),
                         libc::SYS_getrandom => h.getrandom(),
-
+                        libc::SYS_clock_gettime => h.clock_gettime(),
                         syscall => {
                             debugln!(h, "unsupported syscall: 0x{:x}", syscall as u64);
                             Err(libc::ENOSYS).into()

--- a/integration-tests/src/bin/clock_gettime.rs
+++ b/integration-tests/src/bin/clock_gettime.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use libc::clock_gettime;
+
+fn main() {
+    let mut ts = libc::timespec {
+        tv_nsec: Default::default(),
+        tv_sec: Default::default(),
+    };
+
+    unsafe {
+        clock_gettime(libc::CLOCK_MONOTONIC, &mut ts as *mut _);
+    }
+}

--- a/integration-tests/tests/syscall_clock_gettime.rs
+++ b/integration-tests/tests/syscall_clock_gettime.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![deny(clippy::all)]
+
+mod common;
+use common::IntegrationTest;
+
+#[test]
+#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+fn clock_gettime() {
+    IntegrationTest::new("clock_gettime").run(5, 0, "", "", "");
+}


### PR DESCRIPTION
Closes #664

I implemented syscall `clock_gettime` according to the [Usage section](https://github.com/enarx/enarx/tree/master/sallyport#usage) from sallyport. I used `self.block.cursor()` to allocate a buffer memory for host to write the result and then copy it back to the address in enclave.