### PR TITLE
.tests/misc-lints-missing-*: fix ambigous arguments

### DIFF
--- a/.tests/misc-lints-clippy-all
+++ b/.tests/misc-lints-clippy-all
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 crate_roots=$(find ./src/ -name lib.rs -o -name main.rs)
 echo "The following files do not #![deny(clippy::all)]:"
-! git grep -LF '#![deny(clippy::all)]' "$crate_roots"
+! git grep -LF '#![deny(clippy::all)]' -- "$crate_roots"

--- a/.tests/misc-lints-missing-docs
+++ b/.tests/misc-lints-missing-docs
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 crate_roots=$(find src/ -name lib.rs -o -name main.rs)
 echo "The following files do not #![deny(missing_docs)]:"
-! git grep -LF '#![deny(missing_docs)]' "$crate_roots"
+! git grep -LF '#![deny(missing_docs)]' -- "$crate_roots"


### PR DESCRIPTION
Use a '--' to separate paths from revisions, otherwise:

[cargo-make][1] INFO - Project: enarx-keep-sev-shim
[cargo-make][1] INFO - Build File: Makefile.toml
[cargo-make][1] INFO - Task: misc-lints-missing-docs
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: misc-lints-missing-docs
[cargo-make][1] INFO - Execute Command: "/home/harald/git/enarx/enarx/.tests/misc-lints-missing-docs"
The following files do not #![deny(missing_docs)]:
fatal: ambiguous argument 'src/lib.rs
src/main.rs': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'