### PR TITLE
feat(shim-sgx): add stack trace

### DIFF
--- a/internal/shim-sgx/src/handler/mod.rs
+++ b/internal/shim-sgx/src/handler/mod.rs
@@ -33,9 +33,11 @@ mod other;
 mod process;
 
 use core::fmt::Write;
+use core::mem::size_of;
 use core::ptr::read_unaligned;
 
 use crate::heap::Heap;
+use crate::{DEBUG, ENARX_EXEC_END, ENARX_EXEC_START, ENARX_HEAP_END, ENCL_SIZE};
 use lset::Line;
 use sallyport::syscall::*;
 use sallyport::{request, Block};
@@ -106,7 +108,9 @@ impl<'a> Handler<'a> {
                     OP_SYSCALL => h.handle_syscall(),
                     OP_CPUID => h.handle_cpuid(),
                     r => {
-                        debugln!(h, "unsupported opcode: {:?}", r);
+                        debugln!(h, "unsupported opcode: {:#04x}", r);
+                        h.print_ssa_stack_trace();
+
                         h.exit(1)
                     }
                 }
@@ -173,5 +177,71 @@ impl<'a> Handler<'a> {
         );
 
         self.ssa.gpr.rip += 2;
+    }
+
+    /// Print a stack trace using the SSA registers.
+    fn print_ssa_stack_trace(&mut self) {
+        if DEBUG {
+            unsafe { self.print_stack_trace(self.ssa.gpr.rip, self.ssa.gpr.rbp) }
+        }
+    }
+
+    /// Print out `rip` relative to the shim (S) or the payload (P) base address.
+    ///
+    /// This can be used with `addr2line` and the executable with debug info
+    /// to get the function name and line number.
+    unsafe fn print_rip(&mut self, rip: u64) {
+        let shim_start = ENCL_SIZE as u64;
+        let enarx_exec_start = &ENARX_EXEC_START as *const _ as u64;
+        let enarx_exec_end = &ENARX_EXEC_END as *const _ as u64;
+
+        let exec_range = enarx_exec_start..enarx_exec_end;
+
+        if exec_range.contains(&rip) {
+            let rip_pie = rip - enarx_exec_start;
+            debugln!(self, "P {:>#016x}", rip_pie);
+        } else {
+            let rip_pie = (shim_start - 1) & rip;
+            debugln!(self, "S {:>#016x}", rip_pie);
+        }
+    }
+
+    /// Print a stack trace with the old `rbp` stack frame pointers
+    unsafe fn print_stack_trace(&mut self, rip: u64, mut rbp: u64) {
+        let shim_start = ENCL_SIZE as u64;
+        let shim_end = &ENARX_HEAP_END as *const _ as u64;
+
+        let shim_range = shim_start..shim_end;
+
+        debugln!(self, "TRACE:");
+
+        self.print_rip(rip);
+
+        //Maximum 64 frames
+        for _frame in 0..64 {
+            if rbp == 0 || rbp & 7 != 0 {
+                break;
+            }
+
+            if !shim_range.contains(&rbp) {
+                debugln!(self, "invalid rbp: {:>#016x}", rbp);
+                break;
+            }
+
+            match rbp.checked_add(size_of::<usize>() as _) {
+                None => break,
+                Some(rip_rbp) => {
+                    let rip = *(rip_rbp as *const u64);
+                    match rip.checked_sub(1) {
+                        None => break,
+                        Some(0) => break,
+                        Some(rip) => {
+                            self.print_rip(rip);
+                            rbp = *(rbp as *const u64);
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/internal/shim-sgx/src/lib.rs
+++ b/internal/shim-sgx/src/lib.rs
@@ -32,7 +32,8 @@ pub const ATTR: Attributes = Attributes::new(Features::MODE64BIT, XFRM);
 extern "C" {
     /// Extern
     pub static ENARX_EXEC_START: u8;
-    //static ENARX_EXEC_END: u8;
+    /// Extern
+    pub static ENARX_EXEC_END: u8;
     /// Extern
     pub static ENARX_HEAP_START: u8;
     /// Extern

--- a/internal/wasmldr/.cargo/config
+++ b/internal/wasmldr/.cargo/config
@@ -4,7 +4,5 @@ target = "x86_64-unknown-linux-musl"
 [target.x86_64-unknown-linux-musl]
 rustflags = [
     "-C", "relocation-model=pic",
-    "-C", "link-args=-Wl,--sort-section=alignment,-Tlayout.ld -nostartfiles",
-    "-C", "link-self-contained=no",
     "-C", "force-frame-pointers=yes",
 ]


### PR DESCRIPTION
**Pre-Requires**: https://github.com/enarx/enarx/pull/1102

This gives us a nice stack trace for the zerooneone issue, with
```
    config.dynamic_memory_reserved_for_growth(bytes![1; MiB]);
```

We can pipe stderr through `./helper/parse-trace.sh` to get all the
file, function names and line numbers resolved.

```
$ cargo run -- run zerooneone.wasm \
  |& ./helper/parse-trace.sh \
  target/debug/build/enarx-*/out/internal/shim-sgx/x86_64-unknown-linux-musl/debug/shim-sgx \
  target/debug/build/enarx-*/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr

[…]

TRACE:
Shim: 0x000000000fee6c3b: ENARX_HEAP_START at :?
[…]
Payl: 0x000000000026e6ec: wasmtime::func::Func::call_impl::{{closure}} at wasmtime-0.30.0/src/func.rs:746
Payl: 0x00000000002c0b1c: wasmtime_runtime::traphandlers::catch_traps::call_closure at wasmtime-runtime-0.30.0/src/traphandlers.rs:193
Payl: 0x0000000000f462e1: wasmtime_setjmp at wasmtime-runtime-0.30.0/src/helpers.c:29
Payl: 0x00000000002c0d8f: wasmtime_runtime::traphandlers::catch_traps::{{closure}} at wasmtime-runtime-0.30.0/src/traphandlers.rs:181
Payl: 0x00000000002c11b2: wasmtime_runtime::traphandlers::CallThreadState::with::{{closure}} at wasmtime-runtime-0.30.0/src/traphandlers.rs:231
Payl: 0x0000000000331555: wasmtime_runtime::traphandlers::tls::set at wasmtime-runtime-0.30.0/src/traphandlers.rs:473
Payl: 0x00000000002c1099: wasmtime_runtime::traphandlers::CallThreadState::with at wasmtime-runtime-0.30.0/src/traphandlers.rs:231
Payl: 0x00000000002c0cfa: wasmtime_runtime::traphandlers::catch_traps at wasmtime-runtime-0.30.0/src/traphandlers.rs:180
Payl: 0x000000000026c0c8: wasmtime::func::invoke_wasm_and_catch_traps at wasmtime-0.30.0/src/func.rs:1077
Payl: 0x000000000026e52a: wasmtime::func::Func::call_impl at wasmtime-0.30.0/src/func.rs:745
Payl: 0x000000000026d357: wasmtime::func::Func::call at wasmtime-0.30.0/src/func.rs:685
Payl: 0x0000000000275c1f: wasmtime::linker::Linker<T>::module::{{closure}}::{{closure}} at wasmtime-0.30.0/src/linker.rs:648
Payl: 0x000000000026dd6b: wasmtime::func::Func::invoke at wasmtime-0.30.0/src/func.rs:887
Payl: 0x000000000026e97f: wasmtime::func::HostFunc::new::{{closure}}::{{closure}} at wasmtime-0.30.0/src/func.rs:1930
Payl: 0x000000000026b9e7: wasmtime::func::Caller<T>::with at wasmtime-0.30.0/src/func.rs:1541
Payl: 0x000000000026e92e: wasmtime::func::HostFunc::new::{{closure}} at wasmtime-0.30.0/src/func.rs:1929
Payl: 0x00000000002c0a62: wasmtime::trampoline::func::stub_fn::{{closure}} at wasmtime-0.30.0/src/trampoline/func.rs:48
Payl: 0x00000000001dd38c: core::ops::function::FnOnce::call_once at rustc/library/core/src/ops/function.rs:227
Payl: 0x00000000001f26e7: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once at rustc/library/core/src/panic/unwind_safe.rs:271
Payl: 0x00000000003e8f64: std::panicking::try::do_call at rustc/library/std/src/panicking.rs:406
Payl: 0x00000000003f0b8c: __rust_try at w6i0kawtrbtznk9:?
Payl: 0x00000000003de468: std::panicking::try at rustc/library/std/src/panicking.rs:370
Payl: 0x00000000003dc34e: std::panic::catch_unwind at rustc/library/std/src/panic.rs:133
Payl: 0x00000000002c091f: wasmtime::trampoline::func::stub_fn at wasmtime-0.30.0/src/trampoline/func.rs:41
Shim: 0x000000000fffd01e: ENARX_HEAP_START at :?
Shim: 0x000000000fffd005: ENARX_HEAP_START at :?
Payl: 0x000000000026e6ec: wasmtime::func::Func::call_impl::{{closure}} at wasmtime-0.30.0/src/func.rs:746
Payl: 0x00000000002c0b1c: wasmtime_runtime::traphandlers::catch_traps::call_closure at wasmtime-runtime-0.30.0/src/traphandlers.rs:193
Payl: 0x0000000000f462e1: wasmtime_setjmp at wasmtime-runtime-0.30.0/src/helpers.c:29
Payl: 0x00000000002c0d8f: wasmtime_runtime::traphandlers::catch_traps::{{closure}} at wasmtime-runtime-0.30.0/src/traphandlers.rs:181
Payl: 0x00000000002c11b2: wasmtime_runtime::traphandlers::CallThreadState::with::{{closure}} at wasmtime-runtime-0.30.0/src/traphandlers.rs:231
Payl: 0x0000000000331555: wasmtime_runtime::traphandlers::tls::set at wasmtime-runtime-0.30.0/src/traphandlers.rs:473
Payl: 0x00000000002c1099: wasmtime_runtime::traphandlers::CallThreadState::with at wasmtime-runtime-0.30.0/src/traphandlers.rs:231
Payl: 0x00000000002c0cfa: wasmtime_runtime::traphandlers::catch_traps at wasmtime-runtime-0.30.0/src/traphandlers.rs:180
Payl: 0x000000000026c0c8: wasmtime::func::invoke_wasm_and_catch_traps at wasmtime-0.30.0/src/func.rs:1077
Payl: 0x000000000026e52a: wasmtime::func::Func::call_impl at wasmtime-0.30.0/src/func.rs:745
Payl: 0x000000000026d1b3: wasmtime::func::Func::call at wasmtime-0.30.0/src/func.rs:685
Payl: 0x000000000028b573: wasmldr::workload::run at enarx/internal/wasmldr/src/workload.rs:141
Payl: 0x00000000001f3b93: wasmldr::main at enarx/internal/wasmldr/src/main.rs:100
[…]
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
