### PR TITLE
Use sallyport for SGX syscall proxying

### DIFF
--- a/enarx-keep-sgx-shim/src/event.rs
+++ b/enarx-keep-sgx-shim/src/event.rs
@@ -11,6 +11,7 @@ use crate::Layout;
 // Developer's Manual
 const OP_SYSCALL: &[u8] = &[0x0f, 0x05];
 const OP_CPUID: &[u8] = &[0x0f, 0xa2];
+const SYS_ERESUME: usize = !0;
 
 #[no_mangle]
 pub extern "C" fn event(
@@ -98,4 +99,6 @@ pub extern "C" fn event(
             h.attacked();
         }
     }
+
+    block.msg.req.num = SYS_ERESUME.into();
 }

--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -87,7 +87,7 @@ impl<'a> Handler<'a> {
     unsafe fn proxy(&mut self, req: Request) -> sallyport::Result {
         self.block.msg.req = req;
 
-        let ret = syscall(
+        let _ = syscall(
             self.block.msg.req.arg[0].into(), // rdi
             self.block.msg.req.arg[1].into(), // rsi
             self.block.msg.req.arg[2].into(), // rdx
@@ -99,7 +99,6 @@ impl<'a> Handler<'a> {
             self.ctx,
         );
 
-        self.block.msg.rep = Ok([ret.into(), 0usize.into()]).into();
         self.block.msg.rep.into()
     }
 

--- a/enarx-keep-sgx/src/enclave.S
+++ b/enarx-keep-sgx/src/enclave.S
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-#define EENTER  2
-#define ERESUME 3
-
 .macro dpush arg
     push                    \arg
     .cfi_adjust_cfa_offset  8
@@ -46,25 +43,3 @@ eenter:
     dpop    %r15
     ret
     .cfi_endproc
-
-    .text
-    .global handle
-    .type handle, @function
-handle:
-    mov     16(%rsp),   %rax        # %rax = ret parameter
-    cmp     $0,         %rax        # enclave EEXIT
-    je      .Leexit
-    ret
-
-.Leexit:
-    cmp     $~0,        %r11        # Is a syscall?
-    jne     .Lsyscall
-    mov     $ERESUME,   %rax
-    ret
-
-.Lsyscall:
-    mov     %r11,       %rax        # %rax is passed in %r11
-    syscall
-    mov     %rax,       %rdi        # Pass return value in %rdi
-    mov     $EENTER,    %rax        # %rax = EENTER
-    ret

--- a/enarx-keep-sgx/src/enclave.rs
+++ b/enarx-keep-sgx/src/enclave.rs
@@ -7,18 +7,6 @@ use std::mem::MaybeUninit;
 use mmap::Unmap;
 
 extern "C" {
-    fn handle(
-        rdi: usize,
-        rsi: usize,
-        rdx: usize,
-        ursp: usize,
-        r8: usize,
-        r9: usize,
-        tcs: usize,
-        ret: i32,
-        exc: &ExceptionInfo,
-    ) -> i32;
-
     fn eenter(
         rdi: usize,
         rsi: usize,
@@ -28,17 +16,19 @@ extern "C" {
         r9: usize,
         tcs: usize,
         exc: &mut ExceptionInfo,
-        handler: unsafe extern "C" fn(
-            rdi: usize,
-            rsi: usize,
-            rdx: usize,
-            ursp: usize,
-            r8: usize,
-            r9: usize,
-            tcs: usize,
-            ret: i32,
-            exc: &ExceptionInfo,
-        ) -> i32,
+        handler: Option<
+            unsafe extern "C" fn(
+                rdi: usize,
+                rsi: usize,
+                rdx: usize,
+                ursp: usize,
+                r8: usize,
+                r9: usize,
+                tcs: usize,
+                ret: i32,
+                exc: &ExceptionInfo,
+            ) -> i32,
+        >,
         vdso: usize,
     ) -> i32;
 }
@@ -120,7 +110,7 @@ impl Enclave {
 
         let ret = unsafe {
             eenter(
-                rdi, rsi, rdx, leaf, r8, r9, self.tcs, &mut exc, handle, self.fnc,
+                rdi, rsi, rdx, leaf, r8, r9, self.tcs, &mut exc, None, self.fnc,
             )
         };
 


### PR DESCRIPTION
This change removes the `handle()` function passed to the VDSO, instead
handling the process flow in the Keep's `main()`. It also transitions to
using the `sallyport::Block` to proxy system calls.

Related to #614 