### PR TITLE
shim sev/sgx: remove the indirection of the inital function rust call

### DIFF
--- a/enarx-keep-sev-shim/src/start.S
+++ b/enarx-keep-sev-shim/src/start.S
@@ -104,7 +104,7 @@ _trampoline:
 
     # jump to _start_main
     xor %rbp,%rbp
-    jmp *_start_main_l(%rip)
+    jmp _start_main
 
 .L100:  # some paranoid code preventing speculative execution
     hlt
@@ -114,12 +114,6 @@ _trampoline:
 .align 4096
 _initial_shim_stack:
 .space SIZE_OF_INITIAL_STACK
-
-.section .data
-.align 8
-_start_main_l:
-.quad   _start_main
-.global _start_main
 
 #
 # # Page Tables:

--- a/enarx-keep-sgx-shim/src/start.S
+++ b/enarx-keep-sgx-shim/src/start.S
@@ -138,7 +138,7 @@ _start:
 
     xor     %rax,                   %rax            # Clear %rax
 
-    call *_entry_l(%rip)                            # Jump to Rust
+    call    entry                                   # Jump to Rust
 
 # CSSA != 0
 .Levent:
@@ -214,7 +214,7 @@ _start:
 syscall:
     savep                                           # Save preserved registers
     mov     %rsp,                   SRSP(%rdi)      # Save restoration stack pointer
-    
+
     zerox                                           # Clear xCPU state
     xor     %rcx,                   %rcx            # Clear %rcx
     zerof   %rcx                                    # Clear CPU flags
@@ -238,9 +238,3 @@ exit:
 jump:
     mov     %rdi,                   %rsp
     jmp     *%rsi
-
-    .data
-    .global entry
-    .align 8
-_entry_l:
-    .quad   entry


### PR DESCRIPTION
This was introduced with the static-pie rcrt1 dynamic symbol correction,
copying the behaviour of the musl lib rcrt1.o. Apparently it is not
necessary to use the indirection, as the code base is not big enough
yet, that it exceeds the maximum relative jmp/call distance.

If that is ever the case, we should revert this patch.