### PR TITLE
Remove non-functional `--env` and `ARGS` options

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{BackendOptions, Result, StructOpt, WorkldrOptions};
-use anyhow::bail;
+use super::{BackendOptions, StructOpt, WorkldrOptions};
 
 use std::{fmt::Debug, path::PathBuf};
 
@@ -14,30 +13,7 @@ pub struct Options {
     #[structopt(flatten)]
     pub workldr: WorkldrOptions,
 
-    /// Set a WASI environment variable
-    #[structopt(
-        short = "e",
-        long = "env",
-        number_of_values = 1,
-        value_name = "NAME=VAL",
-        parse(try_from_str=parse_env_var),
-    )]
-    pub envs: Vec<(String, String)>,
-
-    // TODO: --stdin, --stdout, --stderr
     /// Path of the WebAssembly module to run
     #[structopt(value_name = "MODULE", parse(from_os_str))]
     pub module: PathBuf,
-
-    /// Arguments to pass to the WebAssembly module
-    #[structopt(value_name = "ARGS", last = true)]
-    pub args: Vec<String>,
-}
-
-fn parse_env_var(s: &str) -> Result<(String, String)> {
-    let parts: Vec<&str> = s.splitn(2, '=').collect();
-    if parts.len() != 2 {
-        bail!("must be of the form `NAME=VAL`");
-    }
-    Ok((parts[0].to_owned(), parts[1].to_owned()))
 }


### PR DESCRIPTION
We don't have things wired up for these arguments to `enarx run` yet, so
rather than filling the help output with LIES and BROKEN PROMISES we
should just remove things that don't actually work yet. See #1044 to
track their return.

Closes #1045.

Signed-off-by: Will Woods <will@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
