### PR TITLE
Refer to correct struct and kernel header

### DIFF
--- a/sev/src/firmware/linux/ioctl.rs
+++ b/sev/src/firmware/linux/ioctl.rs
@@ -67,10 +67,10 @@ pub const PEK_CERT_IMPORT: Ioctl<WriteRead, &Command<PekCertImport<'_>>> =
 /// Get the CPU's unique ID that can be used for getting a certificate for the CEK public key.
 pub const GET_ID: Ioctl<WriteRead, &Command<GetId<'_>>> = unsafe { SEV.write_read(0) };
 
-/// The Rust-flavored, FFI-friendly version of `struct kvm_sev_cmd` which is
+/// The Rust-flavored, FFI-friendly version of `struct sev_issue_cmd` which is
 /// used to pass arguments to the SEV ioctl implementation.
 ///
-/// This struct is defined in the Linux kernel: include/uapi/linux/kvm.h
+/// This struct is defined in the Linux kernel: include/uapi/linux/psp-sev.h
 #[repr(C, packed)]
 pub struct Command<'a, T: Code> {
     code: u32,


### PR DESCRIPTION
Just for clarity's sake since indeed both structs and both headers are
relevant to this crate :-)

This file corresponds to ioctls that are called only on /dev/sev,
meaning the correct header and struct are sev_issue_cmd and psp-sev.h,
respectively.

A different module will be responsible for dealing with the SEV ioctls
that are called on /dev/kvm. Those ioctls will use struct kvm_sev_cmd
and include/uapi/linux/kvm.h.