### PR TITLE
keep-runtime: Port to using wasmtime's Linker interface

### DIFF
--- a/keep-runtime/fixtures/no_export.wat
+++ b/keep-runtime/fixtures/no_export.wat
@@ -1,5 +1,5 @@
 ;;; SPDX-License-Identifier: Apache-2.0
 
 (module
-  (func (export "no_export") (result i32)
-    i32.const 1))
+  (memory (export "") 1)
+)


### PR DESCRIPTION
The [wasmtime::Linker](https://docs.rs/wasmtime/0.19.0/wasmtime/struct.Linker.html) interface transparently performs name resolution which we currently do by our own.