### PR TITLE
enarx-keep: add `--shim-log-level <u8>` argument

### DIFF
--- a/enarx-keep-sev-shim/src/lib.rs
+++ b/enarx-keep-sev-shim/src/lib.rs
@@ -87,8 +87,11 @@ pub struct BootInfo {
     pub shim: Line<usize>,
     /// Memory size
     pub mem_size: usize,
+    /// FIXME: remove volatile `virt_offset`
     /// Loader virtual memory offset to shim physical memory
     pub virt_offset: usize,
+    /// Log level
+    pub shim_log_level: u8,
 }
 
 /// Error returned, if the virtual machine memory is to small for the shim to operate.
@@ -129,6 +132,7 @@ impl BootInfo {
             shim,
             mem_size,
             virt_offset,
+            shim_log_level: 0,
         })
     }
 }

--- a/enarx-keep-sev-shim/src/print.rs
+++ b/enarx-keep-sev-shim/src/print.rs
@@ -6,6 +6,7 @@ use crate::hostcall::{self, HostFd};
 
 struct HostWrite(HostFd);
 
+use crate::BOOT_INFO;
 use core::fmt;
 
 impl fmt::Write for HostWrite {
@@ -21,6 +22,10 @@ impl fmt::Write for HostWrite {
 pub fn _print(args: fmt::Arguments) {
     use fmt::Write;
 
+    if BOOT_INFO.read().unwrap().shim_log_level < 2 {
+        return;
+    }
+
     HostWrite(unsafe { HostFd::from_raw_fd(libc::STDOUT_FILENO) })
         .write_fmt(args)
         .expect("Printing via Host fd 1 failed");
@@ -30,6 +35,10 @@ pub fn _print(args: fmt::Arguments) {
 #[inline(always)]
 pub fn _eprint(args: fmt::Arguments) {
     use fmt::Write;
+
+    if BOOT_INFO.read().unwrap().shim_log_level < 1 {
+        return;
+    }
 
     HostWrite(unsafe { HostFd::from_raw_fd(libc::STDERR_FILENO) })
         .write_fmt(args)

--- a/enarx-keep/src/backend/kvm.rs
+++ b/enarx-keep/src/backend/kvm.rs
@@ -65,12 +65,12 @@ impl backend::Backend for Backend {
         Ok(path)
     }
 
-    fn build(&self, shim: Component, code: Component) -> Result<Arc<dyn Keep>> {
+    fn build(&self, shim: Component, code: Component, shim_log_level: u8) -> Result<Arc<dyn Keep>> {
         let vm = vm::Builder::<New>::new()?
             .with_max_cpus(NonZeroUsize::new(256).unwrap())?
             .with_mem_size(units::bytes![1; GiB])?
             .calculate_layout(shim.region(), code.region())?
-            .load_shim(shim)?
+            .load_shim(shim, shim_log_level)?
             .load_code(code)?
             .build()?;
 

--- a/enarx-keep/src/backend/kvm/vm/builder.rs
+++ b/enarx-keep/src/backend/kvm/vm/builder.rs
@@ -194,11 +194,15 @@ impl Builder<AddressSpace> {
 /// Once component relocations have been calculated, we can load
 /// the shim.
 impl Builder<BootBlock> {
-    pub fn load_shim(mut self, mut shim: Component) -> Result<Builder<Shim>, io::Error> {
+    pub fn load_shim(
+        mut self,
+        mut shim: Component,
+        shim_log_level: u8,
+    ) -> Result<Builder<Shim>, io::Error> {
         let offset = self.data.boot_info.as_ref().unwrap().shim.start;
         self.load_component(&mut shim, offset)?;
         self.data.shim_entry = Some(PhysAddr::new(shim.entry as _));
-
+        self.data.boot_info.unwrap().shim_log_level = shim_log_level;
         Ok(Builder {
             data: self.data,
             _phantom: PhantomData,

--- a/enarx-keep/src/backend/mod.rs
+++ b/enarx-keep/src/backend/mod.rs
@@ -27,7 +27,7 @@ pub trait Backend {
     fn shim(&self) -> Result<PathBuf>;
 
     /// Create a keep instance on this backend
-    fn build(&self, shim: Component, code: Component) -> Result<Arc<dyn Keep>>;
+    fn build(&self, shim: Component, code: Component, shim_log_level: u8) -> Result<Arc<dyn Keep>>;
 }
 
 pub struct Datum {

--- a/enarx-keep/src/backend/sev.rs
+++ b/enarx-keep/src/backend/sev.rs
@@ -187,7 +187,7 @@ impl backend::Backend for Backend {
         unimplemented!()
     }
 
-    fn build(&self, shim: Component, code: Component) -> Result<Arc<dyn Keep>> {
+    fn build(&self, shim: Component, code: Component, shim_log_level: u8) -> Result<Arc<dyn Keep>> {
         unimplemented!()
     }
 }

--- a/enarx-keep/src/backend/sgx.rs
+++ b/enarx-keep/src/backend/sgx.rs
@@ -202,7 +202,12 @@ impl backend::Backend for Backend {
     }
 
     /// Create a keep instance on this backend
-    fn build(&self, shim: Component, code: Component) -> Result<Arc<dyn backend::Keep>> {
+    fn build(
+        &self,
+        shim: Component,
+        code: Component,
+        shim_log_level: u8,
+    ) -> Result<Arc<dyn backend::Keep>> {
         unimplemented!()
     }
 }

--- a/enarx-keep/src/main.rs
+++ b/enarx-keep/src/main.rs
@@ -33,6 +33,10 @@ struct Exec {
     #[structopt(short, long, parse(from_os_str))]
     shim: Option<PathBuf>,
 
+    // FIXME: https://github.com/enarx/enarx/issues/831
+    #[structopt(short = "l", long = "shim-log-level", default_value = "0")]
+    shim_log_level: u8,
+
     /// The payload to run inside the keep
     code: String,
 }
@@ -102,7 +106,7 @@ fn exec(backends: HashMap<String, Box<dyn Backend>>, opts: Exec) -> Result<()> {
 
     let shim = Component::from_path(opts.shim.unwrap_or(backend.shim()?))?;
 
-    let keep = backend.build(shim, code)?;
+    let keep = backend.build(shim, code, opts.shim_log_level)?;
 
     let mut thread = keep.clone().add_thread()?;
     loop {


### PR DESCRIPTION
This patch adds `--log-level <u8>` to enarx-keep.

It also adds a log_level element to the SEV `BootInfo` struct, where the value will get measured.