### PR TITLE
fix: activate new asm features

### DIFF
--- a/internal/shim-sev/src/lib.rs
+++ b/internal/shim-sev/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(clippy::all)]
 #![deny(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
-#![feature(asm, naked_functions)]
+#![feature(asm, asm_const, asm_sym, naked_functions)]
 
 use crate::snp::cpuid_page::CpuidPage;
 use crate::snp::ghcb::Ghcb;

--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -9,7 +9,7 @@
 #![deny(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 #![no_main]
-#![feature(asm, naked_functions)]
+#![feature(asm, asm_const, asm_sym, naked_functions)]
 
 extern crate compiler_builtins;
 extern crate rcrt1;

--- a/internal/shim-sgx/src/main.rs
+++ b/internal/shim-sgx/src/main.rs
@@ -6,7 +6,7 @@
 //! instructions) from the enclave code and proxies them to the host.
 
 #![no_std]
-#![feature(asm, naked_functions)]
+#![feature(asm, asm_const, asm_sym, naked_functions)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
 #![no_main]


### PR DESCRIPTION
Apparently the `asm` feature split into more fine grained features.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
