### PR TITLE
Evolve code! macro into impl_const_id!

### DIFF
--- a/sev/src/lib.rs
+++ b/sev/src/lib.rs
@@ -13,6 +13,7 @@ pub mod firmware;
 pub mod launch;
 #[cfg(feature = "openssl")]
 pub mod session;
+mod util;
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]

--- a/sev/src/util.rs
+++ b/sev/src/util.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helpful primitives for developing the crate.
+
+/// A simple const generics substitute.
+#[macro_export]
+macro_rules! impl_const_id {
+    (
+        $visibility:vis $trait:ident => $id_ty:ty;
+        $(
+            $iocty:ty = $val:expr
+        ),* $(,)*
+    ) => {
+        $visibility trait $trait {
+            const ID: $id_ty;
+        }
+
+        $(
+            impl $trait for $iocty {
+                const ID: $id_ty = $val;
+            }
+        )*
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    struct A;
+    struct B;
+    struct C;
+
+    impl_const_id! {
+        Id => usize;
+        A = 1,
+        B = 2,
+        C = 3,
+    }
+
+    #[test]
+    fn test_const_id_macro() {
+        assert_eq!(A::ID, 1);
+        assert_eq!(B::ID, 2);
+        assert_eq!(C::ID, 3);
+    }
+}


### PR DESCRIPTION
Moving this into a util module will help with expressing other ioctl
structs that follow the pattern of having a command identifier encoded
into the structure that is sent into the kernel.

Furthermore, the new macro structure allows the consumer to name the
marker trait, its visibility, as well as the type of constant
expression; rather than imposing these choices upon client code. This
adds a better degree of usability to this mechanism.

No functional changes.