### PR TITLE
fix(shim-sev): reduce the code stack size

### DIFF
--- a/internal/shim-sev/src/payload.rs
+++ b/internal/shim-sev/src/payload.rs
@@ -33,7 +33,7 @@ const PAYLOAD_STACK_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x7ff0_000
 
 /// Initial payload stack size
 #[allow(clippy::integer_arithmetic)]
-const PAYLOAD_STACK_SIZE: u64 = bytes![8; MiB];
+const PAYLOAD_STACK_SIZE: u64 = bytes![2; MiB];
 
 /// The randomized virtual address of the payload
 pub static PAYLOAD_VIRT_ADDR: Lazy<RwLock<VirtAddr>> = Lazy::new(|| {


### PR DESCRIPTION
Use the same size as the SGX backend for the code stack size.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
