### PR TITLE
Expand setup area to accommodate CPU hotplug

### DIFF
--- a/enarx-keep-sev-shim/src/lib.rs
+++ b/enarx-keep-sev-shim/src/lib.rs
@@ -79,7 +79,7 @@ fn above(rel: impl Into<Line<usize>>, size: usize) -> Option<Span<usize>> {
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct BootInfo {
     /// Memory for the loader to place page tables, GDT and IDT and the
-    /// shared page
+    /// shared pages
     pub setup: Line<usize>,
     /// Memory where the `code` is / has to be loaded
     pub code: Line<usize>,

--- a/enarx-keep-sev/Cargo.toml
+++ b/enarx-keep-sev/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 bounds = { path = "../bounds" }
 enarx-keep-sev-shim = { path = "../enarx-keep-sev-shim" }
+sallyport = { path = "../sallyport" }
 kvm-bindings = "0.3.0"
 kvm-ioctls = "0.5.0"
 libc = "0.2.71"

--- a/enarx-keep-sev/src/main.rs
+++ b/enarx-keep-sev/src/main.rs
@@ -15,6 +15,7 @@ use loader::Component;
 use structopt::StructOpt;
 
 use std::io;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 #[derive(StructOpt, Debug)]
@@ -44,8 +45,9 @@ fn run(args: Args) -> Result<(), io::Error> {
     let code = Component::from_path(&args.code)?;
 
     let vm = vm::Builder::<New>::new()?
+        .with_max_cpus(NonZeroUsize::new(256).unwrap())?
         .with_mem_size(units::bytes![1; GiB])?
-        .component_sizes(shim.region(), code.region())?
+        .calculate_layout(shim.region(), code.region())?
         .load_shim(shim)?
         .load_code(code)?
         .build()?;

--- a/enarx-keep-sev/src/vm/mem.rs
+++ b/enarx-keep-sev/src/vm/mem.rs
@@ -1,18 +1,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::x86_64::VMSetup;
+
 use bounds::Span;
 pub use kvm_bindings::kvm_userspace_memory_region as KvmUserspaceMemoryRegion;
+use memory::Page;
 use mmap::Unmap;
+use x86_64::structures::paging::page_table::PageTable;
 use x86_64::VirtAddr;
 
+use std::mem::size_of_val;
+use std::slice::from_raw_parts_mut;
+
 pub struct Region {
+    num_sally_pages: usize,
     kvm_region: KvmUserspaceMemoryRegion,
     _backing: Unmap,
 }
 
 impl Region {
-    pub fn new(kvm_region: KvmUserspaceMemoryRegion, backing: Unmap) -> Self {
+    pub fn new(
+        num_sally_pages: usize,
+        kvm_region: KvmUserspaceMemoryRegion,
+        backing: Unmap,
+    ) -> Self {
         Self {
+            num_sally_pages,
             kvm_region,
             _backing: backing,
         }
@@ -22,6 +35,29 @@ impl Region {
         Span {
             start: VirtAddr::new(self.kvm_region.userspace_addr),
             count: self.kvm_region.memory_size,
+        }
+    }
+
+    pub fn prefix_mut(&self) -> VMSetup<'_> {
+        let mut dst = self.as_virt().start;
+
+        let zero = unsafe { &mut *dst.as_mut_ptr::<Page>() };
+        dst += size_of_val(zero);
+
+        let shared = unsafe { from_raw_parts_mut(dst.as_mut_ptr::<Page>(), self.num_sally_pages) };
+        dst += size_of_val(shared);
+
+        let pml4t = unsafe { &mut *dst.as_mut_ptr::<PageTable>() };
+        dst += size_of_val(pml4t);
+
+        let pml3t_ident = unsafe { &mut *dst.as_mut_ptr::<PageTable>() };
+        dst += size_of_val(pml3t_ident);
+
+        VMSetup {
+            zero,
+            shared_pages: shared,
+            pml4t,
+            pml3t_ident,
         }
     }
 }

--- a/enarx-keep-sev/src/vm/mod.rs
+++ b/enarx-keep-sev/src/vm/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod builder;
 mod cpu;
-mod mem;
+pub mod mem;
 
 pub use builder::Builder;
 use mem::Region;

--- a/enarx-keep-sev/src/x86_64.rs
+++ b/enarx-keep-sev/src/x86_64.rs
@@ -4,21 +4,25 @@ pub use kvm_bindings::kvm_segment as KvmSegment;
 use memory::Page;
 use x86_64::structures::paging::page_table::PageTable;
 
+use std::mem::size_of_val;
+
 #[repr(C)]
-pub struct VMSetup {
-    pub zero_page: Page,
-    pub shared_page: Page,
-    pub pml4t: PageTable,
-    pub pml3t_ident: PageTable,
+pub struct VMSetup<'a> {
+    pub zero: &'a mut Page,
+    pub shared_pages: &'a mut [Page],
+    pub pml4t: &'a mut PageTable,
+    pub pml3t_ident: &'a mut PageTable,
 }
 
-impl Default for VMSetup {
-    fn default() -> Self {
-        VMSetup {
-            zero_page: Page::default(),
-            shared_page: Page::default(),
-            pml4t: PageTable::new(),
-            pml3t_ident: PageTable::new(),
-        }
+impl VMSetup<'_> {
+    pub fn size(&self) -> usize {
+        let addends = [
+            size_of_val(self.zero),
+            size_of_val(self.shared_pages),
+            size_of_val(self.pml4t),
+            size_of_val(self.pml3t_ident),
+        ];
+
+        addends.iter().sum()
     }
 }


### PR DESCRIPTION
This way a CPU's sallyport block can be indexed into with its processor ID. This should allow me to remove the special-case construction of cpu0 in my other PR #722, so I will rebase that one on top of this one.