### PR TITLE
add kvm integration test

### DIFF
--- a/enarx-keep-sev-shim/src/print.rs
+++ b/enarx-keep-sev-shim/src/print.rs
@@ -8,6 +8,9 @@ struct HostWrite(HostFd);
 
 use core::fmt;
 
+// FIXME: remove, if https://github.com/enarx/enarx/issues/831 is fleshed out
+const TRACE: bool = false;
+
 impl fmt::Write for HostWrite {
     #[inline(always)]
     fn write_str(&mut self, s: &str) -> fmt::Result {
@@ -21,6 +24,10 @@ impl fmt::Write for HostWrite {
 pub fn _print(args: fmt::Arguments) {
     use fmt::Write;
 
+    if !TRACE {
+        return;
+    }
+
     HostWrite(unsafe { HostFd::from_raw_fd(libc::STDOUT_FILENO) })
         .write_fmt(args)
         .expect("Printing via Host fd 1 failed");
@@ -30,6 +37,10 @@ pub fn _print(args: fmt::Arguments) {
 #[inline(always)]
 pub fn _eprint(args: fmt::Arguments) {
     use fmt::Write;
+
+    if !TRACE {
+        return;
+    }
 
     HostWrite(unsafe { HostFd::from_raw_fd(libc::STDERR_FILENO) })
         .write_fmt(args)

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -8,5 +8,7 @@ fn main() {
 
     if std::path::Path::new("/dev/sgx/enclave").exists() {
         println!("cargo:rustc-cfg=has_sgx");
+    } else if std::path::Path::new("/dev/kvm").exists() {
+        println!("cargo:rustc-cfg=has_kvm");
     }
 }

--- a/integration-tests/src/bin/clock_gettime.rs
+++ b/integration-tests/src/bin/clock_gettime.rs
@@ -11,4 +11,6 @@ fn main() {
     unsafe {
         clock_gettime(libc::CLOCK_MONOTONIC, &mut ts as *mut _);
     }
+
+    assert_ne!(ts.tv_sec, 0);
 }

--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -47,9 +47,21 @@ impl IntegrationTest {
     ) {
         let seconds = Duration::from_secs(timeout);
 
+        // FIXME: https://github.com/enarx/enarx/issues/832
+        #[cfg(has_sgx)]
+        let keep = "sgx";
+        #[cfg(has_sev)]
+        let keep = "sev";
+        #[cfg(all(not(any(has_sev, has_sgx)), has_kvm))]
+        let keep = "kvm";
+        #[cfg(not(any(has_sev, has_sgx, has_kvm)))]
+        let keep = "unknown";
+
         let mut cmd = Command::new(self.keep)
             .current_dir(self.root)
             .arg("exec")
+            .arg("--keep")
+            .arg(keep)
             .arg(self.code)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/integration-tests/tests/syscall_clock_gettime.rs
+++ b/integration-tests/tests/syscall_clock_gettime.rs
@@ -6,7 +6,7 @@ mod common;
 use common::IntegrationTest;
 
 #[test]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn clock_gettime() {
     IntegrationTest::new("clock_gettime").run(5, 0, "", "", "");
 }

--- a/integration-tests/tests/syscall_exit.rs
+++ b/integration-tests/tests/syscall_exit.rs
@@ -6,20 +6,20 @@ mod common;
 use common::IntegrationTest;
 
 #[test]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn exit_zero() {
     IntegrationTest::new("exit_zero").run(5, 0, "", "", "");
 }
 
 #[test]
 #[should_panic]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn watchdog() {
     IntegrationTest::new("watchdog").run(5, 0, "", "", "");
 }
 
 #[test]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn exit_one() {
     IntegrationTest::new("exit_one").run(5, 1, "", "", "");
 }

--- a/integration-tests/tests/syscall_read.rs
+++ b/integration-tests/tests/syscall_read.rs
@@ -10,14 +10,14 @@ use common::IntegrationTest;
 
 /// This test runs the read syscall payload in the SGX keep using the SGX shim.
 #[test]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn read() {
     IntegrationTest::new("read").run(5, 0, "hello world\n", "hello world\n", "");
 }
 
 #[test]
 #[should_panic]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn read_with_wrong_output() {
     IntegrationTest::new("read").run(5, 0, "hello", "h", "");
 }

--- a/integration-tests/tests/syscall_write.rs
+++ b/integration-tests/tests/syscall_write.rs
@@ -10,27 +10,27 @@ use common::IntegrationTest;
 
 /// This test runs the write syscall payload in the SGX keep using the SGX shim.
 #[test]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn write_stdout() {
     IntegrationTest::new("write_stdout").run(5, 0, "", "hello world\n", "");
 }
 
 #[test]
 #[should_panic]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn write_with_wrong_output() {
     IntegrationTest::new("write_stdout").run(5, 0, "", "hello", "");
 }
 
 #[test]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn write_stderr() {
     IntegrationTest::new("write_stderr").run(5, 0, "", "", "hello world\n");
 }
 
 #[test]
 #[should_panic]
-#[cfg_attr(not(any(has_sgx, has_sev)), ignore)]
+#[cfg_attr(not(any(has_sgx, has_sev, has_kvm)), ignore)]
 fn write_with_wrong_error() {
     IntegrationTest::new("write_stderr").run(5, 0, "", "", "hello");
 }


### PR DESCRIPTION
- turn off sev-shim debug output
- implement `SYS_clock_gettime` for sev-shim
- enable `integration-tests` for kvm
- fixed `clock_gettime` to check for seconds != 0

Fixes: https://github.com/enarx/enarx/issues/836
Fixes: https://github.com/enarx/enarx/issues/821