### PR TITLE
enarx-keep: remove openssl crates.io patch

### DIFF
--- a/enarx-keep/Cargo.toml
+++ b/enarx-keep/Cargo.toml
@@ -23,6 +23,3 @@ nbytes = "0.1"
 anyhow = "1.0"
 goblin = "0.2"
 libc = "0.2"
-
-[patch.crates-io]
-openssl = { git = 'https://github.com/npmccallum/rust-openssl', branch='patch' }


### PR DESCRIPTION
```console
❯ cargo tree -i -p openssl
openssl v0.10.30
└── sgx v0.1.0 (/home/harald/git/enarx/enarx/sgx)
    └── enarx-keep v0.1.0 (/home/harald/git/enarx/enarx/enarx-keep)
```