### PR TITLE
Make issue templates more consistent with sprints

### DIFF
--- a/.github/ISSUE_TEMPLATE/mentorship.md
+++ b/.github/ISSUE_TEMPLATE/mentorship.md
@@ -8,13 +8,26 @@ assignees: ''
 
 ---
 
+<!--
+If you're new to the project, welcome!
+
+All new issues will be discussed and organized during triage, at our standup.
+Feel free to attend the next scheduled one after you submit yours if you'd like
+to discuss it; for more information, see our wiki:
+https://github.com/enarx/enarx/wiki
+-->
+
 **About**
-Tell us a bit about yourself! How did you find the project? What's your favorite IT Crowd episode? etc.
+<!--Tell us a bit about yourself! How did you find the project? What's your
+favorite IT Crowd episode? etc.-->
 
 **Skills**
+<!--
 Tell us a bit about your background: what skills you have, relevant prior
 experience, etc. Don't copy-paste your entire resume -- this is not an
 interview! We just need enough to get the ball rolling.
+-->
 
 **Interest areas**
-Are there any particular parts of the project you would like to contribute to?
+<!--Are there any particular parts of the project you would like to contribute 
+to?-->

--- a/.github/ISSUE_TEMPLATE/meta.md
+++ b/.github/ISSUE_TEMPLATE/meta.md
@@ -8,12 +8,24 @@ assignees: ''
 
 ---
 
+<!--
+If you're new to the project, welcome!
+
+All new issues will be discussed and organized during triage, at our standup.
+Feel free to attend the next scheduled one after you submit yours if you'd like
+to discuss it; for more information, see our wiki:
+https://github.com/enarx/enarx/wiki
+-->
+
 **Description**
+<!--
 What needs to be improved? What should be done? Has there been any related work before? Any relevant links or material?
 
 Feel free to be verbose. These issues are meant to facilitate conversations.
+-->
 
 **To do**
+<!--
 List the tasks that need to be completed using checkboxes. If there are relevant issues, please include them as well.
 
 You may also use emojis to concisely express certain attributes:
@@ -28,10 +40,4 @@ Here's an example of how you should format this list:
 - [ ] Watch the IT Crowd
     - [ ] :trident: Put this over with the rest of the fire 
     - [ ] :trident: :exclamation: Turn it off and on again (#abc)
-
-**Organization**
-If you have the appropriate repo permissions, please don't forget:
-- Properly label your issue and place it in the appropriate project.
-- If you assign yourself or someone else, please ensure the project status is updated to "Assigned".
-
-Finally, please delete any template boilerplate before submitting!
+    -->

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -7,5 +7,15 @@ assignees: ''
 
 ---
 
+<!--
+If you're new to the project, welcome!
+
+All new issues will be discussed and organized during triage, at our standup.
+Feel free to attend the next scheduled one after you submit yours if you'd like
+to discuss it; for more information, see our wiki:
+https://github.com/enarx/enarx/wiki
+-->
+
 **Question**
-What are you wondering about? Provide as much detail as you feel is necessary. We'll try and answer within our abilities to do so!
+<!--What are you wondering about? Provide as much detail as you feel is
+necessary. We'll try and answer within our abilities to do so!-->

--- a/.github/ISSUE_TEMPLATE/technical.md
+++ b/.github/ISSUE_TEMPLATE/technical.md
@@ -8,12 +8,17 @@ assignees: ''
 
 ---
 
+<!--
+If you're new to the project, welcome!
+
+All new issues will be discussed and organized during triage, at our standup.
+Feel free to attend the next scheduled one after you submit yours if you'd like
+to discuss it; for more information, see our wiki:
+https://github.com/enarx/enarx/wiki
+-->
+
 **Description**
-What needs to be improved? What should be done? Has there been any related work before? Any relevant links or material?
 
-**Organization**
-If you have the appropriate repo permissions, please don't forget:
-- Properly label your issue and place it in the appropriate project.
-- If you assign yourself or someone else, please ensure the project status is updated to "Assigned".
-
-Finally, please delete any template boilerplate before submitting!
+<!--What needs to be improved? What should be done? Has there been any related work
+before? Any relevant links or material?
+-->


### PR DESCRIPTION
- Use Markdown comments to cut down on boilerplate accidentally making it through
- Include a brief welcome message explaining that new issues will be triaged at the next standup, and include a link for more information
- Remove guidance on issue tagging/assignment (no longer needed with triage)