### PR TITLE
Allow multiple Cursors::alloc's in the same block

### DIFF
--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -289,7 +289,7 @@ impl<'a> Handler<'a> {
         let input: &[u8] = unsafe { self.aex.gpr.rsi.as_slice(self.aex.gpr.rdx.into()) };
 
         // Copy the encrypted input into unencrypted memory.
-        let mut cursor = self.block.cursor();
+        let cursor = self.block.cursor();
         let untrusted = match cursor.copy_slice(input).or(Err(libc::EMSGSIZE)) {
             Ok(slice) => slice,
             Err(e) => return -e as u64,

--- a/sallyport/src/lib.rs
+++ b/sallyport/src/lib.rs
@@ -306,3 +306,28 @@ mod tests {
         assert_eq!(&slice, &[87, 2, 3]);
     }
 }
+
+#[test]
+fn cursor_multiple_allocs() {
+    let mut block = Block::default();
+
+    let mut c = block.cursor();
+    assert_eq!(
+        unsafe { c.alloc::<usize>(42usize) }
+            .expect("allocating slab of 42 usize values the first time")
+            .len(),
+        42
+    );
+    assert_eq!(
+        unsafe { c.alloc::<usize>(42usize) }
+            .expect("allocating slab of 42 usize values the second time")
+            .len(),
+        42
+    );
+    assert_eq!(
+        unsafe { c.alloc::<usize>(42usize) }
+            .expect("allocating slab of 42 usize values the third time")
+            .len(),
+        42
+    );
+}


### PR DESCRIPTION
I hope for this PR to add the required functionality in the least intrusive way to the rest of the codebase. Whether that's achievable, I guess we'll see, but that's my goal anyhow. Also, since one way or another, we'll probably need to use an unsafe primitive to store the buffer of memory in, we'll need to be careful about the abstraction on top of it to be safe avoiding potential use-after-free, or aliasing, etc. Either way, any and all input @npmccallum and @lkatalin is most welcome here! Oh, and feel free to push to this branch as well if you feel the need!

TODO:
- [x] add simple test case demonstrating and testing that it works
- [x] redesign using an unsafe primitive (such as `UnsafeCell`) with safe abstractions applied over it

---

@npmccallum & @lkatalin I think this is ready for review. Here's the break up of the changes:
* `Cursor` now stores the mutable reference to the `Block`'s internal buffer inside an `UnsafeCell` to allow for interior mutability of `Cursor`'s method such as `alloc`. In general, `UnsafeCell` doesn't protect from memory aliasing, however, in this case, since `Cursor` only ever allocates non-overlapping, increasing chunks of memory, memory aliasing within the `Cursor` is not a problem.
* `Block::cursor` method remains behind a mutable reference which in this case protects us from memory aliasing between multiple `Cursor`s that are in-scope. An example of such behaviour would be:

```rust
let c1 = block.cursor();
let slab1 = unsafe { c1.alloc::<usize>(1).unwrap() };

let c2 = block.cursor();
let slab2 = unsafe { c2.alloc::<usize>(1).unwrap() };

slab1.copy_from_slice(&[1]); // this will correctly generate a compiler error
                             // since we're trying to refer to the buffer using
                             // c1 which cannot be in scope when another
                             // mutable reference, in this case c2, is in scope
```