### PR TITLE
Add KVM backend detection (kvm-show)

### DIFF
--- a/enarx-keep/Cargo.toml
+++ b/enarx-keep/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 sallyport = { path = "../sallyport" }
 sgx-types = { path = "../sgx-types" }
 bounds = { path = "../bounds" }
+kvm-ioctls = "0.5.0"
 memory = { path = "../memory" }
 mmap = { path = "../mmap" }
 structopt = "0.3"

--- a/enarx-keep/src/backend/kvm.rs
+++ b/enarx-keep/src/backend/kvm.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::backend::{self, Datum, Keep};
+use crate::binary::Component;
+
+use kvm_ioctls::Kvm;
+
+use std::io::Result;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn dev_kvm() -> Datum {
+    let dev_kvm = std::path::Path::new("/dev/kvm");
+
+    Datum {
+        name: "Driver".into(),
+        pass: dev_kvm.exists(),
+        info: Some("/dev/kvm".into()),
+        mesg: None,
+    }
+}
+
+fn kvm_version() -> Datum {
+    let version = Kvm::new().and_then(|kvm| Ok(kvm.get_api_version()));
+    let (pass, info) = match version {
+        Ok(v) => (v == 12, Some(v.to_string())),
+        Err(_) => (false, None),
+    };
+    Datum {
+        name: " API Version".into(),
+        pass,
+        info,
+        mesg: None,
+    }
+}
+
+pub struct Backend;
+
+impl backend::Backend for Backend {
+    fn data(&self) -> Vec<Datum> {
+        vec![dev_kvm(), kvm_version()]
+    }
+
+    fn shim(&self) -> Result<PathBuf> {
+        unimplemented!()
+    }
+
+    fn build(&self, _shim: Component, _code: Component) -> Result<Arc<dyn Keep>> {
+        unimplemented!()
+    }
+}

--- a/enarx-keep/src/backend/mod.rs
+++ b/enarx-keep/src/backend/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod kvm;
 pub mod sgx;
 
 use std::io::Result;

--- a/enarx-keep/src/main.rs
+++ b/enarx-keep/src/main.rs
@@ -43,6 +43,7 @@ enum Options {
 fn main() -> Result<()> {
     let mut backends = HashMap::<String, Box<dyn Backend>>::new();
 
+    backends.insert("kvm".into(), Box::new(backend::kvm::Backend));
     backends.insert("sgx".into(), Box::new(backend::sgx::Backend));
 
     match Options::from_args() {


### PR DESCRIPTION
I intend to port the enarx-keep-sev "bare" VMM implementation onto this backend. The actual SEV-enabled VMM implementation will extend this backend with the SEV API, of course.

I've left this unlabeled since it's not _technically_ SEV but it is the groundwork for that.