### PR TITLE
Fix compiler warnings

### DIFF
--- a/enarx-keep-sev-shim/src/hostcall.rs
+++ b/enarx-keep-sev-shim/src/hostcall.rs
@@ -134,7 +134,7 @@ impl<'a> HostCall<'a> {
     ///
     /// The parameters returned can't be trusted.
     pub unsafe fn write(&mut self, fd: usize, bytes: &[u8]) -> Result<libc::c_int, libc::c_int> {
-        let mut cursor = self.0.cursor();
+        let cursor = self.0.cursor();
         let buf = cursor.copy_slice(bytes).or(Err(libc::EMSGSIZE))?;
 
         let buf_address = Address::from(buf.as_ptr());

--- a/enarx-keep-sev-shim/src/main.rs
+++ b/enarx-keep-sev-shim/src/main.rs
@@ -28,7 +28,6 @@ use core::convert::TryFrom;
 use enarx_keep_sev_shim::BootInfo;
 use hostcall::HostCall;
 use memory::{Address, Page};
-use x86_64::instructions::hlt;
 use x86_64::VirtAddr;
 
 /// Defines the entry point function.
@@ -95,6 +94,6 @@ pub fn panic(info: &core::panic::PanicInfo) -> ! {
     unsafe { _enarx_asm_triple_fault() };
     // in case the triple fault did not cause a shutdown
     loop {
-        hlt()
+        x86_64::instructions::hlt()
     }
 }


### PR DESCRIPTION
Recent changes to `sallyport::Cursor` mean that it no longer needs to be mutable.

I didn't dig into why, but having a `use x86_64::instructions::hlt;` at the top emits a warning, but removing it results in a compiler error because then the compiler doesn't know what `hlt()` is. Using the fully resolved name at the call site removes the warning.