### PR TITLE
sev: update kvm-bindings

### DIFF
--- a/enarx-keep-sev/Cargo.toml
+++ b/enarx-keep-sev/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 bounds = { path = "../bounds" }
 enarx-keep-sev-shim = { path = "../enarx-keep-sev-shim" }
-kvm-bindings = "0.2.0"
+kvm-bindings = "0.3.0"
 kvm-ioctls = "0.5.0"
 libc = "0.2.71"
 loader = { path = "../loader" }


### PR DESCRIPTION
Otherwise

```console
error[E0432]: unresolved import `kvm_bindings::KVM_MAX_CPUID_ENTRIES`
  --> src/vm/mod.rs:10:5
   |
10 | use kvm_bindings::KVM_MAX_CPUID_ENTRIES;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `KVM_MAX_CPUID_ENTRIES` in the root

error[E0308]: mismatched types
   --> src/vm/builder.rs:125:39
    |
125 |             fd.set_user_memory_region(region)?;
    |                                       ^^^^^^ expected struct `kvm_bindings::x86::bindings_v4_20_0::kvm_userspace_memory_region`, found a different struct `kvm_bindings::x86::bindings_v4_20_0::kvm_userspace_memory_region`
    |
    = note: perhaps two different versions of crate `kvm_bindings` are being used?

error[E0308]: mismatched types
  --> src/vm/cpu.rs:41:16
   |
41 |     sregs.cs = cs;
   |                ^^ expected struct `kvm_bindings::x86::bindings_v4_20_0::kvm_segment`, found a different struct `kvm_bindings::x86::bindings_v4_20_0::kvm_segment`
   |
   = note: perhaps two different versions of crate `kvm_bindings` are being used?

error: aborting due to 3 previous errors

```