### PR TITLE
Remove old crate name

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -97,7 +97,7 @@ dependencies = [
 # The "integration" task will invoke this automatically.
 [tasks.pre-integration]
 workspace = false
-env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = ["enarx-keep", "enarx-keep-sgx", "enarx-keep-sgx-shim", "enarx-keep-sev", "enarx-keep-sev-shim"] }
+env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = ["enarx-keep", "enarx-keep-sgx", "enarx-keep-sgx-shim", "enarx-keep-sev-shim"] }
 run_task = { name = "build", fork = true }
 
 # Launches the integration tests. You probably want to run


### PR DESCRIPTION
The keep functionality that was outlined in 'enarx-keep-sev' has since
moved into 'enarx-keep'