### PR TITLE
shim-sev: remove memoffset crate dependency

### DIFF
--- a/enarx-keep/internal/shim-sev/Cargo.toml
+++ b/enarx-keep/internal/shim-sev/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 [dependencies]
 sallyport = { path = "../sallyport", default-features = false }
 rcrt1 = { path = "../rcrt1" }
-memoffset = { git = "https://github.com/Gilnaa/memoffset", features = ["unstable_const", "unstable_raw"] }
 x86_64 = { version = "0.11.2", default-features = false, features = ["array-init", "inline_asm"] }
 lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
 goblin = { version = "0.2", default-features = false, features = [ "elf64" ] }

--- a/enarx-keep/internal/shim-sev/src/main.rs
+++ b/enarx-keep/internal/shim-sev/src/main.rs
@@ -11,14 +11,6 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(test), no_main)]
 #![feature(asm, naked_functions)]
-// FIXME: needed for memoffset
-#![feature(
-    raw_ref_macros,
-    ptr_offset_from,
-    const_raw_ptr_deref,
-    const_ptr_offset_from,
-    const_maybe_uninit_as_ptr
-)]
 
 #[cfg(test)]
 fn main() {}


### PR DESCRIPTION
memoffset does not update to a working crates.io package for nightly.

memoffset needs additional nightly features.

Also we only use 2 offsets, which don't change ever and can be easily
calculated.