### PR TITLE
KVM ballooning

### DIFF
--- a/enarx-keep/shims/shim-sev/src/addr.rs
+++ b/enarx-keep/shims/shim-sev/src/addr.rs
@@ -9,7 +9,7 @@
 /// FIXME: change to dynamic offset with ASLR https://github.com/enarx/enarx/issues/624
 pub const SHIM_VIRT_OFFSET: u64 = 0xFFFF_FF80_0000_0000;
 
-use crate::BOOT_INFO;
+use crate::frame_allocator::FRAME_ALLOCATOR;
 use core::convert::TryFrom;
 use memory::Address;
 
@@ -19,9 +19,7 @@ pub struct HostVirtAddr<U>(Address<u64, U>);
 impl<U> From<ShimPhysAddr<U>> for HostVirtAddr<U> {
     #[inline(always)]
     fn from(val: ShimPhysAddr<U>) -> Self {
-        let offset = BOOT_INFO.read().unwrap().virt_offset;
-        unsafe { Address::<u64, U>::unchecked(val.0.raw().checked_add(offset as u64).unwrap()) }
-            .into()
+        FRAME_ALLOCATOR.read().phys_to_host(val)
     }
 }
 
@@ -62,6 +60,13 @@ where
     #[inline(always)]
     fn from(val: Address<T, U>) -> Self {
         Self(val.into())
+    }
+}
+
+impl<U> ShimPhysAddr<U> {
+    /// Get the raw address
+    pub fn raw(self) -> Address<u64, U> {
+        self.0
     }
 }
 

--- a/enarx-keep/src/backend/kvm.rs
+++ b/enarx-keep/src/backend/kvm.rs
@@ -8,7 +8,6 @@ use crate::binary::Component;
 
 use anyhow::Result;
 use kvm_ioctls::Kvm;
-use nbytes::bytes;
 
 use std::num::NonZeroUsize;
 use std::path::Path;
@@ -57,8 +56,8 @@ impl backend::Backend for Backend {
 
         let vm = vm::Builder::new()?
             .with_max_cpus(NonZeroUsize::new(256).unwrap())?
-            .with_mem_size(bytes![1; GiB])?
             .calculate_layout(shim.region(), code.region())?
+            .add_memory()?
             .load_shim(shim)?
             .load_code(code)?
             .build()?;

--- a/enarx-keep/src/backend/kvm/vm/builder.rs
+++ b/enarx-keep/src/backend/kvm/vm/builder.rs
@@ -16,8 +16,9 @@ use anyhow::Result;
 use bounds::Line;
 use kvm_ioctls::{Kvm, VmFd};
 use memory::Page;
+use nbytes::bytes;
 use x86_64::structures::paging::page_table::{PageTable, PageTableFlags};
-use x86_64::{PhysAddr, VirtAddr};
+use x86_64::{align_up, PhysAddr, VirtAddr};
 
 use std::io;
 use std::marker::PhantomData;
@@ -105,7 +106,7 @@ impl Builder<New> {
     pub fn with_max_cpus(
         mut self,
         max_cpus: NonZeroUsize,
-    ) -> Result<Builder<CpuCapacity>, io::Error> {
+    ) -> Result<Builder<AddressSpace>, io::Error> {
         self.data.max_cpus = Some(max_cpus.get());
 
         Ok(Builder {
@@ -116,13 +117,16 @@ impl Builder<New> {
 }
 
 impl Builder<CpuCapacity> {
-    pub fn with_mem_size(mut self, mem_size: u64) -> Result<Builder<AddressSpace>, io::Error> {
+    pub fn add_memory(mut self) -> Result<Builder<BootBlock>, io::Error> {
+        let mem_size = align_up(self.data.boot_info.unwrap().mem_size as _, bytes![2; MiB]);
+        self.data.boot_info.as_mut().unwrap().mem_size = mem_size as _;
+
         let guest_addr_start = unsafe {
             mmap::map(
                 0,
                 mem_size as _,
                 libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGE_2MB,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
                 None,
                 0,
             )?
@@ -166,22 +170,14 @@ impl Builder<AddressSpace> {
         mut self,
         shim_region: Line<usize>,
         code_region: Line<usize>,
-    ) -> Result<Builder<BootBlock>, io::Error> {
-        let addr_space = self.data.address_space.as_ref().unwrap();
-        let memsz = addr_space.as_virt().count;
-
+    ) -> Result<Builder<CpuCapacity>, io::Error> {
         let vm_setup = Line {
             start: 0,
-            end: addr_space.prefix_mut().size(),
+            end: Region::size_of_setup(*self.data.max_cpus.as_ref().unwrap()),
         };
-        let boot_info = BootInfo::calculate(
-            memsz as _,
-            addr_space.as_virt().start.as_u64() as _,
-            vm_setup,
-            shim_region.into(),
-            code_region.into(),
-        )
-        .map_err(|_| io::Error::from_raw_os_error(libc::ENOMEM))?;
+
+        let boot_info = BootInfo::calculate(vm_setup, shim_region.into(), code_region.into())
+            .map_err(|_| io::Error::from_raw_os_error(libc::ENOMEM))?;
 
         self.data.boot_info = Some(boot_info);
 
@@ -269,12 +265,12 @@ impl Builder<Code> {
             kvm: self.data.kvm.unwrap(),
             fd: self.data.fd.unwrap(),
             id_alloc: Allocator::new(),
-            address_space: self.data.address_space.unwrap(),
+            regions: vec![self.data.address_space.unwrap()],
             shim_entry: self.data.shim_entry.unwrap(),
             shim_start: PhysAddr::new(boot_info.shim.start as _),
         };
 
-        let host_setup = vm.address_space.prefix_mut();
+        let host_setup = vm.regions[0].prefix_mut();
         host_setup.shared_pages[0] = Page::copy(boot_info);
         host_setup.shared_pages[1..]
             .iter_mut()
@@ -283,7 +279,7 @@ impl Builder<Code> {
         *host_setup.pml4t = PageTable::new();
         *host_setup.pml3t_ident = PageTable::new();
 
-        let addr_virt = vm.address_space.as_virt();
+        let addr_virt = vm.regions[0].as_virt();
         let to_guest = |virt_addr| PhysAddr::new(virt_addr - addr_virt.start.as_u64());
 
         // Set up the page tables

--- a/enarx-keep/src/backend/kvm/vm/mem.rs
+++ b/enarx-keep/src/backend/kvm/vm/mem.rs
@@ -7,9 +7,9 @@ pub use kvm_bindings::kvm_userspace_memory_region as KvmUserspaceMemoryRegion;
 use memory::Page;
 use mmap::Unmap;
 use x86_64::structures::paging::page_table::PageTable;
-use x86_64::VirtAddr;
+use x86_64::{PhysAddr, VirtAddr};
 
-use std::mem::size_of_val;
+use std::mem::{size_of, size_of_val};
 use std::slice::from_raw_parts_mut;
 
 pub struct Region {
@@ -31,11 +31,27 @@ impl Region {
         }
     }
 
+    pub fn as_guest(&self) -> Span<PhysAddr, u64> {
+        Span {
+            start: PhysAddr::new(self.kvm_region.guest_phys_addr),
+            count: self.kvm_region.memory_size,
+        }
+    }
+
     pub fn as_virt(&self) -> Span<VirtAddr, u64> {
         Span {
             start: VirtAddr::new(self.kvm_region.userspace_addr),
             count: self.kvm_region.memory_size,
         }
+    }
+
+    pub fn size_of_setup(num_sally_pages: usize) -> usize {
+        let mut size: usize = 0;
+        size += Page::size();
+        size += Page::size() * num_sally_pages;
+        size += size_of::<PageTable>();
+        size += size_of::<PageTable>();
+        size
     }
 
     pub fn prefix_mut(&self) -> VMSetup<'_> {

--- a/enarx-keep/src/backend/mod.rs
+++ b/enarx-keep/src/backend/mod.rs
@@ -56,4 +56,5 @@ pub trait Thread {
 
 pub enum Command<'a> {
     SysCall(&'a mut Block),
+    Continue,
 }

--- a/enarx-keep/src/main.rs
+++ b/enarx-keep/src/main.rs
@@ -111,6 +111,7 @@ fn exec(backends: &[Box<dyn Backend>], opts: Exec) -> Result<()> {
                 Command::SysCall(block) => unsafe {
                     block.msg.rep = block.msg.req.syscall();
                 },
+                Command::Continue => (),
             }
         }
     } else {


### PR DESCRIPTION
Start with basically no free memory and request additional memory regions from the host on demand.

The amount of memory is doubled every time, trying to reach the maximum memory size with the available slots.

Fixes: https://github.com/enarx/enarx/issues/823