### PR TITLE
Rename cargo-make-ci-flow -> cargo-make-ci

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   # Run the entire CI suite
-  cargo-make-ci-flow:
+  cargo-make-ci:
     runs-on: ubuntu-latest
     container: quay.io/enarx/fedora
     steps:


### PR DESCRIPTION
We switched to using a root-level task, "ci", to orchestrate the CI
flows. ci-flow is one of the subordinate tasks, but is no longer the
proper primary CI task to invoke. Fix this just for consistency and to
avoid any ambiguity.

Users should run "cargo make ci"