### PR TITLE
Run hardware tests on Enarx's Packet.com runners

### DIFF
--- a/.github/workflows/packet.yml
+++ b/.github/workflows/packet.yml
@@ -1,0 +1,18 @@
+name: packet
+
+on: [pull_request]
+
+jobs:
+  # Run the CI suite on each technology
+  cargo-make-integration-sev:
+    runs-on: [self-hosted, linux, sev]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Code passes the continuous integration suite on SEV
+        run: cargo make integration-ci
+  cargo-make-integration-sgx1:
+    runs-on: [self-hosted, linux, sgx1]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Code passes the continuous integration suite on SGX1
+        run: cargo make integration-ci


### PR DESCRIPTION
This adds a workflow that triggers on pull requests that runs `cargo make integration-ci` on each technology supported by our Packet.com servers: SEV and SGX1.

Resolves #736.