### PR TITLE
testaso: use memoffset::offset_of!()

### DIFF
--- a/intel-types/Cargo.toml
+++ b/intel-types/Cargo.toml
@@ -11,3 +11,5 @@ edition = "2018"
 enumerate = { path = "../enumerate" }
 bitflags = "1.2.1"
 
+[dev-dependencies]
+memoffset = "0.5.5"

--- a/intel-types/src/lib.rs
+++ b/intel-types/src/lib.rs
@@ -486,11 +486,11 @@ bitflags! {
 /// }
 #[cfg(test)]
 macro_rules! testaso {
-    (@off $name:ty=>$field:ident) => {
-        &unsafe { &*core::ptr::null::<$name>() }.$field as *const _ as usize
+    (@off $name:path=>$field:ident) => {
+        memoffset::offset_of!($name, $field)
     };
 
-    ($(struct $name:ty: $align:expr, $size:expr => { $($field:ident: $offset:expr),* })+) => {
+    ($(struct $name:path: $align:expr, $size:expr => { $($field:ident: $offset:expr),* })+) => {
         #[cfg(test)]
         #[test]
         fn align() {

--- a/sgx/Cargo.toml
+++ b/sgx/Cargo.toml
@@ -26,6 +26,7 @@ libc = { version = "0.2.73", optional = true }
 
 [dev-dependencies]
 rstest = "0.6"
+memoffset = "0.5.5"
 
 [build-dependencies]
 cc = "1.0"

--- a/sgx/src/lib.rs
+++ b/sgx/src/lib.rs
@@ -20,11 +20,11 @@
 #[cfg(test)]
 #[macro_use]
 macro_rules! testaso {
-    (@off $name:ty=>$field:ident) => {
-        &unsafe { &*core::ptr::null::<$name>() }.$field as *const _ as usize
+    (@off $name:path=>$field:ident) => {
+        memoffset::offset_of!($name, $field)
     };
 
-    ($(struct $name:ty: $align:expr, $size:expr => { $($field:ident: $offset:expr),* })+) => {
+    ($(struct $name:path: $align:expr, $size:expr => { $($field:ident: $offset:expr),* })+) => {
         #[cfg(test)]
         #[test]
         fn align() {


### PR DESCRIPTION
Although the current version works, it is unsound. Leverage the work of
the memoffset crate, to someday provide a sound way of calculating the
offset.

This also prevents others from copying unsound code.