### PR TITLE
Remove unnecessary syscall() args

### DIFF
--- a/enarx-keep-sgx-shim/src/handler.rs
+++ b/enarx-keep-sgx-shim/src/handler.rs
@@ -25,17 +25,7 @@ enumerate::enumerate! {
 
 extern "C" {
     #[no_mangle]
-    fn syscall(
-        rdi: u64,
-        rsi: u64,
-        rdx: u64,
-        aex: &mut StateSaveArea,
-        r8: u64,
-        r9: u64,
-        r10: u64,
-        rax: u64,
-        ctx: &Context,
-    ) -> u64;
+    fn syscall(aex: &mut StateSaveArea, ctx: &Context) -> u64;
 }
 
 pub enum Context {}
@@ -87,17 +77,7 @@ impl<'a> Handler<'a> {
     unsafe fn proxy(&mut self, req: Request) -> sallyport::Result {
         self.block.msg.req = req;
 
-        let _ = syscall(
-            self.block.msg.req.arg[0].into(), // rdi
-            self.block.msg.req.arg[1].into(), // rsi
-            self.block.msg.req.arg[2].into(), // rdx
-            self.aex,
-            self.block.msg.req.arg[4].into(), // r8
-            self.block.msg.req.arg[5].into(), // r9
-            self.block.msg.req.arg[3].into(), // r10
-            self.block.msg.req.num.into(),    // rax
-            self.ctx,
-        );
+        let _ret = syscall(self.aex, self.ctx);
 
         self.block.msg.rep.into()
     }

--- a/enarx-keep-sgx-shim/src/start.S
+++ b/enarx-keep-sgx-shim/src/start.S
@@ -176,21 +176,18 @@ enclave:
     zerof   %r11                                    # Clear CPU flags
     ret                                             # Jump to address on the stack
 
-    # int syscall(rdi, rsi, rdx, aex, r8, r9, r10, rax, ctx);
+    # int syscall(rdi = aex, rsi = ctx);
     .text
     .globl syscall
     .type syscall, @function
 syscall:
     savep                                           # Save preserved registers
-    mov     %rsp,                   SRSP(%rcx)      # Save restoration stack pointer
+    mov     %rsp,                   SRSP(%rdi)      # Save restoration stack pointer
     
     zerox                                           # Clear xCPU state
     xor     %rcx,                   %rcx            # Clear %rcx
     zerof   %rcx                                    # Clear CPU flags
-
-    mov     0x38(%rsp),             %r10            # Export %r10
-    mov     0x40(%rsp),             %r11            # Export %rax in %r11
-    mov     0x48(%rsp),             %rsp            # Get the exit context
+    mov     %rsi,                   %rsp            # Get exit context
 
     jmp     .Leexit
 


### PR DESCRIPTION
Related to #614 

This should pass CI when rebased onto #761 .

### Explanation of changes

With #761 , we no longer rely on individual arguments passed in to `syscall()` to proxy a system call. Instead, we [write](https://github.com/lkatalin/enarx/blob/sally/enarx-keep-sgx-shim/src/handler.rs#L88) these arguments (ex. syscall number, `%rdi`, `%rsi` as detailed [here](http://blog.rchapman.org/posts/Linux_System_Call_Table_for_x86_64/)) into an untrusted memory [block](https://github.com/enarx/enarx/blob/master/sallyport/src/lib.rs#L152) and read them from that same block on the host side to properly invoke a system call. 

This means that the only arguments our `syscall()` function still needs are the ones that are not passed in the block. Those are `aex` (a [struct](https://github.com/enarx/enarx/blob/master/sgx/src/types/ssa.rs#L285) holding info regarding an exception that occurred in SGX) and `ctx` (a [pointer](https://github.com/enarx/enarx/blob/master/enarx-keep-sgx-shim/src/start.S#L138) back to the region of our trusted stack that saves register info from the host side and restores it before exiting the Keep). These arguments have to do with our logic for proxying syscalls, whereas the arguments passed in the block are arguments that are [forwarded](https://github.com/enarx/enarx/blob/master/sallyport/src/lib.rs#L73) to the system call itself once we've exited the enclave.

So, the main change here is removing these extra arguments from our `syscall()` function in the enclave `handler`. 

However, that also necessitates a few extra changes. The `syscall()` function defined in `start.S` expects `aex` in the `%rcx` register because it used to be the 4th argument to `syscall()` and the [C calling conventions](https://aaronbloomfield.github.io/pdr/book/x86-64bit-ccc-chapter.pdf) place the first six arguments to a function in `%rdi`, `%rsi`, `%rdx`, `%rcx`, `%r8`, and `%r9`, in that order, with any other arguments pushed onto the stack in reverse order. Since `aex` is now the 1st argument, we have to tell `syscall()` to look for `aex` in `%rdi` instead. Line [185](https://github.com/enarx/enarx/pull/772/files#diff-c44d5e117cccb73d5356de2ed1a1b8a2R185) saves the current stack pointer in a predefined location (based on info in `aex`) on the trusted stack for later use.

Similarly, `ctx` used to be on the stack since it was the last argument to `syscall()`, and thus it was accessed by referring to its offset from the stack pointer with `0x48(%rsp)`. However, now it is the 2nd argument so it is referred to with `%rsi` in line [190](https://github.com/enarx/enarx/pull/772/files#diff-c44d5e117cccb73d5356de2ed1a1b8a2R190). 

### Resources

There are many resources on the C calling conventions, but I've found [this](https://aaronbloomfield.github.io/pdr/book/x86-64bit-ccc-chapter.pdf) to be particularly useful because unlike most others it lists out the parameter order (you can `ctrl + F` for `rdi` and find it).

Another important thing to understand is that our trusted stack really acts like two different stacks, as we have a region we use for the untrusted host-side context and a region we use for trusted context. This is why we need to save the stack pointer(s) in a specific location to refer to it later. `SRSP` is a known offset at which we can save the trusted stack pointer and return to it after doing some syscall stuff on the host side. There is some information [here](https://github.com/enarx/enarx/tree/master/docs/keep/sgx#trusted-stack-layout).