### PR TITLE
feat(shim-sev): use different interrupt macros

### DIFF
--- a/internal/shim-sev/Cargo.lock
+++ b/internal/shim-sev/Cargo.lock
@@ -196,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,11 +292,11 @@ dependencies = [
  "lset",
  "nbytes",
  "noted",
+ "paste",
  "primordial",
  "rcrt1",
  "sallyport",
  "spinning",
- "volatile",
  "x86_64",
  "xsave",
 ]

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -13,8 +13,6 @@ test = false
 sallyport = { git = "https://github.com/enarx/sallyport", rev = "d016f8c6afd50ae2694ddc2d2afea4eec7301a41", features = [ "asm" ] }
 rcrt1 = { git = "https://github.com/enarx/rcrt1", rev = "b28f711" }
 compiler_builtins = { version = "0.1", default-features = false, features = [ "mem" ] }
-# FIXME: can be removed with the release of `x86_64` > 0.14.6
-volatile = "0.4.4"
 x86_64 = { version = "^0.14.6", default-features = false, features = ["instructions", "inline_asm"] }
 goblin = { version = "0.4", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
@@ -32,6 +30,7 @@ bitflags = "1.3.2"
 lock_api = "0.4.5"
 aes-gcm = { version = "0.9.4", features = ["aes"], default-features = false  }
 const-default = { version = "0.2", features = [ "derive" ] }
+paste = "1.0.5"
 
 [profile.dev.package.rcrt1]
 opt-level = 3

--- a/internal/shim-sev/src/interrupts.rs
+++ b/internal/shim-sev/src/interrupts.rs
@@ -6,22 +6,68 @@ use crate::addr::SHIM_VIRT_OFFSET;
 use crate::debug::print_stack_trace;
 use crate::eprintln;
 use crate::hostcall::shim_exit;
-use crate::idt::{InterruptDescriptorTable, InterruptStackFrame};
+use crate::idt::InterruptDescriptorTable;
 use crate::payload::PAYLOAD_VIRT_ADDR;
 use crate::snp::cpuid_count;
 
+use core::fmt;
 use core::mem::size_of;
+use core::ops::Deref;
 
+use paste::paste;
 use spinning::Lazy;
 use x86_64::structures::idt::PageFaultErrorCode;
+use x86_64::VirtAddr;
 use xsave::XSave;
 
 /// size of area reserved for xsave
 pub const XSAVE_AREA_SIZE: u32 = size_of::<XSave>() as _;
 
+#[repr(C)]
+struct ExtendedInterruptStackFrame {
+    value: ExtendedInterruptStackFrameValue,
+}
+
+impl ExtendedInterruptStackFrame {
+    /// Gives mutable access to the contents of the interrupt stack frame.
+    ///
+    /// The `Volatile` wrapper is used because LLVM optimizations remove non-volatile
+    /// modifications of the interrupt stack frame.
+    ///
+    /// ## Safety
+    ///
+    /// This function is unsafe since modifying the content of the interrupt stack frame
+    /// can easily lead to undefined behavior. For example, by writing an invalid value to
+    /// the instruction pointer field, the CPU can jump to arbitrary code at the end of the
+    /// interrupt.
+    ///
+    /// Also, it is not fully clear yet whether modifications of the interrupt stack frame are
+    /// officially supported by LLVM's x86 interrupt calling convention.
+    #[inline]
+    unsafe fn as_mut(&mut self) -> &mut ExtendedInterruptStackFrameValue {
+        &mut self.value
+    }
+}
+
+impl Deref for ExtendedInterruptStackFrame {
+    type Target = ExtendedInterruptStackFrameValue;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl fmt::Debug for ExtendedInterruptStackFrame {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
 #[derive(Debug)]
 #[repr(C)]
-struct EnarxInterruptStackFrame {
+struct ExtendedInterruptStackFrameValue {
     rbp: u64,
     rbx: u64,
     r11: u64,
@@ -31,232 +77,238 @@ struct EnarxInterruptStackFrame {
     rax: u64,
     rcx: u64,
     rdx: u64,
-    rsi: u64,
     rdi: u64,
-    frame: InterruptStackFrame,
-}
-
-#[derive(Debug)]
-#[repr(C)]
-struct EnarxInterruptStackFrameWithArg {
-    rbp: u64,
-    rbx: u64,
-    r11: u64,
-    r10: u64,
-    r9: u64,
-    r8: u64,
-    rax: u64,
-    rcx: u64,
-    rdx: u64,
     rsi: u64,
-    rdi: u64,
-    error_code: u64,
-    frame: InterruptStackFrame,
+    /// This value points to the instruction that should be executed when the interrupt
+    /// handler returns. For most interrupts, this value points to the instruction immediately
+    /// following the last executed instruction. However, for some exceptions (e.g., page faults),
+    /// this value points to the faulting instruction, so that the instruction is restarted on
+    /// return. See the documentation of the [`InterruptDescriptorTable`] fields for more details.
+    instruction_pointer: VirtAddr,
+    /// The code segment selector, padded with zeros.
+    code_segment: u64,
+    /// The flags register before the interrupt handler was invoked.
+    cpu_flags: u64,
+    /// The stack pointer at the time of the interrupt.
+    stack_pointer: VirtAddr,
+    /// The stack segment descriptor at the time of the interrupt (often zero in 64-bit mode).
+    stack_segment: u64,
 }
-
-/// A handler function for an interrupt or an exception without error code.
-#[allow(dead_code)]
-type HandlerFunc = extern "sysv64" fn(&mut EnarxInterruptStackFrame);
-
-/// A handler function for an exception that pushes an error code.
-#[allow(dead_code)]
-type HandlerFuncWithErrCode =
-    extern "sysv64" fn(&mut EnarxInterruptStackFrameWithArg, error_code: u64);
-
-/// A page fault handler function that pushes a page fault error code.
-#[allow(dead_code)]
-type PageFaultHandlerFunc =
-    extern "sysv64" fn(&mut EnarxInterruptStackFrameWithArg, error_code: PageFaultErrorCode);
-
-/// A handler function that must not return, e.g. for a machine check exception.
-#[allow(dead_code)]
-type DivergingHandlerFunc = extern "sysv64" fn(&mut EnarxInterruptStackFrame) -> !;
-
-/// A handler function with an error code that must not return, e.g. for a double fault exception.
-#[allow(dead_code)]
-type DivergingHandlerFuncWithErrCode =
-    extern "sysv64" fn(&mut EnarxInterruptStackFrameWithArg, error_code: u64) -> !;
 
 /// name - interrupt func name
 /// number - interrupt number
 /// callout - call out to extern "sysv64" function
 /// has_error - has error parameter
 macro_rules! declare_interrupt {
-    ($name:ident : HandlerFunc => $callout:ident) => {
-        declare_interrupt!($name : HandlerFunc : 0 => $callout);
+    (fn $name:ident ( $stack:ident : &mut ExtendedInterruptStackFrame $(,)? ) $code:block) => {
+        paste! {
+            extern "sysv64" fn [<__interrupt_ $name>]($stack: &mut ExtendedInterruptStackFrame) {
+                $code
+            }
+        }
+        declare_interrupt!($name => "push rsi");
     };
 
-    ($name:ident : HandlerFuncWithErrCode => $callout:ident) => {
-        declare_interrupt!($name : HandlerFuncWithErrCode : 8 => $callout);
+    (fn $name:ident ( $stack:ident : &mut ExtendedInterruptStackFrame , $error:ident : u64 $(,)? ) $code:block) => {
+        paste! {
+            extern "sysv64" fn [<__interrupt_ $name>]($stack: &mut ExtendedInterruptStackFrame, $error: u64) {
+                $code
+            }
+        }
+        declare_interrupt!($name => "xchg [rsp], rsi");
     };
 
-    ($name:ident : PageFaultHandlerFunc => $callout:ident) => {
-        declare_interrupt!($name : PageFaultHandlerFunc : 8 => $callout);
+    (fn $name:ident ( $stack:ident : &mut ExtendedInterruptStackFrame , $error:ident : PageFaultErrorCode $(,)? ) $code:block) => {
+        paste! {
+            extern "sysv64" fn [<__interrupt_ $name>]($stack: &mut ExtendedInterruptStackFrame, $error: PageFaultErrorCode) {
+                $code
+            }
+        }
+        declare_interrupt!($name => "xchg [rsp], rsi");
     };
 
-    ($name:ident : DivergingHandlerFunc => $callout:ident) => {
-        declare_interrupt!($name : DivergingHandlerFunc : 0 => $callout);
+    (fn $name:ident ( $stack:ident : &mut ExtendedInterruptStackFrame $(,)? ) -> ! $code:block) => {
+        paste! {
+            extern "sysv64" fn [<__interrupt_ $name>]($stack: &mut ExtendedInterruptStackFrame) {
+                $code
+            }
+        }
+        declare_interrupt!($name => "push rsi");
     };
 
-    ($name:ident : DivergingHandlerFuncWithErrCode => $callout:ident) => {
-        declare_interrupt!($name : DivergingHandlerFuncWithErrCode : 8 => $callout);
+    (fn $name:ident ( $stack:ident : &mut ExtendedInterruptStackFrame, $error:ident : u64 $(,)? )  -> ! $code:block) => {
+        paste! {
+            extern "sysv64" fn [<__interrupt_ $name>]($stack: &mut ExtendedInterruptStackFrame, $error: u64) {
+                $code
+            }
+        }
+        declare_interrupt!($name => "xchg [rsp], rsi");
     };
 
-    ($name:ident : $type:ty : $skip:expr => $callout:ident) => {
-        #[naked]
-        #[doc = "interrupt service routine"]
-        pub unsafe extern "sysv64" fn $name() -> ! {
-            const _TYPE_CHECK: $type = $callout;
+    ($name:ident => $push_or_exchange:literal) => {
+        paste! {
+            #[naked]
+            unsafe extern "sysv64" fn $name() -> ! {
+                asm!(
+                    // either push rsi or exchange with error code
+                    $push_or_exchange,
+                    "push   rdi",
+                    "push   rdx",
+                    "push   rcx",
+                    "push   rax",
+                    "push   r8",
+                    "push   r9",
+                    "push   r10",
+                    "push   r11",
+                    "push   rbx",
+                    "push   rbp",
 
-            asm!("
-            push   rdi
-            push   rsi
-            push   rdx
-            push   rcx
-            push   rax
-            push   r8
-            push   r9
-            push   r10
-            push   r11
-            push   rbx
-            push   rbp
+                    // save stack frame
+                    "mov    rbx, rsp",
 
-            // save stack frame
-            mov    rbx, rsp
-            mov    rsi, QWORD PTR [rsp+11*8]
+                    // rsp is first argument
+                    "mov    rdi, rsp",
 
-            // rsp is first argument
-            mov    rdi, rsp
+                    "sub   rsp, {XSAVE_STACK_OFFSET}",
+                    // align stack
+                    "and   rsp, (~(0x40-1))",
 
-            sub   rsp, {XSAVE_STACK_OFFSET}
-            // align stack
-            and   rsp, (~(0x40-1))
+                    // xsave
+                    // memzero xsave array
+                    "xor     rax, rax",
+                    "2:",
+                    "mov     QWORD PTR [rsp+rax*8], 0x0",
+                    "add     eax, 0x1",
+                    "cmp     eax, ({XSAVE_STACK_OFFSET}/8)",
+                    "jne     2b",
 
-            // xsave
-            // memzero xsave array
-            xor     rax, rax
-        2:
-            mov     QWORD PTR [rsp+rax*8], 0x0
-            add     eax, 0x1
-            cmp     eax, ({XSAVE_STACK_OFFSET}/8)
-            jne     2b
+                    "mov   edx, -1",
+                    "mov   eax, -1",
+                    "xsave  [rsp]",
 
-            mov   edx, -1
-            mov   eax, -1
-            xsave  [rsp]
+                    // SYSV:    rdi, rsi, rdx, rcx, r8, r9
+                    "call  {CALLOUT}",
 
-            // SYSV:    rdi, rsi, rdx, rcx, r8, r9
-            call  {CALLOUT}
+                    // xrstor
+                    "mov   edx, -1",
+                    "mov   eax, -1",
+                    "xrstor [rsp]",
 
-            // xrstor
-            mov   edx, -1
-            mov   eax, -1
-            xrstor [rsp]
+                    // restore stack frame
+                    "mov    rsp, rbx",
 
-            // restore stack frame
-            mov    rsp, rbx
+                    "pop    rbp",
+                    "pop    rbx",
+                    "pop    r11",
+                    "pop    r10",
+                    "pop    r9",
+                    "pop    r8",
+                    "pop    rax",
+                    "pop    rcx",
+                    "pop    rdx",
+                    "pop    rdi",
+                    "pop    rsi",
 
-            pop    rbp
-            pop    rbx
-            pop    r11
-            pop    r10
-            pop    r9
-            pop    r8
-            pop    rax
-            pop    rcx
-            pop    rdx
-            pop    rsi
-            pop    rdi
+                    "iretq",
 
-            // skip error_code
-            add    rsp, {SKIP}
+                    // add 64 for alignment
+                    XSAVE_STACK_OFFSET = const (XSAVE_AREA_SIZE + 64),
+                    CALLOUT = sym [<__interrupt_ $name>],
 
-            iretq
-            ",
-            SKIP = const ($skip),
-            // add 64 for alignment
-            XSAVE_STACK_OFFSET = const (XSAVE_AREA_SIZE + 64),
-            CALLOUT = sym $callout,
-            options(noreturn)
-            )
+                    options(noreturn)
+                )
+            }
         }
     };
 }
-
-declare_interrupt!(isr_0: HandlerFunc => divide_error_handler);
-declare_interrupt!(isr_1: HandlerFunc => debug_handler);
-declare_interrupt!(isr_2: HandlerFunc => non_maskable_interrupt_handler);
-declare_interrupt!(isr_3: HandlerFunc => breakpoint_handler);
-declare_interrupt!(isr_4: HandlerFunc => overflow_handler);
-declare_interrupt!(isr_5: HandlerFunc => bound_range_exceeded_handler);
-declare_interrupt!(isr_6: HandlerFunc => invalid_opcode_handler);
-declare_interrupt!(isr_7: HandlerFunc => device_not_available_handler);
-declare_interrupt!(isr_8: DivergingHandlerFuncWithErrCode => double_fault_handler);
-declare_interrupt!(isr_10: HandlerFuncWithErrCode => invalid_tss_handler);
-declare_interrupt!(isr_11: HandlerFuncWithErrCode => segment_not_present_handler);
-declare_interrupt!(isr_12: HandlerFuncWithErrCode => stack_segment_fault);
-declare_interrupt!(isr_13: HandlerFuncWithErrCode => general_protection_fault);
-declare_interrupt!(isr_14: PageFaultHandlerFunc => page_fault_handler);
-declare_interrupt!(isr_16: HandlerFunc => x87_floating_point_handler);
-declare_interrupt!(isr_17: HandlerFuncWithErrCode => alignment_check_handler);
-declare_interrupt!(isr_18: DivergingHandlerFunc => machine_check_handler);
-declare_interrupt!(isr_19: HandlerFunc => simd_floating_point_handler);
-declare_interrupt!(isr_20: HandlerFunc => virtualization_handler);
-declare_interrupt!(isr_29: HandlerFuncWithErrCode => vmm_communication_exception_handler);
-declare_interrupt!(isr_30: HandlerFuncWithErrCode => security_exception_handler);
 
 /// The global IDT
 pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
     unsafe {
-        idt.divide_error.set_handler_fn(isr_0).set_stack_index(6);
-        idt.debug.set_handler_fn(isr_1).set_stack_index(1);
+        let virt = VirtAddr::new_unsafe(divide_error_handler as usize as u64);
+        idt.divide_error.set_handler_addr(virt).set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(debug_handler as usize as u64);
+        idt.debug.set_handler_addr(virt).set_stack_index(1);
+
+        let virt = VirtAddr::new_unsafe(non_maskable_interrupt_handler as usize as u64);
         idt.non_maskable_interrupt
-            .set_handler_fn(isr_2)
+            .set_handler_addr(virt)
             .set_stack_index(2);
-        idt.breakpoint.set_handler_fn(isr_3).set_stack_index(1);
-        idt.overflow.set_handler_fn(isr_4).set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(breakpoint_handler as usize as u64);
+        idt.breakpoint.set_handler_addr(virt).set_stack_index(1);
+
+        let virt = VirtAddr::new_unsafe(overflow_handler as usize as u64);
+        idt.overflow.set_handler_addr(virt).set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(bound_range_exceeded_handler as usize as u64);
         idt.bound_range_exceeded
-            .set_handler_fn(isr_5)
+            .set_handler_addr(virt)
             .set_stack_index(6);
 
-        idt.invalid_opcode.set_handler_fn(isr_6).set_stack_index(5);
+        let virt = VirtAddr::new_unsafe(invalid_opcode_handler as usize as u64);
+        idt.invalid_opcode.set_handler_addr(virt).set_stack_index(5);
 
+        let virt = VirtAddr::new_unsafe(device_not_available_handler as usize as u64);
         idt.device_not_available
-            .set_handler_fn(isr_7)
+            .set_handler_addr(virt)
             .set_stack_index(5);
 
-        idt.double_fault.set_handler_fn(isr_8).set_stack_index(0);
+        let virt = VirtAddr::new_unsafe(double_fault_handler as usize as u64);
+        idt.double_fault.set_handler_addr(virt).set_stack_index(0);
 
-        idt.invalid_tss.set_handler_fn(isr_10).set_stack_index(6);
+        let virt = VirtAddr::new_unsafe(invalid_tss_handler as usize as u64);
+        idt.invalid_tss.set_handler_addr(virt).set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(segment_not_present_handler as usize as u64);
         idt.segment_not_present
-            .set_handler_fn(isr_11)
+            .set_handler_addr(virt)
             .set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(stack_segment_fault as usize as u64);
         idt.stack_segment_fault
-            .set_handler_fn(isr_12)
+            .set_handler_addr(virt)
             .set_stack_index(6);
 
+        let virt = VirtAddr::new_unsafe(general_protection_fault as usize as u64);
         idt.general_protection_fault
-            .set_handler_fn(isr_13)
+            .set_handler_addr(virt)
             .set_stack_index(6);
 
-        idt.page_fault.set_handler_fn(isr_14).set_stack_index(6);
+        let virt = VirtAddr::new_unsafe(page_fault_handler as usize as u64);
+        idt.page_fault.set_handler_addr(virt).set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(x87_floating_point_handler as usize as u64);
         idt.x87_floating_point
-            .set_handler_fn(isr_16)
+            .set_handler_addr(virt)
             .set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(alignment_check_handler as usize as u64);
         idt.alignment_check
-            .set_handler_fn(isr_17)
+            .set_handler_addr(virt)
             .set_stack_index(6);
-        idt.machine_check.set_handler_fn(isr_18).set_stack_index(0);
+
+        let virt = VirtAddr::new_unsafe(machine_check_handler as usize as u64);
+        idt.machine_check.set_handler_addr(virt).set_stack_index(0);
+
+        let virt = VirtAddr::new_unsafe(simd_floating_point_handler as usize as u64);
         idt.simd_floating_point
-            .set_handler_fn(isr_19)
+            .set_handler_addr(virt)
             .set_stack_index(6);
-        idt.virtualization.set_handler_fn(isr_20).set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(virtualization_handler as usize as u64);
+        idt.virtualization.set_handler_addr(virt).set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(vmm_communication_exception_handler as usize as u64);
         idt.vmm_communication_exception
-            .set_handler_fn(isr_29)
+            .set_handler_addr(virt)
             .set_stack_index(6);
+
+        let virt = VirtAddr::new_unsafe(security_exception_handler as usize as u64);
         idt.security_exception
-            .set_handler_fn(isr_30)
+            .set_handler_addr(virt)
             .set_stack_index(6);
     }
     idt
@@ -269,221 +321,237 @@ pub fn init() {
     IDT.load();
 }
 
-extern "sysv64" fn stack_segment_fault(
-    stack_frame: &mut EnarxInterruptStackFrameWithArg,
-    error_code: u64,
-) {
-    eprintln!("stack_segment_fault {}", error_code);
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn general_protection_fault(
-    stack_frame: &mut EnarxInterruptStackFrameWithArg,
-    error_code: u64,
-) {
-    eprintln!("general_protection_fault {:#b}", error_code);
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn segment_not_present_handler(
-    stack_frame: &mut EnarxInterruptStackFrameWithArg,
-    error_code: u64,
-) {
-    eprintln!("segment_not_present_handler {}", error_code);
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn invalid_opcode_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("invalid_opcode_handler");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn divide_error_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("divide_error_handler");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn debug_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("debug_handler");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn overflow_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("overflow_handler");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn bound_range_exceeded_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("bound_range_exceeded_handler");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn device_not_available_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("device_not_available_handler");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn x87_floating_point_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("x87_floating_point_handler");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn alignment_check_handler(
-    stack_frame: &mut EnarxInterruptStackFrameWithArg,
-    error_code: u64,
-) {
-    eprintln!("alignment_check_handler");
-    eprintln!("Error Code: {:?}", error_code);
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn machine_check_handler(stack_frame: &mut EnarxInterruptStackFrame) -> ! {
-    eprintln!("machine_check_handler");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-
-extern "sysv64" fn simd_floating_point_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("simd_floating_point_handler");
-    eprintln!("{:#?}", stack_frame);
-
-    let mxcsr: u32 = 0;
-    unsafe {
-        asm!("stmxcsr [{}]",
-                in(reg) &mxcsr,
-                options(nostack),
-        );
+declare_interrupt!(
+    fn stack_segment_fault(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
+        eprintln!("stack_segment_fault {}", error_code);
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
     }
+);
 
-    eprintln!("MXCSR: {:#b}", mxcsr);
+declare_interrupt!(
+    fn general_protection_fault(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
+        eprintln!("general_protection_fault {:#b}", error_code);
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-    let mut addr = stack_frame.frame.instruction_pointer;
+declare_interrupt!(
+    fn segment_not_present_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
+        eprintln!("segment_not_present_handler {}", error_code);
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-    let payload_virt = *PAYLOAD_VIRT_ADDR.read();
+declare_interrupt!(
+    fn invalid_opcode_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("invalid_opcode_handler");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-    if addr.as_u64() < SHIM_VIRT_OFFSET && addr > payload_virt {
-        addr -= payload_virt.as_u64();
-        eprintln!("TRACE:\nP 0x{:>016x}", addr.as_u64());
-    } else {
-        eprintln!("TRACE:\nS 0x{:>016x}", addr.as_u64());
-    };
+declare_interrupt!(
+    fn divide_error_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("divide_error_handler");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-    print_stack_trace();
-    shim_exit(255);
-}
+declare_interrupt!(
+    fn debug_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("debug_handler");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-extern "sysv64" fn virtualization_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("virtualization_handler");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
+declare_interrupt!(
+    fn overflow_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("overflow_handler");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-extern "sysv64" fn security_exception_handler(
-    stack_frame: &mut EnarxInterruptStackFrameWithArg,
-    error_code: u64,
-) {
-    eprintln!("security_exception_handler");
-    eprintln!("Error Code: {:?}", error_code);
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
+declare_interrupt!(
+    fn bound_range_exceeded_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("bound_range_exceeded_handler");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-extern "sysv64" fn vmm_communication_exception_handler(
-    stack_frame: &mut EnarxInterruptStackFrameWithArg,
-    error_code: u64,
-) {
-    // AMD Progammer's Manual Vol. 2 Appendix C - SVM Intercept Exit Codes
-    match error_code {
-        0x72 => {
-            // VMEXIT_CPUID
+declare_interrupt!(
+    fn device_not_available_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("device_not_available_handler");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-            let cpuid_res = cpuid_count(stack_frame.rax as _, stack_frame.rcx as _);
+declare_interrupt!(
+    fn x87_floating_point_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("x87_floating_point_handler");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-            stack_frame.rax = cpuid_res.eax as u64;
-            stack_frame.rbx = cpuid_res.ebx as u64;
-            stack_frame.rcx = cpuid_res.ecx as u64;
-            stack_frame.rdx = cpuid_res.edx as u64;
+declare_interrupt!(
+    fn alignment_check_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
+        eprintln!("alignment_check_handler");
+        eprintln!("Error Code: {:?}", error_code);
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-            // advance RIP by length of cpuid instruction
-            unsafe {
-                let mut frame = stack_frame.frame.as_mut();
-                frame.update(|frame| frame.instruction_pointer += 2u64)
-            };
+declare_interrupt!(
+    fn machine_check_handler(stack_frame: &mut ExtendedInterruptStackFrame) -> ! {
+        eprintln!("machine_check_handler");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
+
+declare_interrupt!(
+    fn simd_floating_point_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("simd_floating_point_handler");
+        eprintln!("{:#?}", stack_frame);
+
+        let mxcsr: u32 = 0;
+        unsafe {
+            asm!("stmxcsr [{}]",
+                    in(reg) &mxcsr,
+                    options(nostack),
+            );
         }
-        _ => panic!("Unhandled #VC: {:x?}", error_code),
+
+        eprintln!("MXCSR: {:#b}", mxcsr);
+
+        let mut addr = stack_frame.instruction_pointer;
+
+        let payload_virt = *PAYLOAD_VIRT_ADDR.read();
+
+        if addr.as_u64() < SHIM_VIRT_OFFSET && addr > payload_virt {
+            addr -= payload_virt.as_u64();
+            eprintln!("TRACE:\nP 0x{:>016x}", addr.as_u64());
+        } else {
+            eprintln!("TRACE:\nS 0x{:>016x}", addr.as_u64());
+        };
+
+        print_stack_trace();
+        shim_exit(255);
     }
-}
+);
 
-extern "sysv64" fn invalid_tss_handler(
-    stack_frame: &mut EnarxInterruptStackFrameWithArg,
-    error_code: u64,
-) {
-    eprintln!("invalid_tss_handler {}", error_code);
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
+declare_interrupt!(
+    fn virtualization_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("virtualization_handler");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-extern "sysv64" fn breakpoint_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("EXCEPTION: BREAKPOINT");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
+declare_interrupt!(
+    fn security_exception_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
+        eprintln!("security_exception_handler");
+        eprintln!("Error Code: {:?}", error_code);
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-extern "sysv64" fn non_maskable_interrupt_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("EXCEPTION: NMI");
-    eprintln!("{:#?}", stack_frame);
-}
+declare_interrupt!(
+    fn vmm_communication_exception_handler(
+        stack_frame: &mut ExtendedInterruptStackFrame,
+        error_code: u64,
+    ) {
+        // AMD Progammer's Manual Vol. 2 Appendix C - SVM Intercept Exit Codes
+        match error_code {
+            0x72 => {
+                // VMEXIT_CPUID
 
-extern "sysv64" fn page_fault_handler(
-    stack_frame: &mut EnarxInterruptStackFrameWithArg,
-    error_code: PageFaultErrorCode,
-) {
-    use x86_64::registers::control::Cr2;
+                let cpuid_res = cpuid_count(stack_frame.rax as _, stack_frame.rcx as _);
 
-    eprintln!("EXCEPTION: PAGE FAULT");
+                unsafe {
+                    let stack_frame = stack_frame.as_mut();
+                    stack_frame.rax = cpuid_res.eax as u64;
+                    stack_frame.rbx = cpuid_res.ebx as u64;
+                    stack_frame.rcx = cpuid_res.ecx as u64;
+                    stack_frame.rdx = cpuid_res.edx as u64;
 
-    eprintln!("Accessed Address: {:?}", Cr2::read());
-    eprintln!("Error Code: {:?}", error_code);
-    eprintln!("{:x?}", stack_frame);
+                    // advance RIP by length of cpuid instruction
+                    stack_frame.instruction_pointer += 2u64
+                }
+            }
+            _ => panic!("Unhandled #VC: {:x?}", error_code),
+        }
+    }
+);
 
-    let mut addr = stack_frame.frame.instruction_pointer;
+declare_interrupt!(
+    fn invalid_tss_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
+        eprintln!("invalid_tss_handler {}", error_code);
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-    let payload_virt = *PAYLOAD_VIRT_ADDR.read();
+declare_interrupt!(
+    fn breakpoint_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("EXCEPTION: BREAKPOINT");
+        eprintln!("{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);
 
-    if addr.as_u64() < SHIM_VIRT_OFFSET && addr > payload_virt {
-        addr -= payload_virt.as_u64();
-    };
+declare_interrupt!(
+    fn non_maskable_interrupt_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+        eprintln!("EXCEPTION: NMI");
+        eprintln!("{:#?}", stack_frame);
+    }
+);
 
-    eprintln!("RIP: {:?}", addr);
+declare_interrupt!(
+    fn page_fault_handler(
+        stack_frame: &mut ExtendedInterruptStackFrame,
+        error_code: PageFaultErrorCode,
+    ) {
+        use x86_64::registers::control::Cr2;
 
-    print_stack_trace();
+        eprintln!("EXCEPTION: PAGE FAULT");
 
-    shim_exit(255)
-}
+        eprintln!("Accessed Address: {:?}", Cr2::read());
+        eprintln!("Error Code: {:?}", error_code);
+        eprintln!("{:x?}", stack_frame);
 
-extern "sysv64" fn double_fault_handler(
-    stack_frame: &mut EnarxInterruptStackFrameWithArg,
-    _error_code: u64, // Always 0
-) -> ! {
-    eprintln!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
-    shim_exit(255);
-}
+        let mut addr = stack_frame.instruction_pointer;
 
-/*
-fn unknown_interrupt_handler(stack_frame: &mut EnarxInterruptStackFrame) {
-    eprintln!("EXCEPTION: unknown interrupt");
-    eprintln!("{:#?}", stack_frame);
-    shim_exit(255);
-}
-*/
+        let payload_virt = *PAYLOAD_VIRT_ADDR.read();
+
+        if addr.as_u64() < SHIM_VIRT_OFFSET && addr > payload_virt {
+            addr -= payload_virt.as_u64();
+        };
+
+        eprintln!("RIP: {:?}", addr);
+
+        print_stack_trace();
+
+        shim_exit(255)
+    }
+);
+
+declare_interrupt!(
+    fn double_fault_handler(
+        stack_frame: &mut ExtendedInterruptStackFrame,
+        _error_code: u64, // Always 0
+    ) -> ! {
+        eprintln!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
+        shim_exit(255);
+    }
+);

--- a/tests/bin/cpuid.rs
+++ b/tests/bin/cpuid.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    let cpuid_result = unsafe { core::arch::x86_64::__cpuid_count(1, 0) };
+
+    //assert that the CPU has an onboard x87 FPU
+    assert!(cpuid_result.edx & (1 << 0) != 0);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -267,3 +267,9 @@ fn memspike() {
 fn memory_stress_test() {
     run_test("memory_stress_test", 0, None, None, None);
 }
+
+#[test]
+#[serial]
+fn cpuid() {
+    run_test("cpuid", 0, None, None, None);
+}


### PR DESCRIPTION
Use the interrupt macro to define the naked assembler function, calling
out to the code inside the macro body.

Also use the `xchg` trick to handle exceptions with an error code.

Also add an integration test with `cpuid`, testing the
`vmm_communication_exception_handler` on SEV-SNP.

Also add a note about the removal of the `idt.rs` module.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
