### PR TITLE
Explicitly accept ISC licenses for cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,7 @@ allow = [
     "CC0-1.0",
     "MIT",
     "Zlib",
+    "ISC",
 ]
 # Lint level for licenses considered copyleft
 copyleft = "deny"


### PR DESCRIPTION
This was brought up in #909, but the discussion should probably be continued here. The updated config for `deny` will now accept `ISC` explicitly if merged. Please discuss further.

Resolves #909.