### PR TITLE
Proxy syscalls with sallyport

### DIFF
--- a/enarx-keep-sev/Cargo.toml
+++ b/enarx-keep-sev/Cargo.toml
@@ -16,6 +16,7 @@ libc = "0.2.71"
 loader = { path = "../loader" }
 memory = { path = "../memory" }
 mmap = { path = "../mmap" }
+sallyport = { path = "../sallyport" }
 structopt = "0.3"
 units = { path = "../units" }
 x86_64 = { version = "0.11.0", default-features = false, features = ["stable"] }

--- a/enarx-keep-sev/src/vm/builder.rs
+++ b/enarx-keep-sev/src/vm/builder.rs
@@ -263,6 +263,7 @@ impl Builder<Code> {
             fd: self.data.fd.unwrap(),
             address_space: self.data.address_space.unwrap(),
             cpus: vec![],
+            sallyport: VirtAddr::new(&host_setup.shared_page as *const _ as _),
         };
 
         // Create startup CPU

--- a/enarx-keep-sev/src/vm/syscall.rs
+++ b/enarx-keep-sev/src/vm/syscall.rs
@@ -22,10 +22,13 @@ mod param {
     pub const R9: usize = 5;
 }
 
+use param::RSI;
+
 /// Get the fixup table for a given syscall number, if any.
 #[inline]
 fn syscall_fixup_table(syscall: libc::c_long) -> Option<SyscallFixup> {
     match syscall {
+        libc::SYS_write => Some(&[RSI]),
         _ => None,
     }
 }

--- a/enarx-keep-sev/src/vm/syscall.rs
+++ b/enarx-keep-sev/src/vm/syscall.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/// Some system call parameters contain pointers to userspace memory (such as the `write` syscall).
+/// These values are *guest physical addresses*, so they must be "fixed up" to be *host virtual
+/// addresses* so that the host can transparently proxy the syscall.
+///
+/// The `SyscallFixup` type contains a slice of integers that correspond to an index within the
+/// `sallyport::Request.args` array. So, for a given `SyscallFixup` table, each index indicated
+/// by the `SyscallFixup` table *must* be modified to be a host virtual address in order to
+/// successfully proxy the syscall.
+///
+/// Some syscalls won't require any fixups and not all syscalls will use the same fixups.
+type SyscallFixup = &'static [usize];
+
+#[allow(dead_code)]
+mod param {
+    pub const RDI: usize = 0;
+    pub const RSI: usize = 1;
+    pub const RDX: usize = 2;
+    pub const R10: usize = 3;
+    pub const R8: usize = 4;
+    pub const R9: usize = 5;
+}
+
+/// Get the fixup table for a given syscall number, if any.
+#[inline]
+fn syscall_fixup_table(syscall: libc::c_long) -> Option<SyscallFixup> {
+    match syscall {
+        _ => None,
+    }
+}
+
+pub fn syscall(mut req: sallyport::Request, offset: u64) -> sallyport::Reply {
+    if let Some(fixups) = syscall_fixup_table(req.num.raw() as _) {
+        for fixup in fixups {
+            let guest = req.arg[*fixup];
+            let host = guest.raw() + (offset as usize);
+            req.arg[*fixup] = memory::Register::from_raw(host);
+        }
+    }
+
+    unsafe { req.syscall() }
+}


### PR DESCRIPTION
Closes #313 

Last patchset before I incorporate it on top of the backend framework

```
$ ./enarx-keep-sev/target/debug/enarx-keep-sev \
    --shim ./enarx-keep-sev-shim/target/x86_64-unknown-linux-musl/debug/enarx-keep-sev-shim \
    --code ./payload/target/x86_64-unknown-linux-musl/debug/payload
init_gdt
Hello World!
```