### PR TITLE
fix(shim-sev): do not print backtrace, if !TRACE

### DIFF
--- a/internal/shim-sev/src/debug.rs
+++ b/internal/shim-sev/src/debug.rs
@@ -14,6 +14,7 @@ use crate::addr::SHIM_VIRT_OFFSET;
 use crate::paging::SHIM_PAGETABLE;
 use crate::payload::PAYLOAD_VIRT_ADDR;
 use crate::print;
+use crate::print::TRACE;
 use crate::snp::ghcb::{vmgexit_msr, GHCB_MSR_EXIT_REQ};
 use crate::snp::snp_active;
 use crate::PAYLOAD_READY;
@@ -149,6 +150,10 @@ unsafe fn backtrace(mut rbp: u64) -> [u64; 16] {
 /// print a stack trace from a stack frame pointer
 pub fn print_stack_trace() {
     let mut rbp: usize;
+
+    if !TRACE {
+        return;
+    }
 
     unsafe {
         asm!("mov {}, rbp", out(reg) rbp);


### PR DESCRIPTION
If tracing is not enabled globally, don't output anything.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
