### PR TITLE
Tidy up makefile

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Code passes the continuous integration suite
-        run: cargo make ci-project && cargo make ci-flow
+        run: cargo make ci

--- a/.github/workflows/packet.yml
+++ b/.github/workflows/packet.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Code passes the continuous integration suite on SEV
-        run: cargo make integration-ci
+        run: cargo make deep-ci
   cargo-make-integration-sgx1:
     runs-on: [self-hosted, linux, sgx1]
     steps:
       - uses: actions/checkout@v2
       - name: Code passes the continuous integration suite on SGX1
-        run: cargo make integration-ci
+        run: cargo make deep-ci

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -37,7 +37,8 @@ dependencies = ["fork-for-crate-ci-flows", "workspace-ci-flows"]
 [tasks.workspace-ci-flows]
 workspace = false
 dependencies = [
-	"misc-diagrams"
+	"misc-diagrams",
+	"integration",
 ]
 
 # Wrapper task for crate-specific tasks. Using this wrapper
@@ -54,6 +55,39 @@ run_task = { name = "crate-ci-flows", fork = true }
 dependencies = [
 	"ci-flow"
 ]
+
+# Run real code against real Enarx keeps to test various bits
+# and bobs of functionality.
+[tasks.integration]
+workspace = false
+dependencies = [
+	"pre-integration",
+	"integration-test",
+]
+
+# Builds the required crates for the integration tests. You
+# probably want to run the "integration" task, not this one.
+# The "integration" task will invoke this automatically.
+[tasks.pre-integration]
+workspace = false
+env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = ["enarx-keep", "enarx-keep-sgx", "enarx-keep-sgx-shim", "enarx-keep-sev", "enarx-keep-sev-shim"] }
+run_task = { name = "build", fork = true }
+
+# Launches the integration tests. You probably want to run
+# the "integration" task, not this one. The "integration" task
+# will run this automatically once the dependencies have been built.
+[tasks.integration-test]
+workspace = false
+env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = "integration-tests" }
+run_task = { name = "_test", fork = true }
+
+# The integration-tests crate disables the regular "test" target to avoid
+# accidentally misfiring during the regular ci-flows since its dependent
+# targets might not be built and would therefore spuriously fail. You don't
+# want to run this task manually.
+[tasks._test]
+command = "cargo"
+args = ["test"]
 
 [tasks.deny]
 command = "cargo"
@@ -86,21 +120,6 @@ command = "${ENARX_TEST_DIR}/cargo-toml-package-license"
 
 [tasks.misc-licenses-crate]
 command = "${ENARX_TEST_DIR}/misc-licenses-crate"
-
-[tasks.integration]
-workspace = false
-env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = "integration-tests" }
-run_task = { name = "integration-test", fork = true }
-
-[tasks.integration-test]
-command = "cargo"
-args = ["test"]
-
-[tasks.integration-ci]
-workspace = false
-run_task = [
-    { name = ["ci-flow", "integration"], fork = true },
-]
 
 # Add additional tests to the predefined 'ci-flow' target.
 [tasks.pre-ci-flow]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -32,6 +32,21 @@ ENARX_DOCS_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/docs"
 workspace = false
 dependencies = ["fork-for-crate-ci-flows", "workspace-ci-flows"]
 
+# ! WARNING !
+#
+# This target will run a number of tests that will directly
+# manipulate the hardware on the platform you're running on
+# (if equipped). Only invoke this task if you know what
+# you're doing.
+#
+# You probably want the 'ci' task, not this one.
+[tasks.deep-ci]
+workspace = false
+dependencies = [
+	"fork-for-crate-deep-ci-flows",
+	"workspace-deep-ci-flows",
+]
+
 # Tasks that must be ran once at the workspace root (i.e., they don't
 # make sense to run for individual crates).
 [tasks.workspace-ci-flows]
@@ -40,6 +55,10 @@ dependencies = [
 	"misc-diagrams",
 	"integration",
 ]
+
+[tasks.workspace-deep-ci-flows]
+workspace = false
+dependencies = ["workspace-ci-flows"]
 
 # Wrapper task for crate-specific tasks. Using this wrapper
 # allows the crate-ci-flows to be expressed as an array of
@@ -50,10 +69,19 @@ dependencies = [
 [tasks.fork-for-crate-ci-flows]
 run_task = { name = "crate-ci-flows", fork = true }
 
+[tasks.fork-for-crate-deep-ci-flows]
+run_task = { name = "crate-deep-ci-flows", fork = true }
+
 # Tasks that must be ran against individual crates.
 [tasks.crate-ci-flows]
 dependencies = [
 	"ci-flow"
+]
+
+[tasks.crate-deep-ci-flows]
+dependencies = [
+	"crate-ci-flows",
+	"deep-test",
 ]
 
 # Run real code against real Enarx keeps to test various bits
@@ -88,6 +116,14 @@ run_task = { name = "_test", fork = true }
 [tasks._test]
 command = "cargo"
 args = ["test"]
+
+# !WARNING!
+#
+# See warning message under [tasks.deep-ci]
+[tasks.deep-test]
+# Stubbed. Crates must override this specifically if there's
+# anything special to be done to "turn on" the deep testing
+# requirements.
 
 [tasks.deny]
 command = "cargo"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,6 +26,35 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
 ENARX_TEST_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/.tests"
 ENARX_DOCS_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/docs"
 
+# Run all automated unit and integration tests locally (except
+# for any tests that modify platform state).
+[tasks.ci]
+workspace = false
+dependencies = ["fork-for-crate-ci-flows", "workspace-ci-flows"]
+
+# Tasks that must be ran once at the workspace root (i.e., they don't
+# make sense to run for individual crates).
+[tasks.workspace-ci-flows]
+workspace = false
+dependencies = [
+	"misc-diagrams"
+]
+
+# Wrapper task for crate-specific tasks. Using this wrapper
+# allows the crate-ci-flows to be expressed as an array of
+# dependencies. It is important to fork so that cargo-make's
+# child process detects that it is running in a workspace
+# member crate, and it will shed the previous "workspace = false"
+# constraint.
+[tasks.fork-for-crate-ci-flows]
+run_task = { name = "crate-ci-flows", fork = true }
+
+# Tasks that must be ran against individual crates.
+[tasks.crate-ci-flows]
+dependencies = [
+	"ci-flow"
+]
+
 [tasks.deny]
 command = "cargo"
 args = ["deny", "check", "licenses"]
@@ -71,13 +100,6 @@ args = ["test"]
 workspace = false
 run_task = [
     { name = ["ci-flow", "integration"], fork = true },
-]
-
-# Single run tests for the entire project rather than per crate
-[tasks.ci-project]
-workspace = false
-dependencies = [
-	"misc-diagrams"
 ]
 
 # Add additional tests to the predefined 'ci-flow' target.

--- a/sev/Makefile.toml
+++ b/sev/Makefile.toml
@@ -1,3 +1,7 @@
 [tasks.test]
 command = "cargo"
 args = ["test", "--features=openssl"]
+
+[tasks.deep-test]
+command = "cargo"
+args = ["test", "--features=openssl,dangerous_tests"]


### PR DESCRIPTION
Closes #768 
Closes #719 

This pull request unifies our CI tasks meaning that the entire suite can once again be ran anywhere with `cargo make ci` (new difference: this now includes running the integration tests).

It also adds another target that mainly wraps the `ci` target but turns on many of the hardware specific tests. `cargo make deep-ci` is used for this purpose. It is suitable for CI runners. This is explicitly a separate target in case there are those who want to run the tests on their specific hardware but don't want the tests to manipulate their platform state (i.e., SEV reset).

There's also bit a little bit of work to the `integration` target to build *only* the required crates needed to run the integration tests and now the task is no longer coupled with the `ci-flow`.