### PR TITLE
Add a socket for preattestation

### DIFF
--- a/enarx-keep/src/backend/kvm.rs
+++ b/enarx-keep/src/backend/kvm.rs
@@ -10,6 +10,7 @@ use anyhow::Result;
 use kvm_ioctls::Kvm;
 
 use std::num::NonZeroUsize;
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 const SHIM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/bin/shim-sev"));
@@ -50,7 +51,7 @@ impl backend::Backend for Backend {
         vec![dev_kvm(), kvm_version()]
     }
 
-    fn build(&self, code: Component) -> Result<Arc<dyn Keep>> {
+    fn build(&self, code: Component, _sock: Option<&Path>) -> Result<Arc<dyn Keep>> {
         let shim = Component::from_bytes(SHIM)?;
 
         let vm = vm::Builder::new()?

--- a/enarx-keep/src/backend/mod.rs
+++ b/enarx-keep/src/backend/mod.rs
@@ -8,6 +8,7 @@ mod probe;
 
 use crate::binary::Component;
 
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -26,7 +27,7 @@ pub trait Backend {
     fn data(&self) -> Vec<Datum>;
 
     /// Create a keep instance on this backend
-    fn build(&self, code: Component) -> Result<Arc<dyn Keep>>;
+    fn build(&self, code: Component, sock: Option<&Path>) -> Result<Arc<dyn Keep>>;
 }
 
 pub struct Datum {

--- a/enarx-keep/src/backend/sev.rs
+++ b/enarx-keep/src/backend/sev.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use std::arch::x86_64::__cpuid_count;
 use std::fs::OpenOptions;
 use std::mem::transmute;
+use std::path::Path;
 use std::str::from_utf8;
 use std::sync::Arc;
 
@@ -187,7 +188,7 @@ impl backend::Backend for Backend {
         data
     }
 
-    fn build(&self, _code: Component) -> Result<Arc<dyn Keep>> {
+    fn build(&self, _code: Component, _sock: Option<&Path>) -> Result<Arc<dyn Keep>> {
         unimplemented!()
     }
 }

--- a/enarx-keep/src/backend/sgx/mod.rs
+++ b/enarx-keep/src/backend/sgx/mod.rs
@@ -14,6 +14,7 @@ use sgx::types::{
 };
 
 use std::arch::x86_64::__cpuid_count;
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 mod data;
@@ -68,7 +69,7 @@ impl crate::backend::Backend for Backend {
     }
 
     /// Create a keep instance on this backend
-    fn build(&self, mut code: Component) -> Result<Arc<dyn Keep>> {
+    fn build(&self, mut code: Component, _sock: Option<&Path>) -> Result<Arc<dyn Keep>> {
         let mut shim = Component::from_bytes(SHIM)?;
 
         // Calculate the memory layout for the enclave.

--- a/enarx-keep/src/main.rs
+++ b/enarx-keep/src/main.rs
@@ -14,6 +14,8 @@ use binary::Component;
 use anyhow::Result;
 use structopt::StructOpt;
 
+use std::path::PathBuf;
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 
@@ -28,8 +30,12 @@ struct Exec {
     #[structopt(short, long)]
     keep: Option<String>,
 
+    /// The socket to use for preattestation
+    #[structopt(short, long)]
+    sock: Option<PathBuf>,
+
     /// The payload to run inside the keep
-    code: String,
+    code: PathBuf,
 }
 
 #[derive(StructOpt)]
@@ -93,7 +99,7 @@ fn exec(backends: &[Box<dyn Backend>], opts: Exec) -> Result<()> {
         .find(|b| b.have())
         .expect("No supported backend found!");
 
-    let keep = backend.build(code)?;
+    let keep = backend.build(code, opts.sock.as_deref())?;
 
     let mut thread = keep.clone().add_thread()?;
     loop {


### PR DESCRIPTION
Some technologies, like SEV, SEV-ES and PEF, do attestation during the creation of the keep rather than afterwards. These technologies need a way to talk to a client during the keep build process. The general expectation is that if no socket is specified and the technology does preattestation, it should bring up the backend either without attestation or with simulated attestation.