### PR TITLE
crt0stack: internalize `environ` behind a `std` flag

### DIFF
--- a/crt0stack/Cargo.toml
+++ b/crt0stack/Cargo.toml
@@ -24,3 +24,6 @@ keywords = [
 
 [dependencies]
 enumerate = { path = "../enumerate" }
+
+[features]
+std = []

--- a/crt0stack/examples/reader.rs
+++ b/crt0stack/examples/reader.rs
@@ -3,11 +3,7 @@
 use crt0stack::Reader;
 
 fn main() {
-    extern "C" {
-        static environ: *const *const std::os::raw::c_char;
-    }
-
-    let reader = unsafe { Reader::from_environ(&*environ) }.prev().prev();
+    let reader = Reader::from_environ().prev().prev();
     assert_eq!(reader.count(), std::env::args().count());
 
     let mut reader = reader.done();

--- a/vdso/Cargo.toml
+++ b/vdso/Cargo.toml
@@ -9,5 +9,5 @@ license = "Apache-2.0"
 libc = "0.2.67"
 
 [dependencies]
-crt0stack = { path = "../crt0stack" }
+crt0stack = { path = "../crt0stack", features=["std"] }
 goblin = "0.2.0"

--- a/vdso/src/lib.rs
+++ b/vdso/src/lib.rs
@@ -10,10 +10,6 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::slice::from_raw_parts;
 
-extern "C" {
-    static environ: *const *const c_char;
-}
-
 #[cfg(target_pointer_width = "64")]
 mod elf {
     pub use goblin::elf64::dynamic::*;
@@ -110,7 +106,7 @@ pub struct Vdso<'a>(&'a Header);
 impl Vdso<'static> {
     /// Locates the vDSO by parsing the auxiliary vectors
     pub fn locate() -> Option<Self> {
-        for aux in unsafe { Reader::from_environ(&*environ) }.done() {
+        for aux in Reader::from_environ().done() {
             if let Entry::SysInfoEHdr(addr) = aux {
                 let hdr = unsafe { Header::from_ptr(&*(addr as *const _))? };
                 return Some(Self(hdr));


### PR DESCRIPTION
Basically, the only use of `from_environ()` is going to be using the `environ`
POSIX variable which is always available on `std`. Therefore, we don't force
the caller to provide this variable. This allows us to make the function safe.