### PR TITLE
fix(shim-sev): give #VM its own stack

### DIFF
--- a/internal/shim-sev/src/interrupts.rs
+++ b/internal/shim-sev/src/interrupts.rs
@@ -304,7 +304,7 @@ pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
         let virt = VirtAddr::new_unsafe(vmm_communication_exception_handler as usize as u64);
         idt.vmm_communication_exception
             .set_handler_addr(virt)
-            .set_stack_index(6);
+            .set_stack_index(3);
 
         let virt = VirtAddr::new_unsafe(security_exception_handler as usize as u64);
         idt.security_exception


### PR DESCRIPTION
Just in case.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
