### PR TITLE
Freshen up stale readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ computing.
 [Red Hat](https://www.redhat.com) employs many of the engineers who work on this
 project.
 
-### Packet
+### Equinix Metal
 
-[Packet](https://www.packet.com) currently provides development and testing
-infrastructure to the Enarx project from their easy to use bare-metal cloud.
+[Equinix Metal](https://metal.equinix.com/) currently provides development and
+testing infrastructure to the Enarx project from their easy to use bare-metal
+cloud.

--- a/README.md
+++ b/README.md
@@ -37,34 +37,9 @@ The mechanism itself should be capable of being FIPS-certified.
 
 ## Getting Started
 
-### Building
-
-To build Enarx:
-
-1. Install [cargo-make](https://github.com/sagiegurari/cargo-make):
-
-```
-$ cargo install cargo-make
-```
-
-2. Build Enarx:
-
-```
-$ cargo make build
-```
-
-3. You can optionally run tests:
-
-```
-$ cargo make test
-```
-
-### More Information
-
-For more information, please try our
-[wiki](https://github.com/enarx/enarx/wiki), which includes further details on
-how to get more information.  It's also where we plan to keep up-to-date project
-information.
+Please check our [wiki](https://github.com/enarx/enarx/wiki), which includes
+further details on how to get more information.  It's also where we plan to
+keep up-to-date project information.
 
 Ready to dive in? Learn [how to
 contribute](https://github.com/enarx/enarx/wiki/How-to-contribute) on the wiki.


### PR DESCRIPTION
This repo isn't used for building anything at the moment and
furthermore doesn't depend on cargo-make anyway.

Packet rebranded to Equinix Metal.
