### PR TITLE
wasmldr: change version to 0.1.0, bump wasmparser dep

### DIFF
--- a/internal/wasmldr/Cargo.toml
+++ b/internal/wasmldr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmldr"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["The Enarx Project Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ exclude = [ ".gitignore", ".github/*" ]
 wasmtime = { version = "0.30", default-features = false, features = ["cranelift"] }
 wasmtime-wasi = { version = "0.30", default-features = false, features = ["sync"] }
 wasi-common = { version = "0.30", default-features = false }
-wasmparser = "0.80"
+wasmparser = "0.81"
 structopt = { version = "0.3", default-features = false }
 anyhow = "1.0"
 env_logger = { version = "0.9", default-features = false }


### PR DESCRIPTION
Very minor tweak - everything else is v0.1.0, so make wasmldr match
that. Also, while we're here, pull in wasmparser 0.81.

Signed-off-by: Will Woods <will@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
