### PR TITLE
Fix EREPORT example

### DIFF
--- a/sgx/examples/generate_report.rs
+++ b/sgx/examples/generate_report.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use sgx::attestation_types::ti;
+#[cfg(not(feature = "asm"))]
+fn main() {}
 
 #[cfg(feature = "asm")]
 fn main() {
+    use sgx::attestation_types::ti;
+
     let target_info: ti::TargetInfo = Default::default();
     let data = ti::ReportData([0u8; 64]);
     let report = unsafe { target_info.get_report(&data) };


### PR DESCRIPTION
If the "asm" feature is disabled, we get an error during `cargo test`.