### PR TITLE
fix: remove sev crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,12 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,12 +94,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codicon"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61"
-
-[[package]]
 name = "colorful"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,26 +126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9274b445ee572d50bdeb17a1101be829becc565b5c12b21a697af4d360b48e8d"
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +136,7 @@ name = "enarx"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitflags",
  "cc",
  "ciborium",
  "colorful",
@@ -191,7 +160,6 @@ dependencies = [
  "sallyport",
  "semver",
  "serial_test",
- "sev",
  "sgx",
  "spinning",
  "structopt",
@@ -235,17 +203,6 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
 
 [[package]]
 name = "goblin"
@@ -606,16 +563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
-dependencies = [
- "getrandom",
- "redox_syscall",
-]
-
-[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,15 +649,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,20 +679,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sev"
-version = "0.1.0"
-source = "git+https://github.com/enarx/sev?rev=e0e17aac9249b00b0cb3e24a2780ca814d229a11#e0e17aac9249b00b0cb3e24a2780ca814d229a11"
-dependencies = [
- "bitfield",
- "bitflags",
- "codicon",
- "dirs",
- "iocuddle",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -935,12 +859,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ is-it-maintained-open-issues = { repository = "enarx/enarx" }
 [features]
 default = ["backend-kvm", "backend-sgx", "backend-sev", "wasmldr"]
 
-backend-sev = ["backend-kvm", "sev"]
+backend-sev = ["backend-kvm"]
 backend-kvm = ["x86_64", "kvm-bindings", "kvm-ioctls"]
 backend-sgx = ["x86_64", "sgx"]
 wasmldr = ["wat"]
@@ -33,7 +33,6 @@ wasmldr = ["wat"]
 [dependencies]
 sgx = { git = "https://github.com/enarx/sgx", rev = "57df3753a0ea1777963dbf3023452993df2edb8c", features = ["openssl"], optional = true }
 sallyport = { git = "https://github.com/enarx/sallyport", rev = "d016f8c6afd50ae2694ddc2d2afea4eec7301a41", features = [ "asm" ] }
-sev = { git = "https://github.com/enarx/sev", rev = "e0e17aac9249b00b0cb3e24a2780ca814d229a11", optional = true}
 x86_64 = { version = "^0.14.6", default-features = false, optional = true }
 const-default = { version = "0.2", features = [ "derive" ] }
 primordial = { version = "0.3", features = ["alloc"] }
@@ -43,6 +42,7 @@ itertools = "0.10"
 protobuf = "2.22"
 structopt = { version = "0.3", features = ["wrap_help"] }
 openssl = "0.10"
+bitflags = "1.2"
 iocuddle = "0.1"
 ciborium = "0.1"
 colorful = "0.2"

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -12,12 +12,13 @@ use data::{
     kvm_version, sev_enabled_in_kernel, CPUIDS,
 };
 use kvm_ioctls::VmFd;
-use sev::firmware::Firmware;
-use sev::launch::linux::ioctl::KvmEncRegion;
+use snp::firmware::Firmware;
+use snp::launch::linux::KvmEncRegion;
 
 mod builder;
 mod cpuid_page;
 mod data;
+mod snp;
 
 struct SnpKeepPersonality {
     // Must be kept open for the VM to talk to the SEV Firmware

--- a/src/backend/sev/snp/firmware/linux.rs
+++ b/src/backend/sev/snp/firmware/linux.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Operations for managing the SEV platform.
+
+use super::super::{Error, Indeterminate, Version};
+use super::{Build, State, Status, TcbStatus, TcbVersion};
+
+use iocuddle::{Group, Ioctl, WriteRead};
+
+use std::fs::{File, OpenOptions};
+use std::marker::PhantomData;
+use std::os::unix::io::{AsRawFd, RawFd};
+
+// These enum ordinal values are defined in the Linux kernel
+// source code: include/uapi/linux/psp-sev.h
+impl_const_id! {
+    pub Id => u32;
+    // […]
+    SnpPlatformStatus = 9,
+}
+
+const SEV: Group = Group::new(b'S');
+
+/// Return information about the current status and capabilities of the SEV-SNP platform.
+const SNP_PLATFORM_STATUS: Ioctl<WriteRead, &Command<SnpPlatformStatus>> =
+    unsafe { SEV.write_read(0) };
+
+/// Query the SEV-SNP platform status.
+///
+/// (Chapter 8.3; Table 38)
+#[derive(Default)]
+#[repr(C)]
+struct SnpPlatformStatus {
+    /// The firmware API version (major.minor)
+    pub version: Version,
+
+    /// The platform state.
+    pub state: u8,
+
+    /// IsRmpInitiailzied
+    pub is_rmp_init: u8,
+
+    /// The platform build ID.
+    pub build_id: u32,
+
+    /// MaskChipId
+    pub mask_chip_id: u32,
+
+    /// The number of valid guests maintained by the SEV-SNP firmware.
+    pub guest_count: u32,
+
+    /// Installed TCB version.
+    pub platform_tcb_version: TcbVersion,
+
+    /// Reported TCB version.
+    pub reported_tcb_version: TcbVersion,
+}
+
+/// The Rust-flavored, FFI-friendly version of `struct sev_issue_cmd` which is
+/// used to pass arguments to the SEV ioctl implementation.
+///
+/// This struct is defined in the Linux kernel: include/uapi/linux/psp-sev.h
+#[repr(C, packed)]
+pub struct Command<'a, T: Id> {
+    code: u32,
+    data: u64,
+    error: u32,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T: Id> Command<'a, T> {
+    /// Create an SEV command with the expectation that the host platform/kernel will write to
+    /// the caller's address space either to the data held in the `Command.subcmd` field or some
+    /// other region specified by the `Command.subcmd` field.
+    pub fn from_mut(subcmd: &'a mut T) -> Self {
+        Command {
+            code: T::ID,
+            data: subcmd as *mut T as u64,
+            error: 0,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// A handle to the SEV platform.
+pub struct Firmware(File);
+
+impl Firmware {
+    /// Create a handle to the SEV platform.
+    pub fn open() -> std::io::Result<Firmware> {
+        Ok(Firmware(
+            OpenOptions::new().read(true).write(true).open("/dev/sev")?,
+        ))
+    }
+
+    // FIXME: remove `allow(unused)`
+    // because we want to use  `platform_status()` later in a sub command.
+    // See: https://github.com/enarx/enarx/issues/1020
+    #[allow(unused)]
+    /// Query the SNP platform status.
+    pub fn platform_status(&mut self) -> Result<Status, Indeterminate<Error>> {
+        let mut info: SnpPlatformStatus = Default::default();
+        SNP_PLATFORM_STATUS.ioctl(&mut self.0, &mut Command::from_mut(&mut info))?;
+
+        Ok(Status {
+            build: Build {
+                version: Version {
+                    major: info.version.major,
+                    minor: info.version.minor,
+                },
+                build: info.build_id,
+            },
+            guests: info.guest_count,
+            tcb: TcbStatus {
+                platform_version: info.platform_tcb_version,
+                reported_version: info.reported_tcb_version,
+            },
+            is_rmp_init: info.is_rmp_init == 1,
+            mask_chip_id: info.mask_chip_id == 1,
+            state: match info.state {
+                0 => State::Uninitialized,
+                1 => State::Initialized,
+                // SNP platforms cannot be in any other State.
+                _ => return Err(Indeterminate::Unknown),
+            },
+        })
+    }
+}
+
+impl AsRawFd for Firmware {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}

--- a/src/backend/sev/snp/firmware/mod.rs
+++ b/src/backend/sev/snp/firmware/mod.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Operations for managing the SEV platform.
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(target_os = "linux")]
+pub use linux::Firmware;
+
+use super::Version;
+
+use bitflags::bitflags;
+
+use std::fmt::Debug;
+
+/// The platform state.
+///
+/// The underlying SEV platform behaves like a state machine and can
+/// only perform certain actions while it is in certain states.
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum State {
+    /// The platform is uninitialized.
+    Uninitialized,
+
+    /// The platform is initialized, but not currently managing any
+    /// guests.
+    Initialized,
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = match self {
+            State::Uninitialized => "uninitialized",
+            State::Initialized => "initialized",
+        };
+        write!(f, "{}", state)
+    }
+}
+
+bitflags! {
+    /// Describes the platform state.
+    #[derive(Default)]
+    pub struct Flags: u32 {
+        /// If set, this platform is owned. Otherwise, it is self-owned.
+        const OWNED           = 1 << 0;
+
+        /// If set, encrypted state functionality is present.
+        const ENCRYPTED_STATE = 1 << 8;
+    }
+}
+
+/// The CPU-unique identifier for the platform.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Identifier(Vec<u8>);
+
+impl From<Identifier> for Vec<u8> {
+    fn from(id: Identifier) -> Vec<u8> {
+        id.0
+    }
+}
+
+impl std::fmt::Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        for b in self.0.iter() {
+            write!(f, "{:02X}", b)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Information regarding the SEV-SNP platform's TCB version.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TcbStatus {
+    /// Installed TCB version.
+    pub platform_version: TcbVersion,
+
+    /// Reported TCB version.
+    pub reported_version: TcbVersion,
+}
+
+/// Information regarding the SEV-SNP platform's current status.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Status {
+    /// The build information.
+    pub build: Build,
+
+    /// The platform's current state.
+    pub state: State,
+
+    /// Set, if the Reverse Map Table (RMP) is initialized
+    pub is_rmp_init: bool,
+
+    /// If set, the identifier, unique to the chip, is masked out
+    /// in the attestation report
+    pub mask_chip_id: bool,
+
+    /// The number of valid guests supervised by this platform.
+    pub guests: u32,
+
+    /// TCB status.
+    pub tcb: TcbStatus,
+}
+
+/// A description of the SEV-SNP platform's build information.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Build {
+    /// The version information.
+    pub version: Version,
+
+    /// The build ID.
+    pub build: u32,
+}
+
+impl std::fmt::Display for Build {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}.{}", self.version, self.build)
+    }
+}
+
+/// TcbVersion represents the version of the firmware.
+///
+/// (Chapter 2.2; Table 3)
+#[derive(Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct TcbVersion {
+    /// Current bootloader version.
+    /// SVN of PSP bootloader.
+    pub bootloader: u8,
+    /// Current PSP OS version.
+    /// SVN of PSP operating system.
+    pub tee: u8,
+    _reserved: [u8; 4],
+    /// Version of the SNP firmware.
+    /// Security Version Number (SVN) of SNP firmware.
+    pub snp: u8,
+    /// Lowest current patch level of all the cores.
+    pub microcode: u8,
+}

--- a/src/backend/sev/snp/launch/linux.rs
+++ b/src/backend/sev/snp/launch/linux.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types for interacting with the KVM SEV-SNP guest management API.
+//! A collection of type-safe ioctl implementations for the AMD Secure Encrypted Virtualization
+//! (SEV) platform. These ioctls are exported by the Linux kernel.
+
+use super::super::{Error, Indeterminate};
+use super::{Finish, Start, Update};
+
+use iocuddle::{Group, Ioctl, Write, WriteRead};
+use std::marker::PhantomData;
+use std::os::raw::c_ulong;
+use std::os::unix::io::AsRawFd;
+
+// These enum ordinal values are defined in the Linux kernel
+// source code: include/uapi/linux/kvm.h
+impl_const_id! {
+    /// The ioctl sub number
+    pub Id => u32;
+
+    Init = 22,
+    LaunchStart<'_> = 23,
+    LaunchUpdate<'_> = 24,
+    LaunchFinish<'_> = 25,
+}
+
+const KVM: Group = Group::new(0xAE);
+const ENC_OP: Ioctl<WriteRead, &c_ulong> = unsafe { KVM.write_read(0xBA) };
+
+// Note: the iocuddle::Ioctl::lie() constructor has been used here because
+// KVM_MEMORY_ENCRYPT_OP ioctl was defined like this:
+//
+// _IOWR(KVMIO, 0xba, unsigned long)
+//
+// Instead of something like this:
+//
+// _IOWR(KVMIO, 0xba, struct kvm_sev_cmd)
+//
+// which would require extra work to wrap around the design decision for
+// that ioctl.
+
+/// Corresponds to the `KVM_MEMORY_ENCRYPT_REG_REGION` ioctl
+pub const ENC_REG_REGION: Ioctl<Write, &KvmEncRegion> =
+    unsafe { KVM.read::<KvmEncRegion>(0xBB).lie() };
+
+/// Initialize the SEV-SNP platform in KVM.
+pub const SNP_INIT: Ioctl<WriteRead, &Command<Init>> = unsafe { ENC_OP.lie() };
+
+/// Initialize the flow to launch a guest.
+pub const SNP_LAUNCH_START: Ioctl<WriteRead, &Command<LaunchStart>> = unsafe { ENC_OP.lie() };
+
+/// Insert pages into the guest physical address space.
+pub const SNP_LAUNCH_UPDATE: Ioctl<WriteRead, &Command<LaunchUpdate>> = unsafe { ENC_OP.lie() };
+
+/// Complete the guest launch flow.
+pub const SNP_LAUNCH_FINISH: Ioctl<WriteRead, &Command<LaunchFinish>> = unsafe { ENC_OP.lie() };
+
+/// Corresponds to the kernel struct `kvm_enc_region`
+///
+/// FIXME: remove when https://github.com/rust-vmm/kvm-ioctls/pull/178 is merged
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct KvmEncRegion<'a> {
+    addr: u64,
+    size: u64,
+    phantom: PhantomData<&'a [u8]>,
+}
+
+impl<'a> KvmEncRegion<'a> {
+    /// Create a new `KvmEncRegion` referencing some memory assigned to the virtual machine.
+    pub fn new(data: &'a [u8]) -> Self {
+        Self {
+            addr: data.as_ptr() as _,
+            size: data.len() as _,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Register the encrypted memory region to a virtual machine
+    pub fn register(&mut self, vm_fd: &mut impl AsRawFd) -> std::io::Result<std::os::raw::c_uint> {
+        ENC_REG_REGION.ioctl(vm_fd, self)
+    }
+}
+
+/// A generic SEV command
+#[repr(C)]
+pub struct Command<'a, T: Id> {
+    code: u32,
+    data: u64,
+    error: u32,
+    sev_fd: u32,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T: Id> Command<'a, T> {
+    /// create the command from a mutable subcommand
+    pub fn from_mut(sev: &'a mut impl AsRawFd, subcmd: &'a mut T) -> Self {
+        Self {
+            code: T::ID,
+            data: subcmd as *mut T as _,
+            error: 0,
+            sev_fd: sev.as_raw_fd() as _,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// create the command from a subcommand reference
+    pub fn from(sev: &'a mut impl AsRawFd, subcmd: &'a T) -> Self {
+        Self {
+            code: T::ID,
+            data: subcmd as *const T as _,
+            error: 0,
+            sev_fd: sev.as_raw_fd() as _,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// encapsulate a `std::io::Error` in an `Indeterminate<Error>`
+    pub fn encapsulate(&self, err: std::io::Error) -> Indeterminate<Error> {
+        match self.error {
+            0 => Indeterminate::<Error>::from(err),
+            _ => Indeterminate::<Error>::from(self.error as u32),
+        }
+    }
+}
+
+/// Initialize the SEV-SNP platform in KVM.
+#[derive(Default)]
+#[repr(C, packed)]
+pub struct Init {
+    /// Reserved space, must be always set to 0 when issuing the ioctl.
+    flags: u64,
+}
+
+/// Initialize the flow to launch a guest.
+#[repr(C)]
+pub struct LaunchStart<'a> {
+    /// Guest policy. See Table 7 of the AMD SEV-SNP Firmware
+    /// specification for a description of the guest policy structure.
+    policy: u64,
+
+    /// Userspace address of migration agent
+    ma_uaddr: u64,
+
+    /// 1 if this guest is associated with a migration agent. Otherwise 0.
+    ma_en: u8,
+
+    /// 1 if this launch flow is launching an IMI for the purpose of
+    /// guest-assisted migration. Otherwise 0.
+    imi_en: u8,
+
+    /// Hypervisor provided value to indicate guest OS visible workarounds.
+    /// The format is hypervisor defined.
+    gosvw: [u8; 16],
+
+    pad: [u8; 6],
+
+    _phantom: PhantomData<&'a [u8]>,
+}
+
+impl From<Start<'_>> for LaunchStart<'_> {
+    fn from(start: Start) -> Self {
+        Self {
+            policy: start.policy.into(),
+            ma_uaddr: if let Some(addr) = start.ma_uaddr {
+                addr.as_ptr() as u64
+            } else {
+                0
+            },
+            ma_en: if start.ma_uaddr.is_some() { 1 } else { 0 },
+            imi_en: start.imi_en as _,
+            gosvw: start.gosvw,
+            pad: [0u8; 6],
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Insert pages into the guest physical address space.
+#[repr(C)]
+pub struct LaunchUpdate<'a> {
+    /// guest start frame number.
+    start_gfn: u64,
+
+    /// Userspace address of the page needed to be encrypted.
+    uaddr: u64,
+
+    /// Length of the page needed to be encrypted:
+    /// (end encryption uaddr = uaddr + len).
+    len: u32,
+
+    /// Indicates that this page is part of the IMI of the guest.
+    imi_page: u8,
+
+    /// Encoded page type. See Table 58 if the SNP Firmware specification.
+    page_type: u8,
+
+    /// VMPL permission mask for VMPL3. See Table 59 of the SNP Firmware
+    /// specification for the definition of the mask.
+    vmpl3_perms: u8,
+
+    /// VMPL permission mask for VMPL2.
+    vmpl2_perms: u8,
+
+    /// VMPL permission mask for VMPL1.
+    vmpl1_perms: u8,
+
+    _phantom: PhantomData<&'a ()>,
+}
+
+impl From<Update<'_>> for LaunchUpdate<'_> {
+    fn from(update: Update) -> Self {
+        Self {
+            start_gfn: update.start_gfn,
+            uaddr: update.uaddr.as_ptr() as _,
+            len: update.uaddr.len() as _,
+            imi_page: if update.imi_page { 1 } else { 0 },
+            page_type: update.page_type as _,
+            vmpl3_perms: update.vmpl3_perms.bits(),
+            vmpl2_perms: update.vmpl2_perms.bits(),
+            vmpl1_perms: update.vmpl1_perms.bits(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub const KVM_SEV_SNP_FINISH_DATA_SIZE: usize = 32;
+
+/// Complete the guest launch flow.
+#[repr(C)]
+pub struct LaunchFinish<'a> {
+    /// Userspace address of the ID block. Ignored if ID_BLOCK_EN is 0.
+    id_block_uaddr: u64,
+
+    /// Userspace address of the authentication information of the ID block. Ignored if ID_BLOCK_EN is 0.
+    id_auth_uaddr: u64,
+
+    /// Indicates that the ID block is present.
+    id_block_en: u8,
+
+    /// Indicates that the author key is present in the ID authentication information structure.
+    /// Ignored if ID_BLOCK_EN is 0.
+    auth_key_en: u8,
+
+    /// Opaque host-supplied data to describe the guest. The firmware does not interpret this value.
+    host_data: [u8; KVM_SEV_SNP_FINISH_DATA_SIZE],
+
+    pad: [u8; 6],
+
+    _phantom: PhantomData<&'a [u8]>,
+}
+
+impl From<Finish<'_, '_>> for LaunchFinish<'_> {
+    fn from(finish: Finish) -> Self {
+        let id_block = if let Some(addr) = finish.id_block {
+            addr.as_ptr() as u64
+        } else {
+            0
+        };
+
+        let id_auth = if let Some(addr) = finish.id_auth {
+            addr.as_ptr() as u64
+        } else {
+            0
+        };
+
+        Self {
+            id_block_uaddr: id_block,
+            id_auth_uaddr: id_auth,
+            id_block_en: if finish.id_block.is_some() { 1 } else { 0 },
+            auth_key_en: if finish.id_auth.is_some() { 1 } else { 0 },
+            host_data: finish.host_data,
+            pad: [0u8; 6],
+            _phantom: PhantomData,
+        }
+    }
+}

--- a/src/backend/sev/snp/launch/mod.rs
+++ b/src/backend/sev/snp/launch/mod.rs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! An implementation of the SEV-SNP launch process as a type-state machine.
+//! This ensures (at compile time) that the right steps are called in the
+//! right order.
+
+#[cfg(target_os = "linux")]
+pub mod linux;
+
+#[cfg(target_os = "linux")]
+use linux::*;
+
+use super::Version;
+
+use std::io::Result;
+use std::marker::PhantomData;
+use std::os::unix::io::AsRawFd;
+
+use bitflags::bitflags;
+
+/// Launcher type-state that indicates a brand new launch.
+pub struct New;
+
+/// Launcher type-state that indicates a SNP in-progress.
+pub struct Started;
+
+/// Facilitates the correct execution of the SEV launch process.
+pub struct Launcher<T, U: AsRawFd, V: AsRawFd> {
+    vm_fd: U,
+    sev: V,
+    state: PhantomData<T>,
+}
+
+impl<T, U: AsRawFd, V: AsRawFd> AsRef<U> for Launcher<T, U, V> {
+    /// Give access to the vm fd to create vCPUs or such.
+    fn as_ref(&self) -> &U {
+        &self.vm_fd
+    }
+}
+
+impl<T, U: AsRawFd, V: AsRawFd> AsMut<U> for Launcher<T, U, V> {
+    /// Give access to the vm fd to create vCPUs or such.
+    fn as_mut(&mut self) -> &mut U {
+        &mut self.vm_fd
+    }
+}
+
+impl<U: AsRawFd, V: AsRawFd> Launcher<New, U, V> {
+    /// Begin the SEV-SNP launch process by creating a Launcher and issuing the
+    /// KVM_SNP_INIT ioctl.
+    pub fn new(vm_fd: U, sev: V) -> Result<Self> {
+        let mut launcher = Launcher {
+            vm_fd,
+            sev,
+            state: PhantomData::default(),
+        };
+
+        let init = Init::default();
+
+        let mut cmd = Command::from(&mut launcher.sev, &init);
+        SNP_INIT
+            .ioctl(&mut launcher.vm_fd, &mut cmd)
+            .map_err(|e| cmd.encapsulate(e))?;
+
+        Ok(launcher)
+    }
+
+    /// Initialize the flow to launch a guest.
+    pub fn start(mut self, start: Start) -> Result<Launcher<Started, U, V>> {
+        let mut launch_start = LaunchStart::from(start);
+        let mut cmd = Command::from_mut(&mut self.sev, &mut launch_start);
+
+        SNP_LAUNCH_START
+            .ioctl(&mut self.vm_fd, &mut cmd)
+            .map_err(|e| cmd.encapsulate(e))?;
+
+        let launcher = Launcher {
+            vm_fd: self.vm_fd,
+            sev: self.sev,
+            state: PhantomData::default(),
+        };
+
+        Ok(launcher)
+    }
+}
+
+impl<U: AsRawFd, V: AsRawFd> Launcher<Started, U, V> {
+    /// Encrypt guest SNP data.
+    pub fn update_data(&mut self, update: Update) -> Result<()> {
+        let launch_update_data = LaunchUpdate::from(update);
+        let mut cmd = Command::from(&mut self.sev, &launch_update_data);
+
+        KvmEncRegion::new(update.uaddr).register(&mut self.vm_fd)?;
+
+        SNP_LAUNCH_UPDATE
+            .ioctl(&mut self.vm_fd, &mut cmd)
+            .map_err(|e| cmd.encapsulate(e))?;
+
+        Ok(())
+    }
+
+    /// Complete the SNP launch process.
+    pub fn finish(mut self, finish: Finish) -> Result<(U, V)> {
+        let launch_finish = LaunchFinish::from(finish);
+        let mut cmd = Command::from(&mut self.sev, &launch_finish);
+
+        SNP_LAUNCH_FINISH
+            .ioctl(&mut self.vm_fd, &mut cmd)
+            .map_err(|e| cmd.encapsulate(e))?;
+
+        Ok((self.vm_fd, self.sev))
+    }
+}
+
+bitflags! {
+    /// Configurable SNP Policy options.
+    #[derive(Default)]
+    pub struct PolicyFlags: u16 {
+        /// Enable if SMT is enabled in the host machine.
+        const SMT = 1;
+
+        /// If enabled, association with a migration agent is allowed.
+        const MIGRATE_MA = 1 << 2;
+
+        /// If enabled, debugging is allowed.
+        const DEBUG = 1 << 3;
+    }
+}
+
+/// Describes a policy that the AMD Secure Processor will
+/// enforce.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Policy {
+    /// The various policy optons are encoded as bit flags.
+    pub flags: PolicyFlags,
+
+    /// The desired minimum platform firmware version.
+    pub minfw: Version,
+}
+
+impl From<Policy> for u64 {
+    fn from(policy: Policy) -> u64 {
+        let mut val: u64 = 0;
+
+        let minor_version = u64::from(policy.minfw.minor);
+        let mut major_version = u64::from(policy.minfw.major);
+
+        /*
+         * According to the SNP firmware spec, bit 1 of the policy flags is reserved and must
+         * always be set to 1. Rather than passing this responsibility off to callers, set this bit
+         * every time an ioctl is issued to the kernel.
+         */
+        let flags = policy.flags.bits | 0b10;
+        let mut flags_64 = u64::from(flags);
+
+        major_version <<= 8;
+        flags_64 <<= 16;
+
+        val |= minor_version;
+        val |= major_version;
+        val |= flags_64;
+        val &= 0x00FFFFFF;
+
+        val
+    }
+}
+
+/// Encapsulates the various data needed to begin the launch process.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Start<'a> {
+    /// The userspace address of the migration agent region to be encrypted.
+    pub(crate) ma_uaddr: Option<&'a [u8]>,
+
+    /// Describes a policy that the AMD Secure Processor will enforce.
+    pub(crate) policy: Policy,
+
+    /// Indicates that this launch flow is launching an IMI for the purpose of guest-assisted migration.
+    pub(crate) imi_en: bool,
+
+    /// Hypervisor provided value to indicate guest OS visible workarounds.The format is hypervisor defined.
+    pub(crate) gosvw: [u8; 16],
+}
+
+/// Encapsulates the various data needed to begin the update process.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Update<'a> {
+    /// guest start frame number.
+    pub(crate) start_gfn: u64,
+
+    /// The userspace of address of the encrypted region.
+    pub(crate) uaddr: &'a [u8],
+
+    /// Indicates that this page is part of the IMI of the guest.
+    pub(crate) imi_page: bool,
+
+    /// Encoded page type.
+    pub(crate) page_type: PageType,
+
+    /// VMPL3 permission mask.
+    pub(crate) vmpl3_perms: VmplPerms,
+
+    /// VMPL2 permission mask.
+    pub(crate) vmpl2_perms: VmplPerms,
+
+    /// VMPL1 permission mask.
+    pub(crate) vmpl1_perms: VmplPerms,
+}
+
+impl<'a> Update<'a> {
+    /// Encapsulate all data needed for the SNP_LAUNCH_UPDATE ioctl.
+    pub fn new(
+        start_gfn: u64,
+        uaddr: &'a [u8],
+        imi_page: bool,
+        page_type: PageType,
+        perms: (VmplPerms, VmplPerms, VmplPerms),
+    ) -> Self {
+        Self {
+            start_gfn,
+            uaddr,
+            imi_page,
+            page_type,
+            vmpl3_perms: perms.2,
+            vmpl2_perms: perms.1,
+            vmpl1_perms: perms.0,
+        }
+    }
+}
+
+bitflags! {
+    #[derive(Default)]
+    /// VMPL permission masks.
+    pub struct VmplPerms: u8 {
+        /// Page is readable by the VMPL.
+        const READ = 1;
+
+        /// Page is writeable by the VMPL.
+        const WRITE = 1 << 1;
+
+        /// Page is executable by the VMPL in CPL3.
+        const EXECUTE_USER = 1 << 2;
+
+        /// Page is executable by the VMPL in CPL2, CPL1, and CPL0.
+        const EXECUTE_SUPERVISOR = 1 << 3;
+    }
+}
+
+/// Encoded page types for a launch update. See Table 58 of the SNP Firmware
+/// specification for further details.
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C)]
+#[non_exhaustive]
+pub enum PageType {
+    /// A normal data page.
+    Normal = 0x1,
+
+    /// A VMSA page.
+    Vmsa = 0x2,
+
+    /// A page full of zeroes.
+    Zero = 0x3,
+
+    /// A page that is encrypted but not measured
+    Unmeasured = 0x4,
+
+    /// A page for the firmware to store secrets for the guest.
+    Secrets = 0x5,
+
+    /// A page for the hypervisor to provide CPUID function values.
+    Cpuid = 0x6,
+}
+
+/// Encapsulates the data needed to complete a guest launch.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Finish<'a, 'b> {
+    /// The userspace address of the encrypted region.
+    pub(crate) id_block: Option<&'a [u8]>,
+
+    /// The userspace address of the authentication information of the ID block.
+    pub(crate) id_auth: Option<&'b [u8]>,
+
+    /// Opaque host-supplied data to describe the guest. The firmware does not interpret this
+    /// value.
+    pub(crate) host_data: [u8; KVM_SEV_SNP_FINISH_DATA_SIZE],
+}
+
+impl<'a, 'b> Finish<'a, 'b> {
+    /// Encapsulate all data needed for the SNP_LAUNCH_FINISH ioctl.
+    pub fn new(
+        id_block: Option<&'a [u8]>,
+        id_auth: Option<&'b [u8]>,
+        host_data: [u8; KVM_SEV_SNP_FINISH_DATA_SIZE],
+    ) -> Self {
+        Self {
+            id_block,
+            id_auth,
+            host_data,
+        }
+    }
+}

--- a/src/backend/sev/snp/mod.rs
+++ b/src/backend/sev/snp/mod.rs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Everything one needs to launch an AMD SEV encrypted virtual machine.
+//!
+//! This module contains types for establishing a secure channel with the
+//! AMD Secure Processor for purposes of attestation as well as abstractions
+//! for navigating the AMD SEV launch process for a virtual machine.
+
+/// A simple const generics substitute.
+#[doc(hidden)]
+macro_rules! impl_const_id {
+    (
+        $(#[$outer:meta])*
+        $visibility:vis $trait:ident => $id_ty:ty;
+        $(
+            $iocty:ty = $val:expr
+        ),* $(,)*
+    ) => {
+        $(#[$outer])*
+        $visibility trait $trait {
+            $(#[$outer])*
+            const ID: $id_ty;
+        }
+
+        $(
+            impl $trait for $iocty {
+                const ID: $id_ty = $val;
+            }
+        )*
+    };
+}
+
+pub mod firmware;
+pub mod launch;
+
+use std::fmt::{Debug, Display, Formatter};
+use std::{error, io};
+
+/// There are a number of error conditions that can occur between this
+/// layer all the way down to the SEV platform. Most of these cases have
+/// been enumerated; however, there is a possibility that some error
+/// conditions are not encapsulated here.
+#[derive(Debug)]
+pub enum Indeterminate<T: Debug> {
+    /// The error condition is known.
+    Known(T),
+
+    /// The error condition is unknown.
+    Unknown,
+}
+
+impl<T: Debug + Display> Display for Indeterminate<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Indeterminate::Known(e) => {
+                write!(f, "{}", e)
+            }
+            Indeterminate::Unknown => {
+                write!(f, "Unknown Error",)
+            }
+        }
+    }
+}
+
+impl<T: Debug + Display> error::Error for Indeterminate<T> {}
+
+/// Error conditions returned by the SEV platform or by layers above it
+/// (i.e., the Linux kernel).
+///
+/// These error conditions are documented in the AMD SEV API spec, but
+/// their documentation has been copied here for completeness.
+#[derive(Debug)]
+pub enum Error {
+    /// Something went wrong when communicating with the "outside world"
+    /// (kernel, SEV platform).
+    Io(io::Error),
+
+    /// The platform state is invalid for this command.
+    InvalidPlatformState,
+
+    /// The guest state is invalid for this command.
+    InvalidGuestState,
+
+    /// The platform configuration is invalid.
+    InvalidConfig,
+
+    /// A memory buffer is too small.
+    InvalidLen,
+
+    /// The platform is already owned.
+    AlreadyOwned,
+
+    /// The certificate is invalid.
+    InvalidCertificate,
+
+    /// Request is not allowed by guest policy.
+    PolicyFailure,
+
+    /// The guest is inactive.
+    Inactive,
+
+    /// The address provided is invalid.
+    InvalidAddress,
+
+    /// The provided signature is invalid.
+    BadSignature,
+
+    /// The provided measurement is invalid.
+    BadMeasurement,
+
+    /// The ASID is already owned.
+    AsidOwned,
+
+    /// The ASID is invalid.
+    InvalidAsid,
+
+    /// WBINVD instruction required.
+    WbinvdRequired,
+
+    /// `DF_FLUSH` invocation required.
+    DfFlushRequired,
+
+    /// The guest handle is invalid.
+    InvalidGuest,
+
+    /// The command issued is invalid.
+    InvalidCommand,
+
+    /// The guest is active.
+    Active,
+
+    /// A hardware condition has occurred affecting the platform. It is safe
+    /// to re-allocate parameter buffers.
+    HardwarePlatform,
+
+    /// A hardware condition has occurred affecting the platform. Re-allocating
+    /// parameter buffers is not safe.
+    HardwareUnsafe,
+
+    /// Feature is unsupported.
+    Unsupported,
+
+    /// A given parameter is invalid.
+    InvalidParam,
+
+    /// The SEV firmware has run out of a resource required to carry out the
+    /// command.
+    ResourceLimit,
+
+    /// The SEV platform observed a failed integrity check.
+    SecureDataInvalid,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let err_description = match self {
+            Error::Io(_) => "I/O Error",
+            Error::InvalidPlatformState => "Invalid platform state",
+            Error::InvalidGuestState => "Invalid guest state",
+            Error::InvalidConfig => "Platform configuration invalid",
+            Error::InvalidLen => "Memory buffer too small",
+            Error::AlreadyOwned => "Platform is already owned",
+            Error::InvalidCertificate => "Invalid certificate",
+            Error::PolicyFailure => "Policy failure",
+            Error::Inactive => "Guest is inactive",
+            Error::InvalidAddress => "Provided address is invalid",
+            Error::BadSignature => "Provided signature is invalid",
+            Error::BadMeasurement => "Provided measurement is invalid",
+            Error::AsidOwned => "ASID is already owned",
+            Error::InvalidAsid => "ASID is invalid",
+            Error::WbinvdRequired => "WBINVD instruction required",
+            Error::DfFlushRequired => "DF_FLUSH invocation required",
+            Error::InvalidGuest => "Guest handle is invalid",
+            Error::InvalidCommand => "Issued command is invalid",
+            Error::Active => "Guest is active",
+            Error::HardwarePlatform => {
+                "Hardware condition occured, safe to re-allocate parameter buffers"
+            }
+            Error::HardwareUnsafe => {
+                "Hardware condition occured, unsafe to re-allocate parameter buffers"
+            }
+            Error::Unsupported => "Feature is unsupported",
+            Error::InvalidParam => "Given parameter is invalid",
+            Error::ResourceLimit => {
+                "SEV firmware has run out of required resources to carry out command"
+            }
+            Error::SecureDataInvalid => "SEV platform observed a failed integrity check",
+        };
+        write!(f, "{}", err_description)
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    #[inline]
+    fn from(error: io::Error) -> Error {
+        Error::Io(error)
+    }
+}
+
+impl From<io::Error> for Indeterminate<Error> {
+    #[inline]
+    fn from(error: io::Error) -> Indeterminate<Error> {
+        Indeterminate::Known(error.into())
+    }
+}
+
+impl From<Indeterminate<Error>> for io::Error {
+    #[inline]
+    fn from(indeterminate: Indeterminate<Error>) -> io::Error {
+        match indeterminate {
+            Indeterminate::Known(e) => io::Error::new(io::ErrorKind::Other, e),
+            Indeterminate::Unknown => io::Error::new(io::ErrorKind::Other, "unknown SEV error"),
+        }
+    }
+}
+
+impl From<u32> for Indeterminate<Error> {
+    #[inline]
+    fn from(error: u32) -> Indeterminate<Error> {
+        Indeterminate::Known(match error {
+            0 => io::Error::last_os_error().into(),
+            1 => Error::InvalidPlatformState,
+            2 => Error::InvalidGuestState,
+            3 => Error::InvalidConfig,
+            4 => Error::InvalidLen,
+            5 => Error::AlreadyOwned,
+            6 => Error::InvalidCertificate,
+            7 => Error::PolicyFailure,
+            8 => Error::Inactive,
+            9 => Error::InvalidAddress,
+            10 => Error::BadSignature,
+            11 => Error::BadMeasurement,
+            12 => Error::AsidOwned,
+            13 => Error::InvalidAsid,
+            14 => Error::WbinvdRequired,
+            15 => Error::DfFlushRequired,
+            16 => Error::InvalidGuest,
+            17 => Error::InvalidCommand,
+            18 => Error::Active,
+            19 => Error::HardwarePlatform,
+            20 => Error::HardwareUnsafe,
+            21 => Error::Unsupported,
+            22 => Error::InvalidParam,
+            23 => Error::ResourceLimit,
+            24 => Error::SecureDataInvalid,
+            _ => return Indeterminate::Unknown,
+        })
+    }
+}
+
+/// Information about the SEV platform version.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+    /// The major version number.
+    pub major: u8,
+
+    /// The minor version number.
+    pub minor: u8,
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    struct A;
+    struct B;
+    struct C;
+
+    impl_const_id! {
+        Id => usize;
+        A = 1,
+        B = 2,
+        C = 3,
+    }
+
+    #[test]
+    fn test_const_id_macro() {
+        assert_eq!(A::ID, 1);
+        assert_eq!(B::ID, 2);
+        assert_eq!(C::ID, 3);
+    }
+}


### PR DESCRIPTION
And put the needed parts in `backend::sev::snp`.

Signed-off-by: Harald Hoyer <harald@profian.com>
Co-authored-by: Roman Volosatovs <roman@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
