### PR TITLE
shim-sev: don't use `impl` in arguments

### DIFF
--- a/enarx-keep/internal/shim-sev/src/frame_allocator.rs
+++ b/enarx-keep/internal/shim-sev/src/frame_allocator.rs
@@ -353,9 +353,9 @@ impl FrameAllocator {
     }
 
     /// Map physical memory to the given virtual address
-    pub fn map_memory(
+    pub fn map_memory<T: Mapper<Size4KiB> + Mapper<Size2MiB>>(
         &mut self,
-        mapper: &mut (impl Mapper<Size4KiB> + Mapper<Size2MiB>),
+        mapper: &mut T,
         map_from: PhysAddr,
         map_to: VirtAddr,
         size: usize,


### PR DESCRIPTION
Using `impl` in arguments prevents using the turbofish at the caller.