### PR TITLE
mv `use crate::attestation_types::report` in feature gated function

### DIFF
--- a/sgx/src/attestation_types/ti.rs
+++ b/sgx/src/attestation_types/ti.rs
@@ -4,7 +4,6 @@
 //! The Target Info is used to identify the target enclave that will be able to cryptographically
 //! verify the REPORT structure returned by the EREPORT leaf. Must be 512-byte aligned.
 
-use crate::attestation_types::report;
 use crate::types::{attr::Attributes, misc::MiscSelect};
 
 /// Table 38-22
@@ -33,7 +32,9 @@ impl TargetInfo {
     /// # Safety
     /// This function is unsafe because it executes an `enclu` instruction which
     /// is only available on processors that support SGX.
-    pub unsafe fn get_report(&self, data: &ReportData) -> report::Report {
+    pub unsafe fn get_report(&self, data: &ReportData) -> crate::attestation_types::report::Report {
+        use crate::attestation_types::report;
+
         const EREPORT: usize = 0;
 
         let mut report = core::mem::MaybeUninit::<report::Report>::uninit();


### PR DESCRIPTION
otherwise we always get:

```console
   Compiling enarx-keep v0.1.0 (/home/harald/git/enarx/enarx/enarx-keep)
warning: unused import: `crate::attestation_types::report`
 --> /home/harald/git/enarx/enarx/sgx/src/attestation_types/ti.rs:7:5
  |
7 | use crate::attestation_types::report;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```