### PR TITLE
sev-shim: Implement `allocate_and_map_memory()` and allocate the shim stack

### DIFF
--- a/enarx-keep-sev-shim/src/addr.rs
+++ b/enarx-keep-sev-shim/src/addr.rs
@@ -7,7 +7,7 @@
 /// physical address + `SHIM_VIRT_OFFSET` = shim virtual address
 ///
 /// FIXME: change to dynamic offset with ASLR https://github.com/enarx/enarx/issues/624
-const SHIM_VIRT_OFFSET: u64 = 0xFFFF_FF80_0000_0000;
+pub const SHIM_VIRT_OFFSET: u64 = 0xFFFF_FF80_0000_0000;
 
 use core::convert::TryFrom;
 use memory::Address;
@@ -43,7 +43,22 @@ impl<U> TryFrom<Address<u64, U>> for ShimVirtAddr<U> {
     }
 }
 
+impl<U> From<ShimVirtAddr<U>> for *const U {
+    #[inline(always)]
+    fn from(shim_virt_addr: ShimVirtAddr<U>) -> Self {
+        shim_virt_addr.0.raw() as _
+    }
+}
+
+impl<U> From<ShimVirtAddr<U>> for *mut U {
+    #[inline(always)]
+    fn from(shim_virt_addr: ShimVirtAddr<U>) -> Self {
+        shim_virt_addr.0.raw() as _
+    }
+}
+
 impl<U> From<ShimVirtAddr<U>> for ShimPhysAddr<U> {
+    #[inline(always)]
     fn from(shim_virt_addr: ShimVirtAddr<U>) -> Self {
         // Safety: checked, that it is in the shim virtual address space earlier
         #[allow(clippy::integer_arithmetic)]
@@ -52,6 +67,7 @@ impl<U> From<ShimVirtAddr<U>> for ShimPhysAddr<U> {
 }
 
 impl<U> From<ShimVirtAddr<U>> for Address<u64, U> {
+    #[inline(always)]
     fn from(shim_virt_addr: ShimVirtAddr<U>) -> Self {
         shim_virt_addr.0
     }

--- a/enarx-keep-sev-shim/src/frame_allocator.rs
+++ b/enarx-keep-sev-shim/src/frame_allocator.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! The global FrameAllocator
+use crate::BOOT_INFO;
+use memory::Page as Page4KiB;
+use memory::{Address, Offset};
+use spinning::RwLock;
+use x86_64::structures::paging::{
+    self, Mapper, Page, PageSize, PageTableFlags, PhysFrame, Size2MiB, Size4KiB,
+};
+use x86_64::{align_down, PhysAddr, VirtAddr};
+
+/// An aligned 2MiB Page
+///
+/// The `x86_64::structures::paging::Page<S>` is not aligned, so we use
+/// memory::Page as Page4KiB and this Page2MiB
+#[derive(Copy, Clone)]
+#[repr(C, align(0x200000))]
+#[allow(clippy::integer_arithmetic)]
+pub struct Page2MiB([u8; units::bytes![2; MiB]]);
+
+lazy_static! {
+    /// The global ShimFrameAllocator RwLock
+    pub static ref FRAME_ALLOCATOR: RwLock<FrameAllocator> = {
+        RwLock::<FrameAllocator>::const_new(
+            spinning::RawRwLock::const_new(),
+            unsafe { FrameAllocator::new() },
+        )
+    };
+}
+
+/// A frame allocator
+pub struct FrameAllocator {
+    max: usize,
+    next_page: Address<usize, Page4KiB>,
+    next_huge_page: Address<usize, Page2MiB>,
+}
+
+impl core::fmt::Debug for FrameAllocator {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+        f.debug_struct("ShimFrameAllocator")
+            .field("max", &format_args!("{:#?}", self.max as *const u8))
+            .field(
+                "next_page",
+                &format_args!("{:#?}", self.next_page.raw() as *const u8),
+            )
+            .field(
+                "next_huge_page",
+                &format_args!("{:#?}", self.next_huge_page.raw() as *const u8),
+            )
+            .finish()
+    }
+}
+
+impl FrameAllocator {
+    unsafe fn new() -> Self {
+        let boot_info = BOOT_INFO.read().unwrap();
+        let start = Address::from(boot_info.code.end);
+        FrameAllocator {
+            max: boot_info.mem_size,
+            next_page: start.raise(),
+            next_huge_page: start.raise(),
+        }
+    }
+
+    #[inline(always)]
+    fn do_allocate_and_map_memory<S: PageSize>(
+        frame_allocator: &mut (impl paging::FrameAllocator<S> + paging::FrameAllocator<Size4KiB>),
+        map_to: &[Page<S>],
+        mapper: &mut impl Mapper<S>,
+        flags: PageTableFlags,
+        parent_flags: PageTableFlags,
+    ) -> Result<(), ()> {
+        if map_to.is_empty() {
+            return Ok(());
+        }
+        let size = map_to
+            .len()
+            .checked_mul(Page::<S>::SIZE as usize)
+            .ok_or(())?;
+
+        let page_range = {
+            let start = VirtAddr::from_ptr(map_to.as_ptr());
+            let end = start + size - 1u64;
+            let start_page = Page::<S>::containing_address(start);
+            let end_page = Page::<S>::containing_address(end);
+            Page::range_inclusive(start_page, end_page)
+        };
+
+        for page in page_range {
+            let frame = frame_allocator.allocate_frame().ok_or(())?;
+
+            unsafe {
+                mapper
+                    .map_to_with_table_flags(page, frame, flags, parent_flags, frame_allocator)
+                    .map_err(|_| ())?
+                    .flush();
+            }
+        }
+        Ok(())
+    }
+
+    /// Allocate memory and map it to the given virtual address
+    pub fn allocate_and_map_memory(
+        &mut self,
+        mapper: &mut (impl Mapper<Size4KiB> + Mapper<Size2MiB>),
+        map_to: VirtAddr,
+        size: usize,
+        flags: PageTableFlags,
+        parent_flags: PageTableFlags,
+    ) -> Result<&'static mut [u8], ()> {
+        if size == 0 {
+            return Err(());
+        }
+
+        if !map_to.is_aligned(Page::<Size4KiB>::SIZE) {
+            return Err(());
+        }
+
+        if size != align_down(size as _, Page::<Size4KiB>::SIZE) as usize {
+            return Err(());
+        }
+
+        let slice = unsafe {
+            core::slice::from_raw_parts_mut(
+                map_to.as_mut_ptr::<Page4KiB>(),
+                size.checked_div(Page4KiB::size()).ok_or(())?,
+            )
+        };
+
+        // Find the best mix of 4KiB and 2MiB Pages
+        let (pre, middle, post) = unsafe { slice.align_to_mut::<Page2MiB>() };
+
+        let pre: &mut [Page<Size4KiB>] =
+            unsafe { core::slice::from_raw_parts_mut(pre.as_mut_ptr() as *mut Page, pre.len()) };
+
+        let middle: &[Page<Size2MiB>] = unsafe {
+            core::slice::from_raw_parts(middle.as_ptr() as *const Page<Size2MiB>, middle.len())
+        };
+
+        let post: &[Page<Size4KiB>] = unsafe {
+            core::slice::from_raw_parts(post.as_ptr() as *const Page<Size4KiB>, post.len())
+        };
+
+        // Allocate the mix of 4KiB and 2MiB Pages
+        FrameAllocator::do_allocate_and_map_memory(self, &pre, mapper, flags, parent_flags)?;
+        FrameAllocator::do_allocate_and_map_memory(self, &middle, mapper, flags, parent_flags)?;
+        FrameAllocator::do_allocate_and_map_memory(self, &post, mapper, flags, parent_flags)?;
+
+        // transmute the whole thing to one big bytes slice
+        Ok(unsafe { core::slice::from_raw_parts_mut(pre.as_mut_ptr() as *mut u8, size) })
+    }
+
+    /// Map physical memory to the given virtual address
+    pub fn map_memory(
+        &mut self,
+        mapper: &mut (impl Mapper<Size4KiB> + Mapper<Size2MiB>),
+        map_from: PhysAddr,
+        map_to: VirtAddr,
+        size: usize,
+        flags: PageTableFlags,
+        parent_flags: PageTableFlags,
+    ) -> Result<(), ()> {
+        if size == 0 {
+            return Err(());
+        }
+
+        let frame_range_from = {
+            let start = map_from;
+            let end = start + size - 1u64;
+            let start_frame = PhysFrame::<Size4KiB>::containing_address(start);
+            let end_frame = PhysFrame::<Size4KiB>::containing_address(end);
+            PhysFrame::range_inclusive(start_frame, end_frame)
+        };
+
+        let page_range_to = {
+            let start = map_to;
+            let end = start + size - 1u64;
+            let start_page = Page::<Size4KiB>::containing_address(start);
+            let end_page = Page::<Size4KiB>::containing_address(end);
+            Page::range_inclusive(start_page, end_page)
+        };
+
+        for (frame_from, page_to) in frame_range_from.zip(page_range_to) {
+            unsafe {
+                mapper
+                    .map_to_with_table_flags(page_to, frame_from, flags, parent_flags, self)
+                    .map_err(|_| ())?
+                    .flush();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+unsafe impl paging::FrameAllocator<Size4KiB> for FrameAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysFrame> {
+        let frame_address = self.next_page;
+        self.next_page += Offset::from_items(1);
+
+        // if at the start of a 2MiB page, advance to the next free 2MiB
+        if self.next_page.raw() == self.next_page.raise::<Page2MiB>().raw() {
+            self.next_page = self.next_huge_page.raise();
+        }
+
+        if frame_address.raw() >= self.next_huge_page.raw() {
+            // we have taken a bite out of the next 2MiB page
+            // so advance the 2MiB pointer
+            self.next_huge_page += Offset::from_items(1);
+        }
+
+        if self.next_page.raw() > self.max {
+            // OOM
+            return None;
+        }
+
+        Some(PhysFrame::containing_address(PhysAddr::new(
+            frame_address.raw() as _,
+        )))
+    }
+}
+
+unsafe impl paging::FrameAllocator<Size2MiB> for FrameAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<Size2MiB>> {
+        let frame_address = self.next_huge_page;
+        self.next_huge_page += Offset::from_items(1);
+
+        if self.next_huge_page.raw() > self.max {
+            // OOM
+            return None;
+        }
+
+        Some(PhysFrame::containing_address(PhysAddr::new(
+            frame_address.raw() as _,
+        )))
+    }
+}

--- a/enarx-keep-sev-shim/src/paging.rs
+++ b/enarx-keep-sev-shim/src/paging.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Paging
+
+use crate::addr::SHIM_VIRT_OFFSET;
+
+use spinning::RwLock;
+use x86_64::structures::paging::{OffsetPageTable, PageTable};
+use x86_64::VirtAddr;
+
+lazy_static! {
+    /// The global `OffsetPageTable` of the shim
+    pub static ref SHIM_PAGETABLE: RwLock<OffsetPageTable<'static>> = {
+        RwLock::<OffsetPageTable<'static>>::const_new(spinning::RawRwLock::const_new(), unsafe {
+            init()
+        })
+    };
+}
+
+/// Initialize a new OffsetPageTable.
+///
+/// # Safety
+///
+/// This function is unsafe because the caller must guarantee that the
+/// complete physical memory is mapped to virtual memory at the passed
+/// `physical_memory_offset`. Also, this function must be only called once
+/// to avoid aliasing `&mut` references (which is undefined behavior).
+pub unsafe fn init() -> OffsetPageTable<'static> {
+    let physical_memory_offset = VirtAddr::new(SHIM_VIRT_OFFSET as u64);
+    let level_4_table = active_level_4_table(physical_memory_offset);
+    OffsetPageTable::new(level_4_table, physical_memory_offset)
+}
+
+unsafe fn active_level_4_table(physical_memory_offset: VirtAddr) -> &'static mut PageTable {
+    use x86_64::registers::control::Cr3;
+
+    let (level_4_table_frame, _) = Cr3::read();
+
+    let phys = level_4_table_frame.start_address();
+    let virt = physical_memory_offset + phys.as_u64();
+    let page_table_ptr: *mut PageTable = virt.as_mut_ptr();
+
+    &mut *page_table_ptr // unsafe
+}

--- a/enarx-keep-sev-shim/src/shim_stack.rs
+++ b/enarx-keep-sev-shim/src/shim_stack.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper functions for the shim stack
+
+use crate::frame_allocator::FRAME_ALLOCATOR;
+use crate::paging::SHIM_PAGETABLE;
+use crate::{dbg, eprintln};
+use core::ops::{Deref, DerefMut};
+use units::bytes;
+use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
+use x86_64::VirtAddr;
+
+/// The virtual address of the main kernel stack
+pub const SHIM_STACK_START: u64 = 0xFFFF_FF48_4800_0000;
+
+/// The size of the main kernel stack
+#[allow(clippy::integer_arithmetic)]
+pub const SHIM_STACK_SIZE: u64 = bytes![4; MiB];
+
+/// Allocate the stack for the shim with guard pages
+#[allow(clippy::integer_arithmetic)]
+pub fn init_shim_stack() -> VirtAddr {
+    dbg!(FRAME_ALLOCATOR.read().deref());
+
+    // guard page
+    FRAME_ALLOCATOR
+        .write()
+        .allocate_and_map_memory(
+            SHIM_PAGETABLE.write().deref_mut(),
+            VirtAddr::new(SHIM_STACK_START - Page::<Size4KiB>::SIZE),
+            Page::<Size4KiB>::SIZE as _,
+            PageTableFlags::empty(),
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+        )
+        .expect("Stack guard page allocation failed");
+
+    dbg!(FRAME_ALLOCATOR.read().deref());
+
+    let mem_slice = FRAME_ALLOCATOR
+        .write()
+        .allocate_and_map_memory(
+            SHIM_PAGETABLE.write().deref_mut(),
+            VirtAddr::new(SHIM_STACK_START),
+            SHIM_STACK_SIZE as _,
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE,
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+        )
+        .expect("Stack allocation failed");
+
+    dbg!(FRAME_ALLOCATOR.read().deref());
+
+    // guard page
+    FRAME_ALLOCATOR
+        .write()
+        .allocate_and_map_memory(
+            SHIM_PAGETABLE.write().deref_mut(),
+            VirtAddr::new(SHIM_STACK_START + SHIM_STACK_SIZE),
+            Page::<Size4KiB>::SIZE as _,
+            PageTableFlags::empty(),
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+        )
+        .expect("Stack guard page allocation failed");
+
+    dbg!(FRAME_ALLOCATOR.read().deref());
+    // Test, if we can write to it.
+    dbg!(&mem_slice.as_ptr());
+    dbg!(&mem_slice[0]);
+    dbg!(&mem_slice[mem_slice.len() - 1]);
+    mem_slice.iter_mut().for_each(|p| *p = 127);
+    dbg!(&mem_slice[0]);
+    dbg!(&mem_slice[mem_slice.len() - 1]);
+
+    // Point to the end of the stack
+    let stack_ptr = unsafe { mem_slice.as_ptr().offset(SHIM_STACK_SIZE as _) };
+
+    eprintln!("kernel_stack_ptr = {:#?}", stack_ptr);
+
+    // We know it's aligned to 16, so no need to manually align
+    VirtAddr::from_ptr(stack_ptr)
+}


### PR DESCRIPTION


Allocate memory and map it to a given virtual address for the shim stack.