### PR TITLE
enarx_keep/rcrt1: use `#![no_builtins]`

### DIFF
--- a/enarx-keep/internal/rcrt1/src/lib.rs
+++ b/enarx-keep/internal/rcrt1/src/lib.rs
@@ -12,6 +12,7 @@
 #![no_std]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
+#![no_builtins]
 
 const R_TYPE_MASK: u64 = 0x7fffffff;
 


### PR DESCRIPTION
Use `#![no_builtins]`, just in case, although it still doesn't work for
`opt-level = 0`. But better be safe than sorry. At least we tried :-)

https://doc.rust-lang.org/nightly/reference/attributes/codegen.html#the-no_builtins-attribute