### PR TITLE
fix: change crate authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "enarx"
 version = "0.1.0"
-authors = ["Nathaniel McCallum <npmccallum@redhat.com>"]
+authors = ["The Enarx Project Developers"]
 license = "Apache-2.0"
 edition = "2018"
 build = "build.rs"

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shim-sev"
 version = "0.1.0"
-authors = ["Harald Hoyer <harald@redhat.com>"]
+authors = ["The Enarx Project Developers"]
 edition = "2018"
 license = "Apache-2.0"
 

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shim-sgx"
 version = "0.1.0"
-authors = ["Nathaniel McCallum <npmccallum@redhat.com>"]
+authors = ["The Enarx Project Developers"]
 edition = "2018"
 license = "Apache-2.0"
 

--- a/internal/wasmldr/Cargo.toml
+++ b/internal/wasmldr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmldr"
 version = "0.2.0"
-authors = ["Will Woods <will@profian.com>"]
+authors = ["The Enarx Project Developers"]
 edition = "2018"
 license = "Apache-2.0"
 description = "Enarx WebAssembly Loader"


### PR DESCRIPTION
These crates should not name individual authors anymore
in this community project.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
