### PR TITLE
build.rs: run `strip` on the shims before including them in enarx-keep

### DIFF
--- a/enarx-keep/build.rs
+++ b/enarx-keep/build.rs
@@ -123,6 +123,19 @@ fn main() {
             .join(&std::env::var("PROFILE").unwrap())
             .join(&shim_name);
 
-        std::fs::rename(&shim_out_bin, &out_bin).expect("move failed");
+        let status = Command::new("strip")
+            .arg("--strip-unneeded")
+            .arg("-o")
+            .arg(&out_bin)
+            .arg(&shim_out_bin)
+            .status();
+
+        match status {
+            Ok(status) if status.success() => {}
+            _ => {
+                eprintln!("Failed to run strip");
+                std::fs::rename(&shim_out_bin, &out_bin).expect("move failed")
+            }
+        }
     }
 }


### PR DESCRIPTION
This reduces size, and we cannot use gdb anyway (yet).

`-C debuginfo=0` could have been used also, but:
a) it does result in a bigger binary
b) I find myself disassembling the shims quite often and without
   debuginfo, that is not parseable anymore