### PR TITLE
Add better failure reporting in integration tests

### DIFF
--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -106,8 +106,20 @@ impl IntegrationTest {
             .wait_with_output()
             .expect("Failed to read stdout/stderr");
 
-        assert_eq!(stdout.as_ref(), output.stdout.as_slice());
-        assert_eq!(stderr.as_ref(), output.stderr.as_slice());
+        assert_stdio(stdout, output.stdout);
+        assert_stdio(stderr, output.stderr);
         assert_eq!(exit_status, ecode.unwrap());
     }
+}
+
+fn assert_stdio(lhs: impl AsRef<[u8]>, rhs: impl AsRef<[u8]>) {
+    let lhs_str = String::from_utf8_lossy(lhs.as_ref());
+    let rhs_str = String::from_utf8_lossy(rhs.as_ref());
+    assert_eq!(
+        lhs.as_ref(),
+        rhs.as_ref(),
+        "\n\nEXPECTED:\n\n{}\n\nGIVEN\n\n{}\n\n",
+        lhs_str,
+        rhs_str
+    );
 }


### PR DESCRIPTION
This commit tweaks the standard `assert_eq`s in `integration-tests`
so that instead of only dumping the raw bytes when asserting equality
between expected and given stdio outputs, it now also prints the
mismatch converted to a UTF8 string for easier debugging. The conversion
is lossy so that invalid UTF8 don't trigger false positives in our
testing harness.