### PR TITLE
Make rustfmt and clippy non-nightly

### DIFF
--- a/containers/fedora/Dockerfile
+++ b/containers/fedora/Dockerfile
@@ -24,9 +24,15 @@ RUN dnf -y install glibc-static clang-devel llvm-devel openssl-devel
 RUN dnf -y install mscgen graphviz
 
 # Install Rust via rustup
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -q --channel=nightly
-RUN rustup target add x86_64-unknown-linux-musl --toolchain=nightly
-RUN rustup component add rustfmt rls clippy rust-src
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y -q \
+        --target x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
+        --component rustfmt rls clippy rust-src
+RUN rustup toolchain install nightly \
+    --allow-downgrade \
+    --profile minimal \
+    --component rust-src \
+    --target x86_64-unknown-linux-gnu x86_64-unknown-linux-musl
 
 # Install binary crates
 RUN cargo install --force cargo-make


### PR DESCRIPTION
Using nightly rustfmt will cause CI errors all the time, when rustfmt
changes.

Also all components should build with stable by default and only
selected components should switch to nightly.

Additionally the `--channel=nightly` argument for `rustup.sh` did not
work for me.

```console
error: error: Found argument '--channel' which wasn't expected, or isn't valid in this context
```