### PR TITLE
Unbreak the CI

### DIFF
--- a/.github/workflows/packet.yml
+++ b/.github/workflows/packet.yml
@@ -8,11 +8,37 @@ jobs:
     runs-on: [self-hosted, linux, sev]
     steps:
       - uses: actions/checkout@v2
-      - name: Code passes the continuous integration suite on SEV
-        run: cargo make deep-ci
+      - run: sudo apt update
+      - run: sudo apt install -y musl-tools
+      - uses: actions-rs/toolchain@v1
+        with:
+          target: x86_64-unknown-linux-musl
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-make
+      - uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: deep-ci
   cargo-make-integration-sgx1:
     runs-on: [self-hosted, linux, sgx1]
     steps:
       - uses: actions/checkout@v2
-      - name: Code passes the continuous integration suite on SGX1
-        run: cargo make deep-ci
+      - run: sudo apt update
+      - run: sudo apt install -y musl-tools
+      - uses: actions-rs/toolchain@v1
+        with:
+          target: x86_64-unknown-linux-musl
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-make
+      - uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: deep-ci


### PR DESCRIPTION
We have adapted the packet.com runners to match the behavior of the
`ubuntu-latest` cloud runner.