### PR TITLE
shim-sev: implement syscalls for glibc and keep-runtime Hello World

### DIFF
--- a/enarx-keep/shims/shim-sev/src/payload.rs
+++ b/enarx-keep/shims/shim-sev/src/payload.rs
@@ -179,7 +179,6 @@ fn crt0setup(
     builder.push("/init").unwrap();
     let mut builder = builder.done().unwrap();
     builder.push("LANG=C").unwrap();
-    builder.push("TERM=xterm-256color").unwrap();
     let mut builder = builder.done().unwrap();
 
     let ph_header = app_virt_start + header.e_phoff;


### PR DESCRIPTION
Implement
- `uname()`
- fake `readlink("/proc/self/exe")`
- fake `fstat(0|1|2, …)`
- fake `fcntl(0|1|2, F_GETFL)`
- fix brk() for unaligned requests.

This lets us run a glibc compiled static-pie.

```C

int main() {
    puts("Hello World!");
    return 0;
}
```

as well as the `keep-runtime`.