### PR TITLE
containers/fedora: install nightly clippy

### DIFF
--- a/containers/fedora/Dockerfile
+++ b/containers/fedora/Dockerfile
@@ -31,7 +31,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
 RUN rustup toolchain install nightly \
     --allow-downgrade \
     --profile minimal \
-    --component rust-src \
+    --component rust-src clippy \
     --target x86_64-unknown-linux-gnu x86_64-unknown-linux-musl
 
 # Install binary crates


### PR DESCRIPTION
`cargo ci-flow` runs clippy and clippy errors out on `#[feature()]`

```
error[E0554]: `#![feature]` may not be used on the stable release channel
```