### PR TITLE
fix(shim): add `.hash` section

### DIFF
--- a/internal/shim-sev/layout.ld
+++ b/internal/shim-sev/layout.ld
@@ -93,6 +93,7 @@ SECTIONS {
     .dynsym             : { *(.dynsym) } :rodata
     .dynstr             : { *(.dynstr) } :rodata
     .gnu.hash           : { *(.gnu.hash) } :rodata
+    .hash               : { *(.hash) } :rodata
 
     . = ALIGN(CONSTANT(COMMONPAGESIZE));
     .data               : { *(.data .data.*) } :data
@@ -110,8 +111,6 @@ SECTIONS {
       *(.note.GNU-stack)
       *(.gnu_debuglink)
       *(.interp)
-      *(.gnu.hash)
-      *(.hash)
       *(.comment)
       *(COMMON)
       *(.note.gnu.build-id)

--- a/internal/shim-sgx/layout.ld
+++ b/internal/shim-sgx/layout.ld
@@ -23,6 +23,7 @@ SECTIONS {
     .dynsym       : { *(.dynsym) }                      :rodata
     .dynstr       : { *(.dynstr) }                      :rodata
     .gnu.hash     : { *(.gnu.hash) }                    :rodata
+    .hash         : { *(.hash) }                        :rodata
     .note         : { *(.note) }                        :rodata :note
 
     . = ALIGN(4K);
@@ -41,8 +42,6 @@ SECTIONS {
         *(.note.GNU-stack)
         *(.gnu_debuglink)
         *(.interp)
-        *(.gnu.hash)
-        *(.hash)
         *(.comment)
         *(COMMON)
         *(.note.gnu.build-id)


### PR DESCRIPTION
On e.g. NixOs the linker expects `.hash` also, so add it to the list.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
