### PR TITLE
Tell rust-analyzer vscode plugin about our crate layout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml",
+        "internal/shim-sev/Cargo.toml",
+        "internal/shim-sgx/Cargo.toml",
+        "internal/wasmldr/Cargo.toml"
+    ]
+}


### PR DESCRIPTION
`rust-analyzer` is pretty awesome, but its crate autodetection only
looks one level deep for Cargo.toml files. This is good enough to find
anything that's mentioned in the toplevel Cargo.toml (like the crates in
`integration/`), but the crates in `internal/` aren't listed because
(for the moment) we have to do special custom stuff to build them.

This commit adds a `.vscode/settings.json` that tells rust-analyzer to
examine the toplevel Cargo.toml and the internal crates (shim-sev,
shim-sgx, and wasmldr. And now rust-analyzer works for those crates.
Hooray!

Signed-off-by: Will Woods <will@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
