### PR TITLE
Implement payload loading and syscall handling

### DIFF
--- a/enarx-keep-sev-shim/Cargo.toml
+++ b/enarx-keep-sev-shim/Cargo.toml
@@ -11,10 +11,12 @@ bounds = { path = "../bounds" }
 units = { path = "../units" }
 memory = { path = "../memory" }
 sallyport = { path = "../sallyport" }
+crt0stack = { path = "../crt0stack" }
 libc = { version = "0.2.69", features = [] }
 x86_64 = { version = "0.11.0", default-features = false, features = ["stable"] }
 spinning = { version = "0.0", default-features = false}
 lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
+goblin = { version = "0.2", default-features = false, features = [ "elf64" ] }
 
 [profile.dev.package.rcrt1]
 opt-level = 3

--- a/enarx-keep-sev-shim/src/addr.rs
+++ b/enarx-keep-sev-shim/src/addr.rs
@@ -54,6 +54,16 @@ where
     }
 }
 
+impl<T, U> From<Address<T, U>> for ShimPhysAddr<U>
+where
+    Address<T, U>: Into<Address<u64, U>>,
+{
+    #[inline(always)]
+    fn from(val: Address<T, U>) -> Self {
+        Self(val.into())
+    }
+}
+
 /// Address in the shim virtual address space
 pub struct ShimVirtAddr<U>(Address<u64, U>);
 
@@ -92,6 +102,15 @@ impl<U> From<ShimVirtAddr<U>> for ShimPhysAddr<U> {
         // Safety: checked, that it is in the shim virtual address space earlier
         #[allow(clippy::integer_arithmetic)]
         ShimPhysAddr(unsafe { Address::unchecked(shim_virt_addr.0.raw() - SHIM_VIRT_OFFSET) })
+    }
+}
+
+impl<U> From<ShimPhysAddr<U>> for ShimVirtAddr<U> {
+    #[inline(always)]
+    fn from(shim_phys_addr: ShimPhysAddr<U>) -> Self {
+        // Safety: checked, that it is in the shim virtual address space earlier
+        #[allow(clippy::integer_arithmetic)]
+        ShimVirtAddr(unsafe { Address::unchecked(shim_phys_addr.0.raw() + SHIM_VIRT_OFFSET) })
     }
 }
 

--- a/enarx-keep-sev-shim/src/asm.rs
+++ b/enarx-keep-sev-shim/src/asm.rs
@@ -6,4 +6,6 @@
 
 extern "C" {
     pub fn _enarx_asm_triple_fault() -> !;
+    pub fn _rdfsbase() -> u64;
+    pub fn _wrfsbase(val: u64);
 }

--- a/enarx-keep-sev-shim/src/asm.s
+++ b/enarx-keep-sev-shim/src/asm.s
@@ -13,6 +13,7 @@
 /// Fun read: http://www.rcollins.org/Productivity/TripleFault.html
 .global _enarx_asm_triple_fault
 .type _enarx_asm_triple_fault, @function
+.code64
 .p2align 4
 _enarx_asm_triple_fault:
     lea _enarx_asm_Hose_IDTR(%rip), %rdi
@@ -25,3 +26,21 @@ _enarx_asm_triple_fault:
 _enarx_asm_Hose_IDTR:
 .space 10
 .popsection
+
+.section .text, "ax"
+.global _rdfsbase
+.type _rdfsbase, @function
+.code64
+.p2align 4
+_rdfsbase:
+    rdfsbase %rax
+    retq
+
+.section .text, "ax"
+.global _wrfsbase
+.type _wrfsbase, @function
+.code64
+.p2align 4
+_wrfsbase:
+    wrfsbase %rdi
+    retq

--- a/enarx-keep-sev-shim/src/main.rs
+++ b/enarx-keep-sev-shim/src/main.rs
@@ -26,9 +26,11 @@ pub mod gdt;
 pub mod hostcall;
 pub mod no_std;
 pub mod paging;
+pub mod payload;
 pub mod shim_stack;
 #[macro_use]
 pub mod print;
+pub mod random;
 pub mod syscall;
 pub mod usermode;
 
@@ -79,14 +81,11 @@ entry_point!(shim_main);
 pub fn shim_main() -> ! {
     dbg!(BOOT_INFO.read().deref());
 
-    #[cfg(debug_assertions)]
-    eprintln!("Hello World!");
-
     unsafe {
         gdt::init();
     }
 
-    hostcall::shim_exit(0);
+    payload::execute_payload()
 }
 
 /// The panic function

--- a/enarx-keep-sev-shim/src/payload.rs
+++ b/enarx-keep-sev-shim/src/payload.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Functions dealing with the payload
+use crate::addr::{ShimPhysAddr, ShimVirtAddr};
+use crate::frame_allocator::FRAME_ALLOCATOR;
+use crate::paging::SHIM_PAGETABLE;
+use crate::random::random;
+use crate::usermode::usermode;
+use crate::BOOT_INFO;
+use core::ops::DerefMut;
+use crt0stack::{self, Builder, Entry};
+use goblin::elf::header::header64::Header;
+use goblin::elf::header::ELFMAG;
+use goblin::elf::program_header::program_header64::*;
+use memory::Address;
+use spinning::RwLock;
+use units::bytes;
+use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+use x86_64::{PhysAddr, VirtAddr};
+
+/// Payload virtual address, where the elf binary is mapped to, plus a random offset
+const PAYLOAD_ELF_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x7f00_0000_0000);
+
+/// The first brk virtual address the payload gets, plus a random offset
+const PAYLOAD_BRK_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x5555_0000_0000);
+
+/// Payload stack virtual address
+const PAYLOAD_STACK_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x7ff0_0000_0000);
+
+/// Initial payload stack size
+const PAYLOAD_STACK_SIZE: u64 = bytes![16; MiB];
+
+lazy_static! {
+    /// Actual payload virtual address, where the elf binary is mapped to
+    static ref PAYLOAD_VIRT_ADDR: RwLock<VirtAddr> = {
+        RwLock::<VirtAddr>::const_new(
+            spinning::RawRwLock::const_new(),
+            PAYLOAD_ELF_VIRT_ADDR_BASE + (random() & 0x7F_FFFF_F000),
+        )
+    };
+}
+
+lazy_static! {
+    /// Actual brk virtual address the payload gets, when calling brk
+    pub static ref NEXT_BRK_RWLOCK: RwLock<VirtAddr> = {
+        RwLock::<VirtAddr>::const_new(
+            spinning::RawRwLock::const_new(),
+            PAYLOAD_BRK_VIRT_ADDR_BASE + (random() & 0xFFFF_F000))
+    };
+}
+
+lazy_static! {
+    /// The global NextMMap RwLock
+    pub static ref NEXT_MMAP_RWLOCK: RwLock<VirtAddr> = {
+        let boot_info = BOOT_INFO.read().unwrap();
+
+        let mmap_start = (*PAYLOAD_VIRT_ADDR.read().deref() + (boot_info.code.end - boot_info.code.start)).align_up(4096u64);
+
+        RwLock::<VirtAddr>::const_new(
+            spinning::RawRwLock::const_new(),
+            mmap_start)
+    };
+}
+
+/// load the elf binary
+fn map_elf(app_virt_start: VirtAddr) -> &'static Header {
+    let (code_start, code_end) = {
+        let boot_info = BOOT_INFO.read().unwrap();
+        (boot_info.code.start, boot_info.code.end)
+    };
+    let app_load_addr = Address::<usize, Header>::from(code_start as *const Header);
+    let app_load_addr_phys = ShimPhysAddr::<Header>::from(app_load_addr);
+    let app_load_addr_virt = ShimVirtAddr::from(app_load_addr_phys);
+
+    let header_ptr: *const Header = app_load_addr_virt.into();
+    let header: &Header = unsafe { &*header_ptr };
+
+    if !header.e_ident[..ELFMAG.len()].eq(ELFMAG) {
+        panic!("Not valid ELF");
+    }
+
+    let headers: &[ProgramHeader] = unsafe {
+        core::slice::from_raw_parts(
+            (header_ptr as usize as *const u8).offset(header.e_phoff as _) as *const ProgramHeader,
+            header.e_phnum as _,
+        )
+    };
+
+    for ph in headers.iter().filter(|ph| ph.p_type == PT_LOAD) {
+        let map_from = PhysAddr::new(code_start as u64 + ph.p_paddr);
+        debug_assert!(map_from.as_u64() < code_end as u64);
+
+        let map_to = app_virt_start + ph.p_vaddr;
+
+        let mut page_table_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+        if (ph.p_flags & PF_X) == 0 {
+            page_table_flags |= PageTableFlags::NO_EXECUTE
+        };
+        if (ph.p_flags & PF_W) != 0 {
+            page_table_flags |= PageTableFlags::WRITABLE
+        };
+
+        debug_assert_eq!(ph.p_align, Page::<Size4KiB>::SIZE);
+
+        FRAME_ALLOCATOR
+            .write()
+            .map_memory(
+                SHIM_PAGETABLE.write().deref_mut(),
+                map_from,
+                map_to,
+                ph.p_memsz as _,
+                page_table_flags,
+                PageTableFlags::PRESENT
+                    | PageTableFlags::USER_ACCESSIBLE
+                    | PageTableFlags::WRITABLE,
+            )
+            .expect("Map payload elf failed!");
+    }
+
+    header
+}
+
+/// Allocate the stack for the payload with guard pages
+fn init_payload_stack(map_to: VirtAddr) -> &'static mut [u8] {
+    // guard page
+    FRAME_ALLOCATOR
+        .write()
+        .allocate_and_map_memory(
+            SHIM_PAGETABLE.write().deref_mut(),
+            map_to - Page::<Size4KiB>::SIZE,
+            Page::<Size4KiB>::SIZE as _,
+            PageTableFlags::empty(),
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+        )
+        .expect("Stack guard page allocation failed");
+
+    let mem_slice = FRAME_ALLOCATOR
+        .write()
+        .allocate_and_map_memory(
+            SHIM_PAGETABLE.write().deref_mut(),
+            map_to,
+            PAYLOAD_STACK_SIZE as _,
+            PageTableFlags::PRESENT
+                | PageTableFlags::WRITABLE
+                | PageTableFlags::USER_ACCESSIBLE
+                | PageTableFlags::NO_EXECUTE,
+            PageTableFlags::PRESENT
+                | PageTableFlags::WRITABLE
+                | PageTableFlags::USER_ACCESSIBLE
+                | PageTableFlags::NO_EXECUTE,
+        )
+        .expect("Stack allocation failed");
+
+    // guard page
+    FRAME_ALLOCATOR
+        .write()
+        .allocate_and_map_memory(
+            SHIM_PAGETABLE.write().deref_mut(),
+            map_to + PAYLOAD_STACK_SIZE,
+            Page::<Size4KiB>::SIZE as _,
+            PageTableFlags::empty(),
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+        )
+        .expect("Stack guard page allocation failed");
+
+    mem_slice
+}
+
+fn crt0setup(
+    app_virt_start: VirtAddr,
+    stack_slice: &'static mut [u8],
+    header: &Header,
+) -> Result<(VirtAddr, u64), ()> {
+    let mut builder = Builder::new(stack_slice);
+    builder.push("/init").unwrap();
+    let mut builder = builder.done().unwrap();
+    builder.push("LANG=C").unwrap();
+    builder.push("TERM=xterm-256color").unwrap();
+    let mut builder = builder.done().unwrap();
+
+    let ph_header = app_virt_start + header.e_phoff;
+    let ph_entry = app_virt_start + header.e_entry;
+
+    let hwcap = unsafe { core::arch::x86_64::__cpuid(1) }.edx;
+    let rand = unsafe { core::mem::transmute([random(), random()]) };
+
+    for aux in &[
+        //Entry::SysInfoEHdr(0x7FD735C0E000),
+        Entry::ExecFilename("/init"),
+        Entry::Platform("x86_64"),
+        Entry::Uid(1000),
+        Entry::EUid(1000),
+        Entry::Gid(1000),
+        Entry::EGid(1000),
+        Entry::PageSize(4096),
+        Entry::Secure(false),
+        Entry::ClockTick(100),
+        Entry::Flags(0),
+        //Entry::Base(0),
+        Entry::PHdr(ph_header.as_u64() as _),
+        Entry::PHent(header.e_phentsize as _),
+        Entry::PHnum(header.e_phnum as _),
+        Entry::HwCap(hwcap as _),
+        Entry::HwCap2(0),
+        Entry::Random(rand),
+        Entry::Entry(ph_entry.as_u64() as _),
+    ] {
+        builder.push(aux).unwrap();
+    }
+    let handle = builder.done().unwrap();
+    let sp = handle.start_ptr() as *const () as u64;
+
+    Ok((ph_entry, sp))
+}
+
+/// execute the payload
+pub fn execute_payload() -> ! {
+    let header = map_elf(*PAYLOAD_VIRT_ADDR.read());
+
+    let stack = init_payload_stack(PAYLOAD_STACK_VIRT_ADDR_BASE + (random() & 0xFFFF_F000));
+
+    let (entry, sp_handle) =
+        crt0setup(*PAYLOAD_VIRT_ADDR.read(), stack, header).expect("crt0setup failed");
+
+    unsafe {
+        usermode(entry.as_u64(), sp_handle);
+    }
+}

--- a/enarx-keep-sev-shim/src/random.rs
+++ b/enarx-keep-sev-shim/src/random.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Random functions
+
+/// Get a random number
+pub fn random() -> u64 {
+    let mut r: u64 = 0;
+
+    for _ in 0..1024 {
+        if unsafe { core::arch::x86_64::_rdrand64_step(&mut r) } == 1 {
+            return r;
+        }
+    }
+
+    panic!("Could not get random!")
+}

--- a/enarx-keep-sev-shim/src/syscall.rs
+++ b/enarx-keep-sev-shim/src/syscall.rs
@@ -2,6 +2,15 @@
 
 //! syscall interface layer between assembler and rust
 
+use crate::eprintln;
+use crate::frame_allocator::FRAME_ALLOCATOR;
+use crate::hostcall::{self, shim_write_all, HostFd, HOST_CALL};
+use crate::paging::SHIM_PAGETABLE;
+use crate::payload::{NEXT_BRK_RWLOCK, NEXT_MMAP_RWLOCK};
+use core::ops::{Deref, DerefMut};
+use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+use x86_64::{align_up, VirtAddr};
+
 extern "C" {
     pub fn _syscall_enter() -> !;
 }
@@ -10,13 +19,375 @@ extern "C" {
 #[no_mangle]
 /// Handle a syscall in rust
 pub extern "C" fn syscall_rust(
-    _a: usize,
-    _b: usize,
-    _c: usize,
-    _d: usize,
-    _e: usize,
-    _f: usize,
-    _nr: usize,
+    a: usize,
+    b: usize,
+    c: usize,
+    d: usize,
+    e: usize,
+    f: usize,
+    nr: usize,
 ) -> usize {
-    todo!();
+    /*
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "SC> raw: syscall({}, {:#X}, {:#X}, {:#X}, {}, {}, {:#X})",
+            nr, a, b, c, d, e, f
+        );
+    */
+    let h = Handler::new(a, b, c, d, e, f);
+
+    let res = match nr as i64 {
+        libc::SYS_exit => h.exit(),
+        libc::SYS_exit_group => h.exit_group(),
+        libc::SYS_write => h.write(),
+        libc::SYS_writev => h.writev(),
+        libc::SYS_mmap => h.mmap(),
+        libc::SYS_munmap => h.munmap(),
+        libc::SYS_arch_prctl => h.arch_prctl(),
+        libc::SYS_set_tid_address => h.set_tid_address(),
+        libc::SYS_rt_sigaction => h.rt_sigaction(),
+        libc::SYS_rt_sigprocmask => h.rt_sigprocmask(),
+        libc::SYS_sigaltstack => h.sigaltstack(),
+        libc::SYS_getrandom => h.getrandom(),
+        libc::SYS_brk => h.brk(),
+        libc::SYS_ioctl => h.ioctl(),
+        libc::SYS_mprotect => h.mprotect(),
+
+        syscall => {
+            //panic!("SC> unsupported syscall: {}", syscall);
+            eprintln!("SC> unsupported syscall: {}", syscall);
+            Err(libc::ENOSYS)
+        }
+    };
+    res.unwrap_or_else(|e| (-e) as usize) as usize
+}
+
+struct Handler {
+    a: usize,
+    b: usize,
+    c: usize,
+    d: usize,
+    e: usize,
+    f: usize,
+}
+
+impl Handler {
+    pub fn new(a: usize, b: usize, c: usize, d: usize, e: usize, f: usize) -> Self {
+        Self { a, b, c, d, e, f }
+    }
+    pub fn exit(&self) -> ! {
+        eprintln!("SC> exit({})", self.a);
+        hostcall::shim_exit(self.a as _);
+    }
+
+    pub fn exit_group(&self) -> ! {
+        eprintln!("SC> exit_group({})", self.a);
+        hostcall::shim_exit(self.a as _);
+    }
+
+    pub fn write(&self) -> Result<usize, libc::c_int> {
+        let fd = self.a;
+        let data = self.b as *const u8;
+        let len = self.c;
+        let mut host_call = HOST_CALL.try_lock().ok_or(libc::EIO)?;
+        unsafe {
+            let slice = core::slice::from_raw_parts(data, len);
+            // FIXME: allocate unencrypted pages
+            host_call.write(fd, slice).map(|r| r[0].into())
+        }
+    }
+
+    pub fn writev(&self) -> Result<usize, libc::c_int> {
+        let fd = unsafe { HostFd::from_raw_fd(self.a as _) };
+        let iovec =
+            unsafe { core::slice::from_raw_parts_mut(self.b as *mut libc::iovec, self.c as usize) };
+        let bufsize = iovec.iter().fold(0, |a, e| a + e.iov_len);
+
+        for vec in iovec {
+            let data = unsafe {
+                core::slice::from_raw_parts(vec.iov_base as *const u8, vec.iov_len as usize)
+            };
+            // FIXME: allocate unencrypted pages
+            shim_write_all(fd, data)?;
+        }
+        Ok(bufsize)
+    }
+
+    pub fn arch_prctl(&self) -> Result<usize, libc::c_int> {
+        use crate::asm::_wrfsbase;
+
+        const ARCH_SET_GS: usize = 0x1001;
+        const ARCH_SET_FS: usize = 0x1002;
+        const ARCH_GET_FS: usize = 0x1003;
+        const ARCH_GET_GS: usize = 0x1004;
+
+        match self.a {
+            ARCH_SET_FS => {
+                let value: u64 = self.b as _;
+                unsafe {
+                    _wrfsbase(value);
+                }
+                eprintln!("SC> arch_prctl(ARCH_SET_FS, {:#X}) = 0", value);
+                Ok(0)
+            }
+            ARCH_GET_FS => unimplemented!(),
+            ARCH_SET_GS => unimplemented!(),
+            ARCH_GET_GS => unimplemented!(),
+            x => {
+                eprintln!("SC> arch_prctl({:#X}, {:#X}) = -EINVAL", x, self.b);
+                Err(libc::EINVAL)
+            }
+        }
+    }
+
+    pub fn mprotect(&self) -> Result<usize, libc::c_int> {
+        use x86_64::structures::paging::mapper::Mapper;
+
+        let addr = self.a as u64;
+        let len = self.b;
+        let prot = self.c as i32;
+        let mut flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+
+        if prot & libc::PROT_WRITE != 0 {
+            flags |= PageTableFlags::WRITABLE;
+        }
+
+        if prot & libc::PROT_EXEC == 0 {
+            flags |= PageTableFlags::NO_EXECUTE;
+        }
+
+        let mut page_table = SHIM_PAGETABLE.write();
+
+        let start_addr = VirtAddr::new(addr);
+        let start_page: Page = Page::containing_address(start_addr);
+        let end_page: Page = Page::containing_address(start_addr + len - 1u64);
+        let page_range = Page::range_inclusive(start_page, end_page);
+        for page in page_range {
+            unsafe {
+                match page_table.update_flags(page, flags) {
+                    Ok(flush) => flush.flush(),
+                    Err(e) => {
+                        dbg!(e);
+                        return Err(libc::EINVAL);
+                    }
+                }
+            }
+        }
+        eprintln!("SC> mprotect({:#X}, {}, {}, …) = 0", self.a, self.b, self.c);
+
+        Ok(0)
+    }
+
+    pub fn mmap(&self) -> Result<usize, libc::c_int> {
+        const PA: i32 = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
+
+        let addr = self.a;
+        let len = self.b;
+        let prot = self.c as i32;
+        let flags = self.d as i32;
+        let fd = self.e as i32;
+        let offset = self.f;
+
+        match (addr, len, prot, flags, fd, offset) {
+            (0, _, _, PA, -1, 0) => {
+                let mut flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+
+                if prot & libc::PROT_WRITE != 0 {
+                    flags |= PageTableFlags::WRITABLE;
+                }
+
+                if prot & libc::PROT_EXEC == 0 {
+                    flags |= PageTableFlags::NO_EXECUTE;
+                }
+
+                let virt_addr = *NEXT_MMAP_RWLOCK.read().deref();
+                let len_aligned = align_up(len as _, Page::<Size4KiB>::SIZE) as _;
+
+                let mem_slice = FRAME_ALLOCATOR
+                    .write()
+                    .allocate_and_map_memory(
+                        SHIM_PAGETABLE.write().deref_mut(),
+                        virt_addr,
+                        len_aligned,
+                        flags,
+                        PageTableFlags::PRESENT
+                            | PageTableFlags::WRITABLE
+                            | PageTableFlags::USER_ACCESSIBLE,
+                    )
+                    .map_err(|_| {
+                        eprintln!("SC> mmap({:#X}, {}, …) = ENOMEM", self.a, self.b,);
+                        libc::ENOMEM
+                    })?;
+                eprintln!(
+                    "SC> mmap({:#X}, {}, …) = {:#?}",
+                    self.a,
+                    self.b,
+                    mem_slice.as_ptr()
+                );
+                unsafe {
+                    core::ptr::write_bytes(mem_slice.as_mut_ptr(), 0, len);
+                }
+                *NEXT_MMAP_RWLOCK.write().deref_mut() = virt_addr + (len_aligned as u64);
+
+                //eprintln!("next_mmap = {:#X}", *NEXT_MMAP_RWLOCK::read().deref());
+
+                Ok(mem_slice.as_ptr() as usize)
+            }
+            _ => {
+                eprintln!("SC> mmap({:#X}, {}, …)", self.a, self.b);
+                todo!();
+            }
+        }
+    }
+
+    pub fn brk(&self) -> Result<usize, libc::c_int> {
+        let len;
+
+        let next_brk = *NEXT_BRK_RWLOCK.read().deref();
+        let virt_addr = next_brk;
+
+        match self.a {
+            0 => {
+                eprintln!("SC> brk({:#X}) = {:#X}", self.a, next_brk.as_u64());
+                Ok(next_brk.as_u64() as _)
+            }
+            n => {
+                len = n - next_brk.as_u64() as usize;
+
+                // FIXME
+                assert_eq!(
+                    len % (Page::<Size4KiB>::SIZE as usize),
+                    0,
+                    "brk not page aligned"
+                );
+
+                let len_aligned = align_up(len as _, Page::<Size4KiB>::SIZE) as _;
+                let _ = FRAME_ALLOCATOR
+                    .write()
+                    .allocate_and_map_memory(
+                        SHIM_PAGETABLE.write().deref_mut(),
+                        virt_addr,
+                        len_aligned,
+                        PageTableFlags::PRESENT
+                            | PageTableFlags::USER_ACCESSIBLE
+                            | PageTableFlags::WRITABLE,
+                        PageTableFlags::PRESENT
+                            | PageTableFlags::WRITABLE
+                            | PageTableFlags::USER_ACCESSIBLE,
+                    )
+                    .map_err(|_| {
+                        eprintln!("SC> brk({:#X}) = ENOMEM", self.a);
+                        libc::ENOMEM
+                    })?;
+
+                *NEXT_BRK_RWLOCK.write() = virt_addr + (len_aligned as u64);
+
+                eprintln!("SC> brk({:#X}) = {:#X}", self.a, n);
+
+                Ok(n)
+            }
+        }
+    }
+
+    /// Do a ioctl() syscall
+    ///
+    pub fn ioctl(&self) -> Result<usize, libc::c_int> {
+        match (self.a, self.b as i32) {
+            (1, libc::TIOCGWINSZ) | (2, libc::TIOCGWINSZ) => {
+                // simulate TIOCGWINSZ
+                let p: *mut libc::winsize = self.c as _;
+                let winsize = libc::winsize {
+                    ws_row: 40,
+                    ws_col: 80,
+                    ws_xpixel: 0,
+                    ws_ypixel: 0,
+                };
+                unsafe {
+                    p.write_volatile(winsize);
+                }
+                eprintln!("SC> ioctl({}, TIOCGWINSZ, {{ws_row=40, ws_col=80, ws_xpixel=0, ws_ypixel=0}}) = 0", self.a);
+                Ok(0)
+            }
+            _ => Err(libc::EINVAL),
+        }
+    }
+    /// Do a set_tid_address() syscall
+    ///
+    /// This is currently unimplemented and returns a dummy thread id.
+    pub fn set_tid_address(&self) -> Result<usize, libc::c_int> {
+        // FIXME
+        eprintln!("SC> set_tid_address(…) = 1");
+        Ok(1)
+    }
+
+    /// Do a rt_sigaction() syscall
+    ///
+    /// This is currently unimplemented and returns success.
+    pub fn rt_sigaction(&self) -> Result<usize, libc::c_int> {
+        // FIXME
+        eprintln!("SC> rt_sigaction(…) = 0");
+        Ok(0)
+    }
+
+    /// Do a rt_sigaction() syscall
+    ///
+    /// This is currently unimplemented and returns success.
+    pub fn rt_sigprocmask(&self) -> Result<usize, libc::c_int> {
+        // FIXME
+        eprintln!("SC> rt_sigprocmask(…) = 0");
+        Ok(0)
+    }
+
+    /// Do a munmap() syscall
+    ///
+    /// This is currently unimplemented and returns success.
+    pub fn munmap(&self) -> Result<usize, libc::c_int> {
+        // FIXME
+        eprintln!("SC> munmap(…) = 0");
+        Ok(0)
+    }
+
+    /// Do a sigaltstack() syscall
+    ///
+    /// This is currently unimplemented and returns success.
+    pub fn sigaltstack(&self) -> Result<usize, libc::c_int> {
+        // FIXME
+        eprintln!("SC> sigaltstack(…) = 0");
+        Ok(0)
+    }
+
+    /// Do a getrandom() syscall
+    pub fn getrandom(&self) -> Result<usize, libc::c_int> {
+        let flags = self.c as u64;
+        let flags = flags & !((libc::GRND_NONBLOCK | libc::GRND_RANDOM) as u64);
+
+        if flags != 0 {
+            return Err(libc::EINVAL);
+        }
+
+        let trusted =
+            unsafe { core::slice::from_raw_parts_mut(self.a as *mut u8, self.b as usize) };
+
+        for (i, chunk) in trusted.chunks_mut(8).enumerate() {
+            let mut el = 0u64;
+            loop {
+                if unsafe { core::arch::x86_64::_rdrand64_step(&mut el) } == 1 {
+                    chunk.copy_from_slice(&el.to_ne_bytes()[..chunk.len()]);
+                    break;
+                } else {
+                    if (flags & libc::GRND_NONBLOCK as u64) != 0 {
+                        eprintln!("SC> getrandom(…) = -EAGAIN");
+                        return Err(libc::EAGAIN);
+                    }
+                    if (flags & libc::GRND_RANDOM as u64) != 0 {
+                        eprintln!("SC> getrandom(…) = {}", i * 8);
+                        return Ok(i * 8);
+                    }
+                }
+            }
+        }
+        eprintln!("SC> getrandom(…) = {}", trusted.len());
+
+        Ok(trusted.len())
+    }
 }


### PR DESCRIPTION
    Fixes: https://github.com/enarx/enarx/issues/72
    Fixes: https://github.com/enarx/enarx/issues/77

    Related: https://github.com/enarx/enarx/issues/309


With the wasmtime keep-runtime we get:

/home/harald/.cargo/bin/cargo run --color=always --package enarx-keep-sev-shim --bin enarx-keep-sev-shim
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `/home/harald/git/enarx/enarx/enarx-keep-sev-shim/../enarx-keep-sev-test/target/debug/enarx-keep-sev --code ../keep-runtime/target/x86_64-unknown-linux-musl/debug/keep-runtime --shim target/x86_64-unknown-linux-musl/debug/enarx-keep-sev-shim`
SC> mmap(0x0, 1808, …) = 0x0000555500000000
SC> arch_prctl(ARCH_SET_FS, 0x555500000620) = 0
SC> set_tid_address(…) = 337046
SC> rt_sigaction(…) = 0
SC> rt_sigaction(…) = 0
SC> rt_sigprocmask(…) = 0
SC> rt_sigaction(…) = 0
SC> rt_sigaction(…) = 0
SC> rt_sigaction(…) = 0
SC> sigaltstack(…) = 0
SC> brk(0x0) = 0x554500000000
SC> brk(0x554500001000) = 0x554500001000
SC> rt_sigprocmask(…) = 0
SC> rt_sigprocmask(…) = 0
SC> ioctl(2, TIOCGWINSZ, {ws_row=40, ws_col=80, ws_xpixel=0, ws_ypixel=0}) = 0
SC> rt_sigaction(…) = 0
SC> rt_sigaction(…) = 0
SC> rt_sigaction(…) = 0
SC> getrandom(…) = 16
SC> brk(0x554500003000) = 0x554500003000
SC> brk(0x554500006000) = 0x554500006000
SC> brk(0x554500009000) = 0x554500009000
SC> brk(0x55450000A000) = 0x55450000A000
SC> brk(0x55450000B000) = 0x55450000B000
SC> brk(0x55450000C000) = 0x55450000C000
SC> brk(0x55450000D000) = 0x55450000D000
SC> brk(0x55450000E000) = 0x55450000E000
SC> brk(0x55450000F000) = 0x55450000F000
SC> brk(0x554500010000) = 0x554500010000
SC> brk(0x554500011000) = 0x554500011000
SC> brk(0x554500012000) = 0x554500012000
SC> brk(0x554500013000) = 0x554500013000
SC> brk(0x554500014000) = 0x554500014000
SC> brk(0x554500015000) = 0x554500015000
SC> brk(0x554500016000) = 0x554500016000
SC> brk(0x554500017000) = 0x554500017000
SC> brk(0x554500018000) = 0x554500018000
SC> brk(0x554500019000) = 0x554500019000
SC> brk(0x55450001A000) = 0x55450001A000
SC> brk(0x55450001B000) = 0x55450001B000
SC> brk(0x55450001C000) = 0x55450001C000
SC> brk(0x55450001D000) = 0x55450001D000
SC> brk(0x55450001E000) = 0x55450001E000
SC> brk(0x55450001F000) = 0x55450001F000
SC> brk(0x554500020000) = 0x554500020000
SC> brk(0x554500021000) = 0x554500021000
SC> brk(0x554500022000) = 0x554500022000
SC> brk(0x554500023000) = 0x554500023000
SC> brk(0x554500024000) = 0x554500024000
SC> brk(0x554500025000) = 0x554500025000
SC> brk(0x554500026000) = 0x554500026000
SC> brk(0x554500027000) = 0x554500027000
SC> brk(0x554500028000) = 0x554500028000
SC> brk(0x554500029000) = 0x554500029000
SC> brk(0x55450002A000) = 0x55450002A000
SC> mmap(0x0, 65536, …) = 0x0000555500001000
SC> mprotect(0x555500001000, 65536, 5, …) = 0
SC> mmap(0x0, 131072, …) = 0x0000555500011000
SC> mprotect(0x555500011000, 65536, 3, …) = 0
SC> sigaltstack(…) = 0
SC> mmap(0x0, 69632, …) = 0x0000555500031000
SC> mprotect(0x555500032000, 65536, 3, …) = 0
SC> sigaltstack(…) = 0
Hello, world!
SC> munmap(…) = 0
SC> munmap(…) = 0
SC> exit_group(0)
