### PR TITLE
Move SGX signing code into the types module

### DIFF
--- a/sev/Cargo.toml
+++ b/sev/Cargo.toml
@@ -10,11 +10,8 @@ default = []
 dangerous_tests = []
 
 [dependencies]
-openssl = { version = "=0.10.30", optional = true, features = [ "vendored" ] }
+openssl = { version = "0.10", optional = true, features = [ "vendored" ] }
 bitflags = "1.2.1"
 codicon = "2.1.0"
 bitfield = "0.13"
 iocuddle = "0.1"
-
-[patch.crates-io]
-openssl = { git = 'https://github.com/npmccallum/rust-openssl', branch='patch' }

--- a/sgx/Cargo.toml
+++ b/sgx/Cargo.toml
@@ -17,7 +17,7 @@ asm = ["xsave/asm"]
 bounds  = { path = "../bounds" }
 memory = { path = "../memory" }
 mmap = { path = "../mmap", optional = true }
-openssl = { version = "=0.10.30", features = ["vendored"], optional = true }
+openssl = { version = "0.10", features = ["vendored"], optional = true }
 xsave = { version = "0.1.1", default-features = false }
 iocuddle = { version = "0.1", optional = true }
 libc = { version = "0.2", optional = true }
@@ -30,6 +30,3 @@ memoffset = "0.5.5"
 
 [build-dependencies]
 cc = "1.0"
-
-[patch.crates-io]
-openssl = { git = 'https://github.com/npmccallum/rust-openssl', branch='patch' }

--- a/sgx/src/enclave/builder.rs
+++ b/sgx/src/enclave/builder.rs
@@ -2,7 +2,7 @@
 
 use super::{enclave::Enclave, ioctls};
 use crate::{
-    crypto::{Hasher, Signer},
+    crypto::Hasher,
     types::{
         page::{Class, Flags, SecInfo},
         tcs::Tcs,
@@ -14,7 +14,6 @@ use bounds::Span;
 use memory::Page;
 use openssl::{bn, rsa};
 
-use std::convert::TryFrom;
 use std::fs::{File, OpenOptions};
 use std::io::Result;
 use std::sync::{Arc, RwLock};
@@ -147,12 +146,12 @@ impl Builder {
     /// TODO add more comprehensive docs.
     pub fn build(mut self) -> Result<Arc<RwLock<Enclave>>> {
         // Generate a signing key.
-        let exp = bn::BigNum::try_from(3u32)?;
+        let exp = bn::BigNum::from_u32(3u32)?;
         let key = rsa::Rsa::generate_with_e(3072, &exp)?;
 
         // Create the enclave signature
         let vendor = Author::new(0, 0);
-        let sig = key.sign(vendor, self.hash.finish(self.sign))?;
+        let sig = self.hash.finish(self.sign).sign(vendor, key)?;
 
         // Initialize the enclave.
         let init = ioctls::Init::new(&sig);

--- a/sgx/src/enclave/ioctls.rs
+++ b/sgx/src/enclave/ioctls.rs
@@ -112,12 +112,11 @@ impl<'a> SetAttribute<'a> {
 mod test {
     use super::*;
 
-    use std::convert::TryFrom;
     use std::fs::File;
     use std::num::NonZeroU32;
 
     use crate::{
-        crypto::{Hasher, Signer},
+        crypto::Hasher,
         types::{page::Flags as Perms, secs},
     };
     use bounds::Span;
@@ -131,7 +130,7 @@ mod test {
 
     #[fixture]
     fn key() -> rsa::Rsa<pkey::Private> {
-        let e = bn::BigNum::try_from(3u32).unwrap();
+        let e = bn::BigNum::from_u32(3u32).unwrap();
         rsa::Rsa::generate_with_e(3072, &e).unwrap()
     }
 
@@ -181,7 +180,7 @@ mod test {
 
         // Initialize the enclave.
         let author = sig::Author::new(0, 0);
-        let sig = key.sign(author, hasher.finish(None)).unwrap();
+        let sig = hasher.finish(None).sign(author, key).unwrap();
         ENCLAVE_INIT.ioctl(&mut file, &Init::new(&sig)).unwrap();
     }
 }

--- a/sgx/src/types/sig.rs
+++ b/sgx/src/types/sig.rs
@@ -10,6 +10,12 @@ use super::{attr::Attributes, isv, misc::MiscSelect};
 use core::fmt::Debug;
 use core::ops::{BitAnd, BitOr, Not};
 
+#[cfg(feature = "crypto")]
+use openssl::{bn, pkey, rsa};
+
+#[cfg(feature = "crypto")]
+use core::convert::{TryFrom, TryInto};
+
 /// Succinctly describes a masked type, e.g. masked Attributes or masked MiscSelect.
 /// A mask is applied to Attributes and MiscSelect structs in a Signature (SIGSTRUCT)
 /// to specify values of Attributes and MiscSelect to enforce. This struct combines
@@ -162,10 +168,69 @@ impl Measurement {
             attr: self.attr,
         }
     }
+
+    /// Signs a measurement using the specified key on behalf of an author
+    #[cfg(feature = "crypto")]
+    pub fn sign(self, author: Author, key: rsa::Rsa<pkey::Private>) -> std::io::Result<Signature> {
+        use openssl::{hash, sign};
+        const EXPONENT: u32 = 3;
+
+        if key.e() != &*bn::BigNum::from_u32(EXPONENT)? {
+            return Err(std::io::ErrorKind::InvalidInput.into());
+        }
+
+        let a = unsafe {
+            core::slice::from_raw_parts(
+                &author as *const _ as *const u8,
+                core::mem::size_of_val(&author),
+            )
+        };
+
+        let c = unsafe {
+            core::slice::from_raw_parts(
+                &self as *const _ as *const u8,
+                core::mem::size_of_val(&self),
+            )
+        };
+
+        // Generates signature on Signature author and contents
+        let rsa_key = pkey::PKey::from_rsa(key.clone())?;
+        let md = hash::MessageDigest::sha256();
+        let mut signer = sign::Signer::new(md, &rsa_key)?;
+        signer.update(a)?;
+        signer.update(c)?;
+        let signature = signer.sign_to_vec()?;
+
+        // Generates q1, q2 values for RSA signature verification
+        let s = bn::BigNum::from_slice(&signature)?;
+        let m = key.n();
+
+        let mut ctx = bn::BigNumContext::new()?;
+        let mut q1 = bn::BigNum::new()?;
+        let mut qr = bn::BigNum::new()?;
+
+        q1.div_rem(&mut qr, &(&s * &s), &m, &mut ctx)?;
+        let q2 = &(&s * &qr) / m;
+
+        Ok(Signature {
+            author,
+            modulus: m.try_into()?,
+            exponent: EXPONENT,
+            signature: s.try_into()?,
+            measurement: self,
+            reserved: [0; 12],
+            q1: q1.try_into()?,
+            q2: q2.try_into()?,
+        })
+    }
 }
 
 #[derive(Clone)]
-struct RsaNumber([u8; 384]);
+struct RsaNumber([u8; Self::SIZE]);
+
+impl RsaNumber {
+    const SIZE: usize = 384;
+}
 
 impl core::fmt::Debug for RsaNumber {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -181,6 +246,37 @@ impl Eq for RsaNumber {}
 impl PartialEq for RsaNumber {
     fn eq(&self, rhs: &Self) -> bool {
         self.0[..] == rhs.0[..]
+    }
+}
+
+#[cfg(feature = "crypto")]
+impl TryFrom<&bn::BigNumRef> for RsaNumber {
+    type Error = std::io::Error;
+
+    #[inline]
+    fn try_from(value: &bn::BigNumRef) -> Result<Self, Self::Error> {
+        let mut le = [0u8; Self::SIZE];
+        let be = value.to_vec();
+
+        if be.len() > Self::SIZE {
+            return Err(std::io::ErrorKind::InvalidInput.into());
+        }
+
+        for i in 0..be.len() {
+            le[be.len() - i - 1] = be[i];
+        }
+
+        Ok(Self(le))
+    }
+}
+
+#[cfg(feature = "crypto")]
+impl TryFrom<bn::BigNum> for RsaNumber {
+    type Error = std::io::Error;
+
+    #[inline]
+    fn try_from(value: bn::BigNum) -> Result<Self, Self::Error> {
+        TryFrom::<&bn::BigNumRef>::try_from(&*value)
     }
 }
 
@@ -207,28 +303,6 @@ pub struct Signature {
 }
 
 impl Signature {
-    /// Creates a new Signature.
-    pub const fn new(
-        author: Author,
-        measurement: Measurement,
-        exponent: u32,
-        modulus: [u8; 384],
-        signature: [u8; 384],
-        q1: [u8; 384],
-        q2: [u8; 384],
-    ) -> Self {
-        Self {
-            author,
-            modulus: RsaNumber(modulus),
-            exponent,
-            signature: RsaNumber(signature),
-            measurement,
-            reserved: [0; 12],
-            q1: RsaNumber(q1),
-            q2: RsaNumber(q2),
-        }
-    }
-
     /// Get the enclave author
     pub fn author(&self) -> Author {
         self.author
@@ -276,6 +350,14 @@ testaso! {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::types::page::{Flags as Perms, SecInfo};
+
+    use memory::Page;
+
+    use std::fs::File;
+    use std::io::Read;
+
     #[test]
     fn author_instantiation() {
         let author = Author::new(20000330, 0u32);
@@ -290,5 +372,73 @@ mod tests {
         );
         assert_eq!(author.swdefined, 0u32);
         assert_eq!(author.reserved, [0; 21]);
+    }
+
+    fn load(path: &str) -> Vec<u8> {
+        let mut file = File::open(path).unwrap();
+        let size = file.metadata().unwrap().len();
+
+        let mut data = vec![0u8; size as usize];
+        file.read_exact(&mut data).unwrap();
+
+        data
+    }
+
+    fn loadsig(path: &str) -> Signature {
+        let mut sig: Signature;
+        let buf: &mut [u8];
+
+        unsafe {
+            sig = std::mem::MaybeUninit::uninit().assume_init();
+            buf = std::slice::from_raw_parts_mut(
+                &mut sig as *mut _ as *mut u8,
+                std::mem::size_of_val(&sig),
+            );
+        }
+
+        let mut file = File::open(path).unwrap();
+        file.read_exact(buf).unwrap();
+
+        sig
+    }
+
+    fn loadkey(path: &str) -> rsa::Rsa<pkey::Private> {
+        let pem = load(path);
+        rsa::Rsa::private_key_from_pem(&pem).unwrap()
+    }
+
+    #[test]
+    fn selftest() {
+        let bin = load("tests/encl.bin");
+        let sig = loadsig("tests/encl.ss");
+        let key = loadkey("tests/encl.pem");
+
+        let len = (bin.len() - 1) / Page::size();
+
+        let mut tcs = [Page::default()];
+        let mut src = vec![Page::default(); len];
+
+        let dst = unsafe { tcs.align_to_mut::<u8>().1 };
+        dst.copy_from_slice(&bin[..Page::size()]);
+
+        let dst = unsafe { src.align_to_mut::<u8>().1 };
+        dst.copy_from_slice(&bin[Page::size()..]);
+
+        // Validate the hash.
+        assert_eq!(
+            sig.measurement().mrenclave(),
+            crate::crypto::test::hash(&[
+                (&tcs, SecInfo::tcs()),
+                (&src, SecInfo::reg(Perms::R | Perms::W | Perms::X))
+            ]),
+            "failed to produce correct mrenclave hash"
+        );
+
+        // Ensure that sign() can reproduce the exact same signature struct.
+        assert_eq!(
+            sig,
+            sig.measurement().sign(sig.author(), key).unwrap(),
+            "failed to produce correct signature"
+        );
     }
 }


### PR DESCRIPTION
Since we have combined sgx-types and sgx-crypto into a single crate, the
artificial extension trait is no longer needed. Instead, we just implement
`sign()` on `Measurement` directly.

Additionally, remove the dependency on the patched version of openssl. If
upstream decides to merge my patches, then we can rebase on top of those. Until
then, we'll use the current inefficient conversions that upstream has.