### PR TITLE
Ignore VSCode configs and add rust-src for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 Cargo.lock
 target/
 .idea/
+.vscode/
+.devcontainer/
+*.code-workspace

--- a/containers/fedora/Dockerfile
+++ b/containers/fedora/Dockerfile
@@ -26,7 +26,7 @@ RUN dnf -y install mscgen graphviz
 # Install Rust via rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q
 RUN rustup target add x86_64-unknown-linux-musl
-RUN rustup component add rustfmt rls clippy
+RUN rustup component add rustfmt rls clippy rust-src
 
 # Install binary crates
 RUN cargo install --force cargo-make


### PR DESCRIPTION
I spent some time today setting up development environment on my Mac, which using VS Code Remote to [connect to a linux container in Docker](https://code.visualstudio.com/docs/remote/containers). I used [this Dockerfile](https://github.com/enarx/enarx/blob/7dd05db8415039ca4678bc26ccce9f95b0610572/containers/fedora/Dockerfile) as the dev container and I added `rust-src` components for `rust-analyzer` setup. Here is the commit (https://github.com/ziyi-yan/enarx/commit/890eef53411319fa80c6a39930dd95e6086efcca).

But, I’m not sure whether we need to add this configuration files into our repo (Although I’m glad to write a tutorial for Mac dev environment setup :smile:). If that’s not the case, I want to merge this PR for ignoring these configs and add `rust-src` in dev container, which `rust-analyzer` required.