### PR TITLE
fix(shim-sgx): remove asm feature from sallyport dep

### DIFF
--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -14,7 +14,7 @@ compiler_builtins = { version = "0.1", default-features = false, features = [ "m
 goblin = { version = "0.4", default-features = false, features = [ "elf64" ] }
 x86_64 = { version = "^0.14.6", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
-sallyport = { version = "0.1", features = [ "asm" ] }
+sallyport = { version = "0.1" }
 libc = { version = "0.2", default-features = false }
 const-default = "0.2"
 primordial = "0.3.0"


### PR DESCRIPTION
`shim-sgx` does not need the `asm` feature of sallyport.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
