### PR TITLE
Ignore segments with no pages

### DIFF
--- a/enarx-keep-sgx/src/builder.rs
+++ b/enarx-keep-sgx/src/builder.rs
@@ -88,6 +88,11 @@ impl Builder {
         const FLAGS: ioctls::Flags = ioctls::Flags::MEASURE;
 
         for seg in segs {
+            // Ignore segments with no pages.
+            if seg.src.len() == 0 {
+                continue;
+            }
+
             let off = seg.dst - self.mmap.span().start;
 
             // Update the enclave.


### PR DESCRIPTION
Sometimes GCC will produce ELF binaries that have a segment with no pages.
These can be ignored. However, the previous version of this code was trying to
mprotect() on that memory region, which caused errors. Therefore, we should
explicitly skip them.