### PR TITLE
Ease creation of Register and Request objects

### DIFF
--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -4,7 +4,7 @@ use crate::Layout;
 
 use bounds::{Contains, Line, Span};
 use memory::Register;
-use sallyport::{Block, Request};
+use sallyport::{request, Block, Request};
 use sgx_types::ssa::StateSaveArea;
 
 use core::fmt::Write;
@@ -217,7 +217,7 @@ impl<'a> Handler<'a> {
             .unwrap_or_else(|| self.aex.gpr.rdi.raw());
 
         loop {
-            unsafe { self.proxy(Request::new(libc::SYS_exit as usize, &[code.into()])) };
+            unsafe { self.proxy(request!(libc::SYS_exit => code)) };
         }
     }
 
@@ -234,7 +234,7 @@ impl<'a> Handler<'a> {
             .map(|x| x.into())
             .unwrap_or_else(|| self.aex.gpr.rdi.raw());
         loop {
-            unsafe { self.proxy(Request::new(libc::SYS_exit_group as usize, &[code.into()])) };
+            unsafe { self.proxy(request!(libc::SYS_exit_group => code)) };
         }
     }
 
@@ -242,7 +242,7 @@ impl<'a> Handler<'a> {
     pub fn getuid(&mut self) -> u64 {
         self.trace("getuid", 0);
 
-        match unsafe { self.proxy(Request::new(libc::SYS_getuid as usize, &[])) } {
+        match unsafe { self.proxy(request!(libc::SYS_getuid)) } {
             Ok(res) => res[0].raw() as u64,
             Err(code) => code as u64,
         }

--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -645,19 +645,3 @@ impl<'a> Handler<'a> {
         trusted.len() as u64
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn errno_values() {
-        assert_eq!(-22i64 as u64, -libc::EINVAL as u64);
-        // ERRNO return values are the last 4096 numbers in a u64
-        let ret = -libc::EINVAL as u64;
-        assert_eq!(Some(libc::EINVAL as i64), Some(-(ret as i64)));
-    }
-    #[test]
-    fn syscall_values() {
-        assert_eq!(0u64, libc::SYS_read as u64);
-        assert_eq!(libc::SYS_read, 0i64 as i64);
-    }
-}

--- a/enarx-keep-sgx-shim/src/heap.rs
+++ b/enarx-keep-sgx-shim/src/heap.rs
@@ -200,12 +200,3 @@ impl Heap {
         0
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn const_values() {
-        assert_eq!(1u64, libc::PROT_READ as u64);
-        assert_eq!(1u64 as libc::c_int, libc::PROT_READ);
-    }
-}

--- a/memory/src/register.rs
+++ b/memory/src/register.rs
@@ -131,9 +131,15 @@ macro_rules! implfrom {
 }
 
 implfrom! {
-    u8:i8       [u16:i16 u32:i32 u64:i64 u128:i128],
-    u16:i16     [u32:i32 u64:i64 u128:i128],
-    u32:i32     [u64:i64 u128:i128],
+    u8:i8       [u16:i16 u32:i32 u64:i64 u128:i128 usize:isize],
+    u16:i16     [u32:i32 u64:i64 u128:i128 usize:isize],
+
+    #[cfg(target_pointer_width = "64")]
+    u32:i32     [u64:i64 u128:i128 usize:isize],
+
+    #[cfg(target_pointer_width = "32")]
+    u32:i32     [u64:i64 u128:i128] usize:isize,
+
     u64:i64     [u128:i128],
     u128:i128   [],
 
@@ -204,5 +210,23 @@ impl<T> Register<T> {
     /// Returns the raw value
     pub fn raw(self) -> T {
         self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Register;
+
+    #[test]
+    fn integers() {
+        Register::<usize>::from(0u8);
+        Register::<usize>::from(0u16);
+        Register::<usize>::from(0u32);
+        Register::<usize>::from(0i8);
+        Register::<usize>::from(0i16);
+        Register::<usize>::from(0i32);
+
+        Register::<u64>::from(0usize);
+        Register::<u64>::from(0isize);
     }
 }

--- a/sallyport/src/lib.rs
+++ b/sallyport/src/lib.rs
@@ -59,23 +59,6 @@ pub struct Request {
 }
 
 impl Request {
-    /// Create a new request
-    #[inline]
-    pub fn new(num: impl Into<Register<usize>>, arg: &[Register<usize>]) -> Self {
-        Self {
-            num: num.into(),
-            arg: [
-                arg.get(0).copied().unwrap_or_default(),
-                arg.get(1).copied().unwrap_or_default(),
-                arg.get(2).copied().unwrap_or_default(),
-                arg.get(3).copied().unwrap_or_default(),
-                arg.get(4).copied().unwrap_or_default(),
-                arg.get(5).copied().unwrap_or_default(),
-                arg.get(6).copied().unwrap_or_default(),
-            ],
-        }
-    }
-
     /// Issues the requested syscall and returns the reply
     ///
     /// # Safety


### PR DESCRIPTION
Note that we only convert `mut` pointers and references to `Register` to avoid discarding `const`, which would be unsafe. If we need a conversion for this in the future, we can add one.