### PR TITLE
Let the sev/kvm do the address translation for the loader

### DIFF
--- a/enarx-keep-sev-shim/src/hostcall.rs
+++ b/enarx-keep-sev-shim/src/hostcall.rs
@@ -2,7 +2,7 @@
 
 //! Host <-> Shim Communication
 
-use crate::addr::{ShimPhysAddr, ShimVirtAddr};
+use crate::addr::{HostVirtAddr, ShimPhysAddr, ShimVirtAddr};
 use crate::asm::_enarx_asm_triple_fault;
 use crate::SHIM_HOSTCALL_VIRT_ADDR;
 use core::convert::TryFrom;
@@ -89,10 +89,9 @@ impl<'a> HostCall<'a> {
 
         let buf_address = Address::from(buf.as_ptr());
         let shim_virt_address = ShimVirtAddr::try_from(buf_address).map_err(|_| libc::EFAULT)?;
+        let host_virt: HostVirtAddr<_> = ShimPhysAddr::from(shim_virt_address).into();
 
-        let phys = ShimPhysAddr::from(shim_virt_address);
-
-        self.0.msg.req = request!(libc::SYS_write => fd, phys, buf.len());
+        self.0.msg.req = request!(libc::SYS_write => fd, host_virt, buf.len());
         self.hostcall()
     }
 

--- a/enarx-keep-sev-shim/src/lib.rs
+++ b/enarx-keep-sev-shim/src/lib.rs
@@ -87,6 +87,8 @@ pub struct BootInfo {
     pub shim: Line<usize>,
     /// Memory size
     pub mem_size: usize,
+    /// Loader virtual memory offset to shim physical memory
+    pub virt_offset: usize,
 }
 
 /// Error returned, if the virtual machine memory is to small for the shim to operate.
@@ -107,6 +109,7 @@ impl BootInfo {
     #[inline]
     pub fn calculate(
         mem_size: usize,
+        virt_offset: usize,
         setup: Line<usize>,
         shim: Span<usize>,
         code: Span<usize>,
@@ -125,6 +128,7 @@ impl BootInfo {
             code,
             shim,
             mem_size,
+            virt_offset,
         })
     }
 }

--- a/enarx-keep/src/backend/kvm/vm/builder.rs
+++ b/enarx-keep/src/backend/kvm/vm/builder.rs
@@ -173,9 +173,14 @@ impl Builder<AddressSpace> {
             start: 0,
             end: addr_space.prefix_mut().size(),
         };
-        let boot_info =
-            BootInfo::calculate(memsz as _, vm_setup, shim_region.into(), code_region.into())
-                .map_err(|_| io::Error::from_raw_os_error(libc::ENOMEM))?;
+        let boot_info = BootInfo::calculate(
+            memsz as _,
+            addr_space.as_virt().start.as_u64() as _,
+            vm_setup,
+            shim_region.into(),
+            code_region.into(),
+        )
+        .map_err(|_| io::Error::from_raw_os_error(libc::ENOMEM))?;
 
         self.data.boot_info = Some(boot_info);
 


### PR DESCRIPTION
This simplifies the code path in the loader.
