### PR TITLE
Fix a crasher in SGX

### DIFF
--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -351,7 +351,7 @@ impl<'a> Handler<'a> {
             self.aex.gpr.rsi.into(),
             self.aex.gpr.rdx.try_into().or(Err(libc::EINVAL))?,
             self.aex.gpr.r10.try_into().or(Err(libc::EINVAL))?,
-            self.aex.gpr.r8.try_into().or(Err(libc::EINVAL))?,
+            usize::from(self.aex.gpr.r8) as _, // Allow truncation!
             self.aex.gpr.r9.into(),
         )?;
 


### PR DESCRIPTION
When libc does its own internal initialization, it calls mmap(). It assumes
this mmap() will succeed and crashes if it fails. The reason that mmap() was
failing was because libc passed -1 as the file descriptor.  However, our
attempt to use a TryInto conversion would fail because it required truncation.
This caused mmap() to return EINVAL.