### PR TITLE
Gdb support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,34 @@ jobs:
           - {name: kvm, host: [self-hosted, linux]}
         profile:
           - name: debug
+          - name: debug with dbg
+            flag: --features=dbg
           - name: release
             flag: --release
+
+  build-only:
+    name: enarx build-only nightly ${{ matrix.profile.name }}
+    runs-on: ubuntu-20.04
+    steps:
+      - run: sudo apt update
+      - run: sudo apt install -y musl-tools
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          target: x86_64-unknown-linux-musl
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: ${{ matrix.profile.flag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        profile:
+          - name: default-features
+          - name: gdb
+            flag: --features=gdb
 
   internal:
     name: ${{ matrix.crate }} nightly ${{ matrix.profile.name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -180,6 +186,7 @@ dependencies = [
  "colorful",
  "const-default 1.0.0",
  "env_logger",
+ "gdbstub",
  "goblin 0.4.3",
  "iocuddle",
  "kvm-bindings",
@@ -195,7 +202,7 @@ dependencies = [
  "protobuf",
  "protobuf-codegen-pure",
  "reqwest",
- "sallyport",
+ "sallyport 0.1.0 (git+https://github.com/enarx/sallyport?rev=dd42c91cc9e5cbc74f342eede3bc072f60ba11bd)",
  "semver",
  "serial_test",
  "sgx",
@@ -214,7 +221,7 @@ version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -311,12 +318,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdbstub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e135587d3f6eee6fa02c4ba174270c2337424e6d852c156942c0840b3c0f5cc"
+dependencies = [
+ "cfg-if 0.1.10",
+ "log",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -490,7 +510,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -573,7 +593,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -581,6 +601,12 @@ name = "lset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efeae5282702b072b5e21cf8f430ccd3c5031c1e346321a28429523266c4a9b0"
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matches"
@@ -674,6 +700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,7 +731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -739,13 +774,19 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "percent-encoding"
@@ -1004,6 +1045,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sallyport"
+version = "0.1.0"
+source = "git+https://github.com/enarx/sallyport?rev=dd42c91cc9e5cbc74f342eede3bc072f60ba11bd#dd42c91cc9e5cbc74f342eede3bc072f60ba11bd"
+dependencies = [
+ "goblin 0.4.3",
+ "libc",
+ "primordial",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,7 +1184,7 @@ name = "sev_attestation"
 version = "0.1.0"
 dependencies = [
  "memoffset",
- "sallyport",
+ "sallyport 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1230,7 +1281,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand",
  "redox_syscall",
@@ -1363,7 +1414,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -1505,7 +1556,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -1530,7 +1581,7 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ backend-sev = ["backend-kvm", "reqwest"]
 backend-kvm = ["x86_64", "kvm-bindings", "kvm-ioctls"]
 backend-sgx = ["x86_64", "sgx"]
 wasmldr = []
+gdb = []
 dbg = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ backend-sev = ["backend-kvm", "reqwest"]
 backend-kvm = ["x86_64", "kvm-bindings", "kvm-ioctls"]
 backend-sgx = ["x86_64", "sgx"]
 wasmldr = []
+dbg = []
 
 [dependencies]
 x86_64 = { version = "^0.14.6", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ backend-sev = ["backend-kvm", "reqwest"]
 backend-kvm = ["x86_64", "kvm-bindings", "kvm-ioctls"]
 backend-sgx = ["x86_64", "sgx"]
 wasmldr = []
-gdb = []
+gdb = ["gdbstub"]
 dbg = []
 
 [dependencies]
@@ -36,9 +36,10 @@ x86_64 = { version = "^0.14.6", default-features = false, optional = true }
 sgx = { version = "0.1.0", features = ["openssl"], optional = true }
 const-default = { version = "1.0", features = [ "derive" ] }
 primordial = { version = "0.3", features = ["alloc"] }
-sallyport = { version = "0.1", features = [ "asm" ] }
+sallyport = { git = "https://github.com/enarx/sallyport", rev = "dd42c91cc9e5cbc74f342eede3bc072f60ba11bd", features = [ "asm" ] }
 kvm-bindings = { version = "0.5", optional = true }
 kvm-ioctls = { version = "0.11", optional = true }
+gdbstub = { version = "0.5.0", optional = true }
 protobuf = "2.22"
 structopt = { version = "0.3", features = ["wrap_help"] }
 openssl = "0.10"

--- a/README-DEBUG.md
+++ b/README-DEBUG.md
@@ -48,7 +48,7 @@ Error: Shutdown Ok(
 you might get a meaningful stack backtrace with the `helper/parse-trace.sh` script:
 
 ```console
-$ ./helper/parse-trace.sh <shim> [<payload>]
+$ ./helper/parse-trace.sh <shim> [<exec>]
 ```
 
 `parse-trace.sh` needs `addr2line` from `binutils`, so make sure that is installed.
@@ -73,7 +73,183 @@ $ ./helper/parse-trace.sh \
 ### Pipe
 
 ```console
-$ cargo run -- exec <payload> |& ./helper/parse-trace.sh \
+$ cargo run -- exec <exec> |& ./helper/parse-trace.sh \
   target/debug/build/*/out/internal/shim-sev/x86_64-unknown-linux-musl/debug/shim-sev 
 ```
 
+## GDB
+
+To enable gdb support, compile enarx with the `gdb` feature:
+
+```console
+$ cargo clean
+$ cargo build --features gdb
+```
+
+### KVM / SEV-SNP
+
+Find the "shim" of the TEE. Normally this is `shim-sev`:
+```console
+$ find target -wholename '*linux-musl/*/shim-sev'
+target/debug/build/enarx-f0e8a07172ba3be9/out/internal/shim-sev/x86_64-unknown-linux-musl/debug/shim-sev
+```
+
+Find the "exec" of the TEE. Normally this is `wasmldr`:
+```console
+$ find target -wholename '*linux-musl/*/wasmldr'
+target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr
+```
+
+Start the TEE:
+```console
+$ ./target/debug/enarx run ~/git/zerooneone/target/wasm32-wasi/debug/zerooneone.wasm
+[…]
+Starting GDB session...
+symbol-file -o 0xffffff8000000000 <shim>
+add-symbol-file -o 0x7f6ffbef8000 <exec>
+[…]
+Waiting for a GDB connection on "localhost:23456"...
+```
+
+You can set the listen address with `--gdblisten <address>`.
+
+Now connect with `gdb` from another terminal and load the symbols from the debug executables as mentioned by the output
+with the offsets mentioned. Note: the offsets can vary for every run due to address space layout randomization (ASLR).
+```console
+$ gdb
+[…]
+(gdb) symbol-file -o 0xffffff8000000000 target/debug/build/enarx-f0e8a07172ba3be9/out/internal/shim-sev/x86_64-unknown-linux-musl/debug/shim-sev
+Reading symbols from target/debug/build/enarx-f0e8a07172ba3be9/out/internal/shim-sev/x86_64-unknown-linux-musl/debug/shim-sev...
+
+(gdb) add-symbol-file -o 0x7f6ffbef8000 target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr
+add symbol table from file "target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr" with all sections offset by 0xfbef8000
+(y or n) y
+[…]
+
+(gdb) target remote localhost:23456
+Remote debugging using localhost:23456
+[…]
+0x00007f434ee83cc9 in _start ()
+```
+
+The current execution is stopped in the "exec" executable at the ELF entry point `_start`. You can now start debugging the "exec".
+
+```console
+(gdb) br wasmldr::main
+Breakpoint 1 at 0x7f434efddbeb: file src/main.rs, line 72.
+(gdb) cont
+Continuing.
+
+Breakpoint 1, wasmldr::main () at src/main.rs:72
+72	    env_logger::Builder::from_default_env().init();
+(gdb) list
+67	fn main() {
+68	    // KEEP-CONFIG HACK: we've inherited stdio and the shim sets
+69	    // "RUST_LOG=debug", so this should make logging go to stderr.
+70	    // FUTURE: we should have a keep-provided debug channel where we can
+71	    // (safely, securely) send logs. Might need our own logger for that..
+72	    env_logger::Builder::from_default_env().init();
+73	
+74	    info!("version {} starting up", env!("CARGO_PKG_VERSION"));
+75	
+76	    warn!("🌭DEV-ONLY BUILD, NOT FOR PRODUCTION USE🌭");
+(gdb) print $pc
+$1 = (*mut fn ()) 0x7f434efddbeb <wasmldr::main+11>
+(gdb) stepi
+0x00007f434efddbf2	72	    env_logger::Builder::from_default_env().init();
+(gdb) print $pc
+$2 = (*mut fn ()) 0x7f434efddbf2 <wasmldr::main+18>
+(gdb) stepi
+0x00007f434efddbf9	72	    env_logger::Builder::from_default_env().init();
+(gdb) print $pc
+$3 = (*mut fn ()) 0x7f434efddbf9 <wasmldr::main+25>
+```
+
+### SGX
+
+Find the "shim" of the TEE. Normally this is `shim-sgx`:
+```console
+$ find target -wholename '*linux-musl/*/shim-sgx'
+target/debug/build/enarx-f0e8a07172ba3be9/out/internal/shim-sgx/x86_64-unknown-linux-musl/debug/shim-sgx
+```
+
+Find the "exec" of the TEE. Normally this is `wasmldr`:
+```console
+$ find target -wholename '*linux-musl/*/wasmldr'
+target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr
+```
+
+Start the TEE:
+
+```console
+$ ./target/debug/enarx run ~/git/zerooneone/target/wasm32-wasi/debug/zerooneone.wasm
+[…]
+Starting GDB session...
+symbol-file -o 0x7fcf00000000 <shim>
+symbol-file -o 0x7fcf00400000 <exec>
+Waiting for a GDB connection on "localhost:23456"...
+```
+
+You can set the listen address with `--gdblisten <address>`.
+
+Now connect with `gdb` from another terminal and load the symbols from the debug executables as mentioned by the output
+with the offsets mentioned. Note: the offsets can vary for every run due to address space layout randomization (ASLR).
+
+```console
+$ gdb
+[…]
+
+(gdb) symbol-file -o 0x7fcf00400000 target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr
+Reading symbols from target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr...
+warning: Missing auto-load script at offset 0 in section .debug_gdb_scripts
+of file /home/harald/git/enarx/enarx/target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr.
+Use `info auto-load python-scripts [REGEXP]' to list them.
+
+(gdb) target remote localhost:23456
+Remote debugging using localhost:23456
+[…]
+0x00007f434ee83cc9 in _start ()
+```
+
+The current execution is stopped in the "exec" executable at the ELF entry point `_start`. You can now start debugging the "exec".
+
+NOTE: stepping does not work (yet) in SGX.
+
+```console
+(gdb) br wasmldr::main
+Breakpoint 1 at 0x7fcf007368cb: file src/main.rs, line 72.
+(gdb) cont
+Continuing.
+
+Breakpoint 1, wasmldr::main () at src/main.rs:72
+72	    env_logger::Builder::from_default_env().init();
+(gdb) list
+67	fn main() {
+68	    // KEEP-CONFIG HACK: we've inherited stdio and the shim sets
+69	    // "RUST_LOG=debug", so this should make logging go to stderr.
+70	    // FUTURE: we should have a keep-provided debug channel where we can
+71	    // (safely, securely) send logs. Might need our own logger for that..
+72	    env_logger::Builder::from_default_env().init();
+73	
+74	    info!("version {} starting up", env!("CARGO_PKG_VERSION"));
+75	
+76	    warn!("🌭DEV-ONLY BUILD, NOT FOR PRODUCTION USE🌭");
+(gdb) br workload::run
+Breakpoint 2 at 0x7fcf005f6c64: file src/workload.rs, line 81.
+(gdb) cont
+Continuing.
+
+Breakpoint 2, wasmldr::workload::run<alloc::string::String, alloc::string::String, alloc::vec::Vec<u8, alloc::alloc::Global>, alloc::vec::Vec<alloc::string::String, alloc::alloc::Global>, alloc::vec::Vec<(alloc::string::String, alloc::string::String), alloc::alloc::Global>> (bytes=..., args=..., envs=...) at src/workload.rs:81
+81	    debug!("configuring wasmtime engine");
+(gdb) list
+76	pub fn run<T: AsRef<str>, U: AsRef<str>>(
+77	    bytes: impl AsRef<[u8]>,
+78	    args: impl IntoIterator<Item = T>,
+79	    envs: impl IntoIterator<Item = (U, U)>,
+80	) -> Result<Box<[wasmtime::Val]>> {
+81	    debug!("configuring wasmtime engine");
+82	    let mut config = wasmtime::Config::new();
+83	    // Support module-linking (https://github.com/webassembly/module-linking)
+84	    config.wasm_module_linking(true);
+85	    // module-linking requires multi-memory
+```

--- a/build.rs
+++ b/build.rs
@@ -128,6 +128,9 @@ fn cargo_build_bin(
         .arg("--bin")
         .arg(bin_name);
 
+    #[cfg(feature = "gdb")]
+    let cmd = cmd.arg("--features=gdb");
+
     #[cfg(feature = "dbg")]
     let cmd = cmd.arg("--features=dbg");
 

--- a/build.rs
+++ b/build.rs
@@ -112,7 +112,8 @@ fn cargo_build_bin(
         .map(Stdio::from)
         .unwrap_or_else(|_| Stdio::inherit());
 
-    let status = Command::new("cargo")
+    let mut cmd = Command::new("cargo");
+    let cmd = cmd
         .current_dir(&path)
         .env_clear()
         .envs(&filtered_env)
@@ -125,8 +126,12 @@ fn cargo_build_bin(
         .arg("--target")
         .arg(target_name)
         .arg("--bin")
-        .arg(bin_name)
-        .status()?;
+        .arg(bin_name);
+
+    #[cfg(feature = "dbg")]
+    let cmd = cmd.arg("--features=dbg");
+
+    let status = cmd.status()?;
 
     if !status.success() {
         eprintln!("Failed to build in {}", path);

--- a/helper/parse-trace.sh
+++ b/helper/parse-trace.sh
@@ -4,7 +4,7 @@ SHIM="$1"
 PAYLOAD="$2"
 
 if [[ -z $SHIM ]]; then
-    echo "Usage: $0 <shim> [<payload>]"
+    echo "Usage: $0 <shim> [<exec>]"
 fi
 
 strstr() { [[ $1 = *"$2"* ]]; }
@@ -50,15 +50,15 @@ while read line; do
         line=${line/ffffff8}
     fi
 
-    if [[ $ADDR2LINE = "TRACE" ]] && [[ $line = "P "* ]]; then
+    if [[ $ADDR2LINE = "TRACE" ]] && [[ $line = "E "* ]]; then
         if [[ $PAYLOAD ]]; then
             addr2line -apiCf -e "$PAYLOAD" $line | grep -F -v '??' | \
             while read line; do
-                 printf -- "Payl: %s\n" "$line"
+                 printf -- "Exec: %s\n" "$line"
             done
             continue
         else
-            printf -- "Payl: %s\n" "$line"
+            printf -- "Exec: %s\n" "$line"
             continue
         fi
     fi

--- a/internal/shim-sev/Cargo.lock
+++ b/internal/shim-sev/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
  "opaque-debug",
@@ -60,6 +60,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -128,6 +134,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdbstub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e135587d3f6eee6fa02c4ba174270c2337424e6d852c156942c0840b3c0f5cc"
+dependencies = [
+ "cfg-if 0.1.10",
+ "log",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "gdbstub_arch"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e358b9c0e1468eae66099062e47bb502849308b987b74b5e72f1936397c33c16"
+dependencies = [
+ "gdbstub",
+ "num-traits",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,10 +208,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "lset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efeae5282702b072b5e21cf8f430ccd3c5031c1e346321a28429523266c4a9b0"
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memoffset"
@@ -204,6 +248,15 @@ name = "noted"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9ed3de88cf5f12b1b461eb59a5b85f60d84216207bda41bf0f0eb2d7d51d397"
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -229,7 +282,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
@@ -282,8 +335,7 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59efbc99f5c98530d4151b67b6b754956b8a016b60da071a463f2d6ef71dda2"
+source = "git+https://github.com/enarx/sallyport?rev=dd42c91cc9e5cbc74f342eede3bc072f60ba11bd#dd42c91cc9e5cbc74f342eede3bc072f60ba11bd"
 dependencies = [
  "goblin",
  "libc",
@@ -319,6 +371,8 @@ dependencies = [
  "compiler_builtins",
  "const-default",
  "crt0stack",
+ "gdbstub",
+ "gdbstub_arch",
  "goblin",
  "libc",
  "linked_list_allocator",

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -10,6 +10,7 @@ name = "shim-sev"
 test = false
 
 [features]
+gdb = [ "dbg" ]
 dbg = []
 
 [dependencies]

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 name = "shim-sev"
 test = false
 
+[features]
+dbg = []
+
 [dependencies]
 compiler_builtins = { version = "0.1", default-features = false, features = [ "mem" ] }
 x86_64 = { version = "^0.14.6", default-features = false, features = ["instructions", "inline_asm"] }

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -10,18 +10,20 @@ name = "shim-sev"
 test = false
 
 [features]
-gdb = [ "dbg" ]
+gdb = [ "gdbstub", "gdbstub_arch", "dbg" ]
 dbg = []
 
 [dependencies]
 compiler_builtins = { version = "0.1", default-features = false, features = [ "mem" ] }
 x86_64 = { version = "^0.14.6", default-features = false, features = ["instructions", "inline_asm"] }
+gdbstub_arch = { version = "0.1.1" , default-features = false, optional = true }
+gdbstub = { version = "0.5.0" , default-features = false, optional = true }
 goblin = { version = "0.4", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
 spinning = { version = "0.1", default-features = false }
 libc = { version = "0.2", default-features = false }
 primordial = "0.3"
-sallyport = "0.1"
+sallyport = { git = "https://github.com/enarx/sallyport", rev = "dd42c91cc9e5cbc74f342eede3bc072f60ba11bd" }
 xsave = "2.0.0"
 noted = "^1.0.0"
 nbytes = "0.1"

--- a/internal/shim-sev/src/allocator.rs
+++ b/internal/shim-sev/src/allocator.rs
@@ -3,10 +3,10 @@
 //! The global Allocator
 
 use crate::addr::{ShimPhysAddr, ShimVirtAddr, SHIM_VIRT_OFFSET};
+use crate::exec::NEXT_MMAP_RWLOCK;
 use crate::hostcall::HOST_CALL_ALLOC;
 use crate::hostmap::HOSTMAP;
 use crate::paging::SHIM_PAGETABLE;
-use crate::payload::NEXT_MMAP_RWLOCK;
 use crate::snp::{get_cbit_mask, pvalidate, snp_active, PvalidateSize};
 use crate::spin::RwLocked;
 

--- a/internal/shim-sev/src/debug.rs
+++ b/internal/shim-sev/src/debug.rs
@@ -240,5 +240,9 @@ pub(crate) fn interrupt_trace(stack_frame: &crate::interrupts::ExtendedInterrupt
         eprintln!("TRACE:\nP 0x{:>016x}", addr.as_u64());
     };
 
+    unsafe {
+        stack_trace_from_rbp(stack_frame.rbp as _);
+    }
+
     print_stack_trace();
 }

--- a/internal/shim-sev/src/exec.rs
+++ b/internal/shim-sev/src/exec.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! Functions dealing with the payload
+//! Functions dealing with the exec
 
 use crate::addr::ShimPhysAddr;
 use crate::allocator::ALLOCATOR;
@@ -8,10 +8,9 @@ use crate::random::random;
 use crate::shim_stack::init_stack_with_guard;
 use crate::snp::cpuid;
 use crate::usermode::usermode;
-use crate::PAYLOAD_READY;
 
 use core::convert::TryFrom;
-use core::sync::atomic::Ordering;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use crt0stack::{self, Builder, Entry};
 use goblin::elf::header::header64::Header;
@@ -22,45 +21,48 @@ use spinning::{Lazy, RwLock};
 use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
 use x86_64::{PhysAddr, VirtAddr};
 
-/// Payload virtual address, where the elf binary is mapped to, plus a random offset
-const PAYLOAD_ELF_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x7f00_0000_0000);
+/// Indicator, if the executable is ready to be executed or already executed
+pub static EXEC_READY: AtomicBool = AtomicBool::new(false);
 
-/// The first brk virtual address the payload gets, plus a random offset
-const PAYLOAD_BRK_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x5555_0000_0000);
+/// Exec virtual address, where the elf binary is mapped to, plus a random offset
+const EXEC_ELF_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x7f00_0000_0000);
 
-/// Payload stack virtual address
-const PAYLOAD_STACK_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x7ff0_0000_0000);
+/// The first brk virtual address the exec gets, plus a random offset
+const EXEC_BRK_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x5555_0000_0000);
 
-/// Initial payload stack size
+/// Exec stack virtual address
+const EXEC_STACK_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x7ff0_0000_0000);
+
+/// Initial exec stack size
 #[allow(clippy::integer_arithmetic)]
-const PAYLOAD_STACK_SIZE: u64 = bytes![2; MiB];
+const EXEC_STACK_SIZE: u64 = bytes![2; MiB];
 
-/// The randomized virtual address of the payload
+/// The randomized virtual address of the exec
 #[cfg(not(feature = "gdb"))]
-pub static PAYLOAD_VIRT_ADDR: Lazy<RwLock<VirtAddr>> = Lazy::new(|| {
+pub static EXEC_VIRT_ADDR: Lazy<RwLock<VirtAddr>> = Lazy::new(|| {
     RwLock::<VirtAddr>::const_new(
         spinning::RawRwLock::const_new(),
-        PAYLOAD_ELF_VIRT_ADDR_BASE + (random() & 0x7F_FFFF_F000),
+        EXEC_ELF_VIRT_ADDR_BASE + (random() & 0x7F_FFFF_F000),
     )
 });
 
 /// The non-randomized virtual address of the exec in case the gdb feature is active
 #[cfg(feature = "gdb")]
-pub static PAYLOAD_VIRT_ADDR: Lazy<RwLock<VirtAddr>> = Lazy::new(|| {
-    RwLock::<VirtAddr>::const_new(spinning::RawRwLock::const_new(), PAYLOAD_ELF_VIRT_ADDR_BASE)
+pub static EXEC_VIRT_ADDR: Lazy<RwLock<VirtAddr>> = Lazy::new(|| {
+    RwLock::<VirtAddr>::const_new(spinning::RawRwLock::const_new(), EXEC_ELF_VIRT_ADDR_BASE)
 });
 
-/// Actual brk virtual address the payload gets, when calling brk
+/// Actual brk virtual address the exec gets, when calling brk
 pub static NEXT_BRK_RWLOCK: Lazy<RwLock<VirtAddr>> = Lazy::new(|| {
     RwLock::<VirtAddr>::const_new(
         spinning::RawRwLock::const_new(),
-        PAYLOAD_BRK_VIRT_ADDR_BASE + (random() & 0xFFFF_F000),
+        EXEC_BRK_VIRT_ADDR_BASE + (random() & 0xFFFF_F000),
     )
 });
 
 /// The global NextMMap RwLock
 pub static NEXT_MMAP_RWLOCK: Lazy<RwLock<VirtAddr>> = Lazy::new(|| {
-    RwLock::<VirtAddr>::const_new(spinning::RawRwLock::const_new(), *PAYLOAD_VIRT_ADDR.read())
+    RwLock::<VirtAddr>::const_new(spinning::RawRwLock::const_new(), *EXEC_VIRT_ADDR.read())
 });
 
 /// load the elf binary
@@ -115,7 +117,7 @@ fn map_elf(app_virt_start: VirtAddr) -> &'static Header {
                     | PageTableFlags::USER_ACCESSIBLE
                     | PageTableFlags::WRITABLE,
             )
-            .expect("Map payload elf failed!");
+            .expect("Map exec elf failed!");
     }
 
     header
@@ -180,21 +182,21 @@ fn crt0setup(
     (ph_entry, sp)
 }
 
-/// execute the payload
-pub fn execute_payload() -> ! {
-    let header = map_elf(*PAYLOAD_VIRT_ADDR.read());
+/// execute the exec
+pub fn execute_exec() -> ! {
+    let header = map_elf(*EXEC_VIRT_ADDR.read());
 
     let stack = init_stack_with_guard(
-        PAYLOAD_STACK_VIRT_ADDR_BASE + (random() & 0xFFFF_F000),
-        PAYLOAD_STACK_SIZE,
+        EXEC_STACK_VIRT_ADDR_BASE + (random() & 0xFFFF_F000),
+        EXEC_STACK_SIZE,
         PageTableFlags::USER_ACCESSIBLE,
     );
 
-    let (entry, sp_handle) = crt0setup(*PAYLOAD_VIRT_ADDR.read(), stack.slice, header);
+    let (entry, sp_handle) = crt0setup(*EXEC_VIRT_ADDR.read(), stack.slice, header);
 
     #[cfg(feature = "gdb")]
     unsafe {
-        // Breakpoint at the payload entry address
+        // Breakpoint at the exec entry address
         asm!(
             "mov dr0, {}",
             "mov dr7, {}",
@@ -205,7 +207,7 @@ pub fn execute_payload() -> ! {
     };
 
     unsafe {
-        PAYLOAD_READY.store(true, Ordering::Relaxed);
+        EXEC_READY.store(true, Ordering::Relaxed);
         usermode(entry.as_u64(), sp_handle)
     }
 }

--- a/internal/shim-sev/src/gdb.rs
+++ b/internal/shim-sev/src/gdb.rs
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! GDB debugging
+
+#![cfg(feature = "gdb")]
+
+use crate::hostcall::HOST_CALL_ALLOC;
+use crate::interrupts::ExtendedInterruptStackFrameValue;
+use crate::syscall::ProxySyscall;
+use crate::PAYLOAD_READY;
+
+use core::convert::TryFrom;
+use core::sync::atomic::Ordering;
+
+use crate::addr::SHIM_VIRT_OFFSET;
+use crate::paging::SHIM_PAGETABLE;
+use crate::payload::PAYLOAD_VIRT_ADDR;
+use gdbstub::arch::Arch;
+use gdbstub::target::ext::base::singlethread::SingleThreadOps;
+use gdbstub::target::ext::base::singlethread::{GdbInterrupt, ResumeAction, StopReason};
+use gdbstub::target::ext::base::BaseOps;
+use gdbstub::target::{Target, TargetError, TargetResult};
+use gdbstub::{DisconnectReason, GdbStubBuilder, GdbStubError};
+use gdbstub_arch::x86::reg::X86_64CoreRegs;
+use primordial::Register;
+use sallyport::request;
+use sallyport::syscall::{
+    SYS_ENARX_GDB_PEEK, SYS_ENARX_GDB_READ, SYS_ENARX_GDB_START, SYS_ENARX_GDB_WRITE,
+};
+use x86_64::registers::rflags::RFlags;
+use x86_64::structures::paging::Translate;
+use x86_64::VirtAddr;
+
+pub(crate) struct GdbConnection(());
+
+impl GdbConnection {
+    pub fn new() -> Self {
+        Self(())
+    }
+}
+
+impl gdbstub::Connection for GdbConnection {
+    type Error = libc::c_int;
+
+    fn read(&mut self) -> Result<u8, Self::Error> {
+        let mut buf = [0u8];
+        match self.read_exact(&mut buf) {
+            Ok(_) => Ok(buf[0]),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        let bytes_len = buf.len();
+        let mut to_read = bytes_len;
+
+        let mut host_call = HOST_CALL_ALLOC.try_alloc().ok_or(libc::EIO)?;
+
+        loop {
+            let next = bytes_len.checked_sub(to_read).ok_or(libc::EFAULT)?;
+
+            let buf_ptr = buf[next..].as_mut_ptr();
+            let ret = request!(SYS_ENARX_GDB_READ => buf_ptr, to_read).proxy(host_call)?;
+
+            host_call = ret.0;
+            let read = usize::from(ret.1[0]);
+
+            // be careful with `written` as it is untrusted
+            to_read = to_read.checked_sub(read).ok_or(libc::EIO)?;
+            if to_read == 0 {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn write(&mut self, byte: u8) -> Result<(), Self::Error> {
+        self.write_all(&[byte])
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        let bytes_len = buf.len();
+        let mut to_write = bytes_len;
+
+        let mut host_call = HOST_CALL_ALLOC.try_alloc().ok_or(libc::EIO)?;
+
+        loop {
+            let next = bytes_len.checked_sub(to_write).ok_or(libc::EFAULT)?;
+
+            let buf_ptr = buf[next..].as_ptr();
+            let ret = request!(SYS_ENARX_GDB_WRITE => buf_ptr, to_write).proxy(host_call)?;
+
+            host_call = ret.0;
+            let written = usize::from(ret.1[0]);
+
+            // be careful with `written` as it is untrusted
+            to_write = to_write.checked_sub(written).ok_or(libc::EIO)?;
+            if to_write == 0 {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn peek(&mut self) -> Result<Option<u8>, Self::Error> {
+        let host_call = HOST_CALL_ALLOC.try_alloc().ok_or(libc::EIO)?;
+        let ret = request!(SYS_ENARX_GDB_PEEK).proxy(host_call)?;
+        let val = usize::from(ret.1[0]);
+        Ok(u8::try_from(val).ok())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn on_session_start(&mut self) -> Result<(), Self::Error> {
+        let host_call = HOST_CALL_ALLOC.try_alloc().ok_or(libc::EIO)?;
+        let _ret = request!(SYS_ENARX_GDB_START).proxy(host_call)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum GdbTargetError {
+    ResumeContinue,
+    ResumeStep,
+    ResumeContinueWithSignal,
+    ResumeStepWithSignal,
+    // ReadMemoryOutOfRange(u64),
+    WriteMemoryOutOfRange(u64),
+}
+
+/// FIXME
+#[derive(Debug)]
+pub(crate) struct GdbTarget<'a> {
+    frame: &'a mut ExtendedInterruptStackFrameValue,
+}
+
+impl<'a> GdbTarget<'a> {
+    pub(crate) fn new(frame: &'a mut ExtendedInterruptStackFrameValue) -> Self {
+        Self { frame }
+    }
+}
+
+impl Target for GdbTarget<'_> {
+    type Arch = gdbstub_arch::x86::X86_64_SSE;
+    type Error = GdbTargetError;
+
+    fn base_ops(&mut self) -> BaseOps<Self::Arch, Self::Error> {
+        BaseOps::SingleThread(self)
+    }
+}
+
+impl SingleThreadOps for GdbTarget<'_> {
+    fn resume(
+        &mut self,
+        action: ResumeAction,
+        _gdb_interrupt: GdbInterrupt<'_>,
+    ) -> Result<StopReason<<Self::Arch as Arch>::Usize>, Self::Error> {
+        match action {
+            ResumeAction::Continue => {
+                self.frame.cpu_flags &= !RFlags::TRAP_FLAG.bits();
+                Err(GdbTargetError::ResumeContinue)
+            }
+            ResumeAction::Step => {
+                self.frame.cpu_flags |= RFlags::TRAP_FLAG.bits();
+                Err(GdbTargetError::ResumeStep)
+            }
+            ResumeAction::ContinueWithSignal(_) => {
+                self.frame.cpu_flags &= !RFlags::TRAP_FLAG.bits();
+                Err(GdbTargetError::ResumeContinueWithSignal)
+            }
+            ResumeAction::StepWithSignal(_) => {
+                self.frame.cpu_flags |= RFlags::TRAP_FLAG.bits();
+                Err(GdbTargetError::ResumeStepWithSignal)
+            }
+        }
+    }
+
+    fn read_registers(
+        &mut self,
+        regs: &mut <Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        *regs = (self.frame as &ExtendedInterruptStackFrameValue).into();
+        Ok(())
+    }
+
+    fn write_registers(
+        &mut self,
+        regs: &<Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        self.frame.rax = regs.regs[0];
+        self.frame.rbx = regs.regs[1];
+        self.frame.rcx = regs.regs[2];
+        self.frame.rdx = regs.regs[3];
+        self.frame.rsi = regs.regs[4];
+        self.frame.rdi = regs.regs[5];
+        self.frame.rbp = regs.regs[6];
+        self.frame.stack_pointer = unsafe { VirtAddr::new_unsafe(regs.regs[7]) };
+        self.frame.r8 = regs.regs[8];
+        self.frame.r9 = regs.regs[9];
+        self.frame.r10 = regs.regs[10];
+        self.frame.r11 = regs.regs[11];
+        self.frame.r12 = regs.regs[12];
+        self.frame.r13 = regs.regs[13];
+        self.frame.r14 = regs.regs[14];
+        self.frame.r15 = regs.regs[15];
+        self.frame.instruction_pointer = unsafe { VirtAddr::new_unsafe(regs.rip) };
+        self.frame.cpu_flags &= 0xFFFF_FFFF_0000_0000;
+        self.frame.cpu_flags |= regs.eflags as u64;
+        Ok(())
+    }
+
+    fn read_addrs(
+        &mut self,
+        start_addr: <Self::Arch as Arch>::Usize,
+        data: &mut [u8],
+    ) -> TargetResult<(), Self> {
+        let ptr = start_addr as *const u8;
+
+        let _phys = SHIM_PAGETABLE
+            .read()
+            .translate_addr(VirtAddr::from_ptr(ptr))
+            .ok_or(TargetError::NonFatal)?;
+        let _phys_end = SHIM_PAGETABLE
+            .read()
+            .translate_addr(VirtAddr::from_ptr(unsafe { ptr.add(data.len()) }))
+            .ok_or(TargetError::NonFatal)?;
+
+        //eprintln!("read_addrs: {:?} size {}", ptr, data.len());
+        let src = unsafe { core::slice::from_raw_parts(ptr, data.len()) };
+        data.copy_from_slice(src);
+        Ok(())
+    }
+
+    fn write_addrs(
+        &mut self,
+        start_addr: <Self::Arch as Arch>::Usize,
+        data: &[u8],
+    ) -> TargetResult<(), Self> {
+        let ptr = start_addr as *mut u8;
+
+        let _phys = SHIM_PAGETABLE
+            .read()
+            .translate_addr(VirtAddr::from_ptr(ptr))
+            .ok_or(TargetError::Fatal(GdbTargetError::WriteMemoryOutOfRange(
+                start_addr,
+            )))?;
+        let _phys_end = SHIM_PAGETABLE
+            .read()
+            .translate_addr(VirtAddr::from_ptr(unsafe { ptr.add(data.len()) }))
+            .ok_or(TargetError::Fatal(GdbTargetError::WriteMemoryOutOfRange(
+                start_addr,
+            )))?;
+
+        //eprintln!("write_addrs: {:?} size {}", ptr, data.len());
+        let dst = unsafe { core::slice::from_raw_parts_mut(ptr, data.len()) };
+        dst.copy_from_slice(data);
+        Ok(())
+    }
+}
+
+impl From<&ExtendedInterruptStackFrameValue> for X86_64CoreRegs {
+    fn from(frame: &ExtendedInterruptStackFrameValue) -> Self {
+        let mut mxcsr: u32 = 0;
+        unsafe { asm!("stmxcsr [{}]", in(reg) &mut mxcsr, options(nostack)) };
+
+        Self {
+            regs: [
+                frame.rax,
+                frame.rbx,
+                frame.rcx,
+                frame.rdx,
+                frame.rsi,
+                frame.rdi,
+                frame.rbp,
+                frame.stack_pointer.as_u64(),
+                frame.r8,
+                frame.r9,
+                frame.r10,
+                frame.r11,
+                frame.r12,
+                frame.r13,
+                frame.r14,
+                frame.r15,
+            ],
+            eflags: frame.cpu_flags as u32,
+            rip: frame.instruction_pointer.as_u64(),
+            segments: Default::default(),
+            st: Default::default(),
+            fpu: Default::default(),
+            xmm: Default::default(),
+            mxcsr,
+        }
+    }
+}
+
+pub(crate) fn gdb_session(stack_frame: &mut ExtendedInterruptStackFrameValue) {
+    let regs: X86_64CoreRegs = (stack_frame as &ExtendedInterruptStackFrameValue).into();
+    regs.regs
+        .iter()
+        .enumerate()
+        .for_each(|(i, v)| eprintln!("r{} = {:#x}", i, v));
+
+    let mut target = GdbTarget::new(stack_frame);
+
+    let mut buf = [0; 4096];
+
+    eprintln!("Starting GDB session...");
+
+    eprintln!("symbol-file -o {:#x} <shim>", SHIM_VIRT_OFFSET);
+
+    if PAYLOAD_READY.load(Ordering::Relaxed) {
+        let payload_virt = *PAYLOAD_VIRT_ADDR.read();
+        eprintln!(
+            "add-symbol-file -o {:?} <payload>",
+            payload_virt.as_mut_ptr::<u8>()
+        );
+    }
+
+    loop {
+        let conn = GdbConnection::new();
+        let mut gdb = GdbStubBuilder::new(conn)
+            .with_packet_buffer(&mut buf)
+            .build()
+            .unwrap();
+
+        match gdb.run(&mut target) {
+            Ok(disconnect_reason) => {
+                match disconnect_reason {
+                    DisconnectReason::Disconnect => eprintln!("GDB Disconnected"),
+                    DisconnectReason::TargetExited(_) => eprintln!("Target exited"),
+                    DisconnectReason::TargetTerminated(_) => eprintln!("Target halted"),
+                    DisconnectReason::Kill => eprintln!("GDB sent a kill command"),
+                }
+                break;
+            }
+
+            Err(GdbStubError::TargetError(e)) => {
+                eprintln!("resume: {:#?}", e);
+                break;
+            }
+
+            // workaround for the gdbstub main loop (will change with gdbstub-0.6
+            Err(e) => match e {
+                GdbStubError::ConnectionRead(_) => break,
+                GdbStubError::ConnectionWrite(_) => break,
+                GdbStubError::PacketParse(_) => break,
+                GdbStubError::PacketUnexpected => break,
+                GdbStubError::TargetMismatch => break,
+                GdbStubError::UnsupportedStopReason => break,
+                _ => eprintln!("gdbstub internal error: {:#?}", e),
+            },
+        };
+    }
+}

--- a/internal/shim-sev/src/gdb.rs
+++ b/internal/shim-sev/src/gdb.rs
@@ -4,17 +4,17 @@
 
 #![cfg(feature = "gdb")]
 
+use crate::exec::EXEC_READY;
 use crate::hostcall::HOST_CALL_ALLOC;
 use crate::interrupts::ExtendedInterruptStackFrameValue;
 use crate::syscall::ProxySyscall;
-use crate::PAYLOAD_READY;
 
 use core::convert::TryFrom;
 use core::sync::atomic::Ordering;
 
 use crate::addr::SHIM_VIRT_OFFSET;
+use crate::exec::EXEC_VIRT_ADDR;
 use crate::paging::SHIM_PAGETABLE;
-use crate::payload::PAYLOAD_VIRT_ADDR;
 use gdbstub::arch::Arch;
 use gdbstub::target::ext::base::singlethread::SingleThreadOps;
 use gdbstub::target::ext::base::singlethread::{GdbInterrupt, ResumeAction, StopReason};
@@ -312,11 +312,11 @@ pub(crate) fn gdb_session(stack_frame: &mut ExtendedInterruptStackFrameValue) {
 
     eprintln!("symbol-file -o {:#x} <shim>", SHIM_VIRT_OFFSET);
 
-    if PAYLOAD_READY.load(Ordering::Relaxed) {
-        let payload_virt = *PAYLOAD_VIRT_ADDR.read();
+    if EXEC_READY.load(Ordering::Relaxed) {
+        let exec_virt = *EXEC_VIRT_ADDR.read();
         eprintln!(
-            "add-symbol-file -o {:?} <payload>",
-            payload_virt.as_mut_ptr::<u8>()
+            "add-symbol-file -o {:?} <exec>",
+            exec_virt.as_mut_ptr::<u8>()
         );
     }
 

--- a/internal/shim-sev/src/gdt.rs
+++ b/internal/shim-sev/src/gdt.rs
@@ -51,22 +51,31 @@ pub static TSS: Lazy<TaskStateSegment> = Lazy::new(|| {
     let mut interrupt_stack_table = unsafe { ptr_interrupt_stack_table.read_unaligned() };
 
     // Assign the stacks for the exceptions and interrupts
-    interrupt_stack_table
-        .iter_mut()
-        .enumerate()
-        .for_each(|(idx, p)| {
-            let offset: u64 = align_up(
-                SHIM_EX_STACK_SIZE
-                    .checked_add(Page::<Size4KiB>::SIZE.checked_mul(2).unwrap())
-                    .unwrap(),
-                Page::<Size2MiB>::SIZE,
-            );
+    if !cfg!(feature = "dbg") {
+        // Only the vmm_communication_exception is needed
+        let start = VirtAddr::new(SHIM_EX_STACK_START);
+        let ptr = init_stack_with_guard(start, SHIM_EX_STACK_SIZE, PageTableFlags::empty()).pointer;
+        interrupt_stack_table[0] = ptr;
+    } else {
+        // Allocate all for debug
+        interrupt_stack_table
+            .iter_mut()
+            .enumerate()
+            .for_each(|(idx, p)| {
+                let offset: u64 = align_up(
+                    SHIM_EX_STACK_SIZE
+                        .checked_add(Page::<Size4KiB>::SIZE.checked_mul(2).unwrap())
+                        .unwrap(),
+                    Page::<Size2MiB>::SIZE,
+                );
 
-            let stack_offset = offset.checked_mul(idx as _).unwrap();
-            let start = VirtAddr::new(SHIM_EX_STACK_START.checked_add(stack_offset).unwrap());
+                let stack_offset = offset.checked_mul(idx as _).unwrap();
+                let start = VirtAddr::new(SHIM_EX_STACK_START.checked_add(stack_offset).unwrap());
 
-            *p = init_stack_with_guard(start, SHIM_EX_STACK_SIZE, PageTableFlags::empty()).pointer;
-        });
+                *p = init_stack_with_guard(start, SHIM_EX_STACK_SIZE, PageTableFlags::empty())
+                    .pointer;
+            });
+    }
 
     unsafe {
         ptr_interrupt_stack_table.write_unaligned(interrupt_stack_table);

--- a/internal/shim-sev/src/gdt.rs
+++ b/internal/shim-sev/src/gdt.rs
@@ -30,7 +30,13 @@ pub const SHIM_EX_STACK_START: u64 = 0xFFFF_FF48_F000_0000;
 
 /// The size of the main kernel stack for exceptions
 #[allow(clippy::integer_arithmetic)]
-pub const SHIM_EX_STACK_SIZE: u64 = bytes![32; KiB];
+pub const SHIM_EX_STACK_SIZE: u64 = {
+    if cfg!(feature = "gdb") {
+        bytes![2; MiB]
+    } else {
+        bytes![32; KiB]
+    }
+};
 
 /// The initial shim stack
 pub static INITIAL_STACK: Lazy<GuardedStack> = Lazy::new(|| {

--- a/internal/shim-sev/src/gdt.rs
+++ b/internal/shim-sev/src/gdt.rs
@@ -96,9 +96,9 @@ pub struct Selectors {
     pub code: SegmentSelector,
     /// shim data selector
     pub data: SegmentSelector,
-    /// payload data selector
+    /// exec data selector
     pub user_data: SegmentSelector,
-    /// payload code selector
+    /// exec code selector
     pub user_code: SegmentSelector,
     /// TSS selector
     pub tss: SegmentSelector,

--- a/internal/shim-sev/src/interrupts.rs
+++ b/internal/shim-sev/src/interrupts.rs
@@ -2,12 +2,12 @@
 
 //! Interrupt handling
 
-use crate::addr::SHIM_VIRT_OFFSET;
-use crate::debug::print_stack_trace;
+#[cfg(feature = "dbg")]
+use crate::debug::{interrupt_trace, print_stack_trace};
 use crate::eprintln;
+#[cfg(feature = "dbg")]
 use crate::hostcall::shim_exit;
 use crate::idt::InterruptDescriptorTable;
-use crate::payload::PAYLOAD_VIRT_ADDR;
 use crate::snp::cpuid_count;
 
 use core::fmt;
@@ -16,7 +16,6 @@ use core::ops::Deref;
 
 use paste::paste;
 use spinning::Lazy;
-use x86_64::structures::idt::PageFaultErrorCode;
 use x86_64::VirtAddr;
 use xsave::XSave;
 
@@ -24,7 +23,7 @@ use xsave::XSave;
 pub const XSAVE_AREA_SIZE: u32 = size_of::<XSave>() as _;
 
 #[repr(C)]
-struct ExtendedInterruptStackFrame {
+pub(crate) struct ExtendedInterruptStackFrame {
     value: ExtendedInterruptStackFrameValue,
 }
 
@@ -67,32 +66,32 @@ impl fmt::Debug for ExtendedInterruptStackFrame {
 
 #[derive(Debug)]
 #[repr(C)]
-struct ExtendedInterruptStackFrameValue {
-    rbp: u64,
-    rbx: u64,
-    r11: u64,
-    r10: u64,
-    r9: u64,
-    r8: u64,
-    rax: u64,
-    rcx: u64,
-    rdx: u64,
-    rdi: u64,
-    rsi: u64,
+pub(crate) struct ExtendedInterruptStackFrameValue {
+    pub rbp: u64,
+    pub rbx: u64,
+    pub r11: u64,
+    pub r10: u64,
+    pub r9: u64,
+    pub r8: u64,
+    pub rax: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rdi: u64,
+    pub rsi: u64,
     /// This value points to the instruction that should be executed when the interrupt
     /// handler returns. For most interrupts, this value points to the instruction immediately
     /// following the last executed instruction. However, for some exceptions (e.g., page faults),
     /// this value points to the faulting instruction, so that the instruction is restarted on
     /// return. See the documentation of the [`InterruptDescriptorTable`] fields for more details.
-    instruction_pointer: VirtAddr,
+    pub instruction_pointer: VirtAddr,
     /// The code segment selector, padded with zeros.
-    code_segment: u64,
+    pub code_segment: u64,
     /// The flags register before the interrupt handler was invoked.
-    cpu_flags: u64,
+    pub cpu_flags: u64,
     /// The stack pointer at the time of the interrupt.
-    stack_pointer: VirtAddr,
+    pub stack_pointer: VirtAddr,
     /// The stack segment descriptor at the time of the interrupt (often zero in 64-bit mode).
-    stack_segment: u64,
+    pub stack_segment: u64,
 }
 
 /// name - interrupt func name
@@ -118,9 +117,9 @@ macro_rules! declare_interrupt {
         declare_interrupt!($name => "xchg [rsp], rsi");
     };
 
-    (fn $name:ident ( $stack:ident : &mut ExtendedInterruptStackFrame , $error:ident : PageFaultErrorCode $(,)? ) $code:block) => {
+    (fn $name:ident ( $stack:ident : &mut ExtendedInterruptStackFrame , $error:ident : x86_64::structures::idt::PageFaultErrorCode $(,)? ) $code:block) => {
         paste! {
-            extern "sysv64" fn [<__interrupt_ $name>]($stack: &mut ExtendedInterruptStackFrame, $error: PageFaultErrorCode) {
+            extern "sysv64" fn [<__interrupt_ $name>]($stack: &mut ExtendedInterruptStackFrame, $error: x86_64::structures::idt::PageFaultErrorCode) {
                 $code
             }
         }
@@ -222,250 +221,6 @@ macro_rules! declare_interrupt {
     };
 }
 
-/// The global IDT
-pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
-    let mut idt = InterruptDescriptorTable::new();
-    unsafe {
-        let virt = VirtAddr::new_unsafe(divide_error_handler as usize as u64);
-        idt.divide_error.set_handler_addr(virt).set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(debug_handler as usize as u64);
-        idt.debug.set_handler_addr(virt).set_stack_index(1);
-
-        let virt = VirtAddr::new_unsafe(non_maskable_interrupt_handler as usize as u64);
-        idt.non_maskable_interrupt
-            .set_handler_addr(virt)
-            .set_stack_index(2);
-
-        let virt = VirtAddr::new_unsafe(breakpoint_handler as usize as u64);
-        idt.breakpoint.set_handler_addr(virt).set_stack_index(1);
-
-        let virt = VirtAddr::new_unsafe(overflow_handler as usize as u64);
-        idt.overflow.set_handler_addr(virt).set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(bound_range_exceeded_handler as usize as u64);
-        idt.bound_range_exceeded
-            .set_handler_addr(virt)
-            .set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(invalid_opcode_handler as usize as u64);
-        idt.invalid_opcode.set_handler_addr(virt).set_stack_index(5);
-
-        let virt = VirtAddr::new_unsafe(device_not_available_handler as usize as u64);
-        idt.device_not_available
-            .set_handler_addr(virt)
-            .set_stack_index(5);
-
-        let virt = VirtAddr::new_unsafe(double_fault_handler as usize as u64);
-        idt.double_fault.set_handler_addr(virt).set_stack_index(0);
-
-        let virt = VirtAddr::new_unsafe(invalid_tss_handler as usize as u64);
-        idt.invalid_tss.set_handler_addr(virt).set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(segment_not_present_handler as usize as u64);
-        idt.segment_not_present
-            .set_handler_addr(virt)
-            .set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(stack_segment_fault as usize as u64);
-        idt.stack_segment_fault
-            .set_handler_addr(virt)
-            .set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(general_protection_fault as usize as u64);
-        idt.general_protection_fault
-            .set_handler_addr(virt)
-            .set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(page_fault_handler as usize as u64);
-        idt.page_fault.set_handler_addr(virt).set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(x87_floating_point_handler as usize as u64);
-        idt.x87_floating_point
-            .set_handler_addr(virt)
-            .set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(alignment_check_handler as usize as u64);
-        idt.alignment_check
-            .set_handler_addr(virt)
-            .set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(machine_check_handler as usize as u64);
-        idt.machine_check.set_handler_addr(virt).set_stack_index(0);
-
-        let virt = VirtAddr::new_unsafe(simd_floating_point_handler as usize as u64);
-        idt.simd_floating_point
-            .set_handler_addr(virt)
-            .set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(virtualization_handler as usize as u64);
-        idt.virtualization.set_handler_addr(virt).set_stack_index(6);
-
-        let virt = VirtAddr::new_unsafe(vmm_communication_exception_handler as usize as u64);
-        idt.vmm_communication_exception
-            .set_handler_addr(virt)
-            .set_stack_index(3);
-
-        let virt = VirtAddr::new_unsafe(security_exception_handler as usize as u64);
-        idt.security_exception
-            .set_handler_addr(virt)
-            .set_stack_index(6);
-    }
-    idt
-});
-
-/// Initialize the IDT
-pub fn init() {
-    #[cfg(debug_assertions)]
-    eprintln!("interrupts::init");
-    IDT.load();
-}
-
-declare_interrupt!(
-    fn stack_segment_fault(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
-        eprintln!("stack_segment_fault {}", error_code);
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn general_protection_fault(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
-        eprintln!("general_protection_fault {:#b}", error_code);
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn segment_not_present_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
-        eprintln!("segment_not_present_handler {}", error_code);
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn invalid_opcode_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("invalid_opcode_handler");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn divide_error_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("divide_error_handler");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn debug_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("debug_handler");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn overflow_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("overflow_handler");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn bound_range_exceeded_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("bound_range_exceeded_handler");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn device_not_available_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("device_not_available_handler");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn x87_floating_point_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("x87_floating_point_handler");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn alignment_check_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
-        eprintln!("alignment_check_handler");
-        eprintln!("Error Code: {:?}", error_code);
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn machine_check_handler(stack_frame: &mut ExtendedInterruptStackFrame) -> ! {
-        eprintln!("machine_check_handler");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn simd_floating_point_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("simd_floating_point_handler");
-        eprintln!("{:#?}", stack_frame);
-
-        let mxcsr: u32 = 0;
-        unsafe {
-            asm!("stmxcsr [{}]",
-                    in(reg) &mxcsr,
-                    options(nostack),
-            );
-        }
-
-        eprintln!("MXCSR: {:#b}", mxcsr);
-
-        let mut addr = stack_frame.instruction_pointer;
-
-        let payload_virt = *PAYLOAD_VIRT_ADDR.read();
-
-        if addr.as_u64() < SHIM_VIRT_OFFSET && addr > payload_virt {
-            addr -= payload_virt.as_u64();
-            eprintln!("TRACE:\nP 0x{:>016x}", addr.as_u64());
-        } else {
-            eprintln!("TRACE:\nS 0x{:>016x}", addr.as_u64());
-        };
-
-        print_stack_trace();
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn virtualization_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("virtualization_handler");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
-declare_interrupt!(
-    fn security_exception_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
-        eprintln!("security_exception_handler");
-        eprintln!("Error Code: {:?}", error_code);
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
-
 declare_interrupt!(
     fn vmm_communication_exception_handler(
         stack_frame: &mut ExtendedInterruptStackFrame,
@@ -494,65 +249,330 @@ declare_interrupt!(
     }
 );
 
-declare_interrupt!(
-    fn invalid_tss_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
-        eprintln!("invalid_tss_handler {}", error_code);
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
+/// The global IDT
+pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
+    let mut idt = InterruptDescriptorTable::new();
+    unsafe {
+        let virt = VirtAddr::new_unsafe(vmm_communication_exception_handler as usize as u64);
+        idt.vmm_communication_exception
+            .set_handler_addr(virt)
+            .set_stack_index(0);
+
+        #[cfg(feature = "dbg")]
+        debug::idt_add_debug_exception_handlers(&mut idt);
     }
-);
+    idt
+});
 
-declare_interrupt!(
-    fn breakpoint_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("EXCEPTION: BREAKPOINT");
-        eprintln!("{:#?}", stack_frame);
-        shim_exit(255);
+/// Initialize the IDT
+pub fn init() {
+    #[cfg(debug_assertions)]
+    eprintln!("interrupts::init");
+    IDT.load();
+}
+
+#[cfg(feature = "dbg")]
+mod debug {
+    use super::*;
+
+    pub(crate) fn idt_add_debug_exception_handlers(idt: &mut InterruptDescriptorTable) {
+        unsafe {
+            let virt = VirtAddr::new_unsafe(divide_error_handler as usize as u64);
+            idt.divide_error.set_handler_addr(virt).set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(debug_handler as usize as u64);
+            idt.debug.set_handler_addr(virt).set_stack_index(1);
+
+            let virt = VirtAddr::new_unsafe(non_maskable_interrupt_handler as usize as u64);
+            idt.non_maskable_interrupt
+                .set_handler_addr(virt)
+                .set_stack_index(2);
+
+            let virt = VirtAddr::new_unsafe(breakpoint_handler as usize as u64);
+            let _br_opts = idt.breakpoint.set_handler_addr(virt).set_stack_index(1);
+
+            let virt = VirtAddr::new_unsafe(overflow_handler as usize as u64);
+            idt.overflow.set_handler_addr(virt).set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(bound_range_exceeded_handler as usize as u64);
+            idt.bound_range_exceeded
+                .set_handler_addr(virt)
+                .set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(invalid_opcode_handler as usize as u64);
+            idt.invalid_opcode.set_handler_addr(virt).set_stack_index(5);
+
+            let virt = VirtAddr::new_unsafe(device_not_available_handler as usize as u64);
+            idt.device_not_available
+                .set_handler_addr(virt)
+                .set_stack_index(5);
+
+            let virt = VirtAddr::new_unsafe(double_fault_handler as usize as u64);
+            idt.double_fault.set_handler_addr(virt).set_stack_index(3);
+
+            let virt = VirtAddr::new_unsafe(invalid_tss_handler as usize as u64);
+            idt.invalid_tss.set_handler_addr(virt).set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(segment_not_present_handler as usize as u64);
+            idt.segment_not_present
+                .set_handler_addr(virt)
+                .set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(stack_segment_fault as usize as u64);
+            idt.stack_segment_fault
+                .set_handler_addr(virt)
+                .set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(general_protection_fault as usize as u64);
+            idt.general_protection_fault
+                .set_handler_addr(virt)
+                .set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(page_fault_handler as usize as u64);
+            idt.page_fault.set_handler_addr(virt).set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(x87_floating_point_handler as usize as u64);
+            idt.x87_floating_point
+                .set_handler_addr(virt)
+                .set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(alignment_check_handler as usize as u64);
+            idt.alignment_check
+                .set_handler_addr(virt)
+                .set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(machine_check_handler as usize as u64);
+            idt.machine_check.set_handler_addr(virt).set_stack_index(3);
+
+            let virt = VirtAddr::new_unsafe(simd_floating_point_handler as usize as u64);
+            idt.simd_floating_point
+                .set_handler_addr(virt)
+                .set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(virtualization_handler as usize as u64);
+            idt.virtualization.set_handler_addr(virt).set_stack_index(6);
+
+            let virt = VirtAddr::new_unsafe(security_exception_handler as usize as u64);
+            idt.security_exception
+                .set_handler_addr(virt)
+                .set_stack_index(6);
+        }
     }
-);
 
-declare_interrupt!(
-    fn non_maskable_interrupt_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
-        eprintln!("EXCEPTION: NMI");
-        eprintln!("{:#?}", stack_frame);
-    }
-);
+    declare_interrupt!(
+        fn stack_segment_fault(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
+            eprintln!("stack_segment_fault {}", error_code);
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
 
-declare_interrupt!(
-    fn page_fault_handler(
-        stack_frame: &mut ExtendedInterruptStackFrame,
-        error_code: PageFaultErrorCode,
-    ) {
-        use x86_64::registers::control::Cr2;
+    declare_interrupt!(
+        fn general_protection_fault(
+            stack_frame: &mut ExtendedInterruptStackFrame,
+            error_code: u64,
+        ) {
+            eprintln!("general_protection_fault {:#b}", error_code);
+            eprintln!("{:#?}", stack_frame);
 
-        eprintln!("EXCEPTION: PAGE FAULT");
+            interrupt_trace(stack_frame);
 
-        eprintln!("Accessed Address: {:?}", Cr2::read());
-        eprintln!("Error Code: {:?}", error_code);
-        eprintln!("{:x?}", stack_frame);
+            shim_exit(255);
+        }
+    );
 
-        let payload_virt = *PAYLOAD_VIRT_ADDR.read();
-        let mut addr = stack_frame.instruction_pointer;
+    declare_interrupt!(
+        fn segment_not_present_handler(
+            stack_frame: &mut ExtendedInterruptStackFrame,
+            error_code: u64,
+        ) {
+            eprintln!("segment_not_present_handler {}", error_code);
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
 
-        if addr.as_u64() > SHIM_VIRT_OFFSET {
-            addr -= SHIM_VIRT_OFFSET;
-            eprintln!("TRACE:\nS 0x{:>016x}", addr.as_u64());
-        } else if addr > payload_virt {
-            addr -= payload_virt.as_u64();
-            eprintln!("TRACE:\nP 0x{:>016x}", addr.as_u64());
-        };
+    declare_interrupt!(
+        fn invalid_opcode_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("invalid_opcode_handler");
+            eprintln!("{:#?}", stack_frame);
 
-        print_stack_trace();
+            interrupt_trace(stack_frame);
 
-        shim_exit(255)
-    }
-);
+            shim_exit(255);
+        }
+    );
 
-declare_interrupt!(
-    fn double_fault_handler(
-        stack_frame: &mut ExtendedInterruptStackFrame,
-        _error_code: u64, // Always 0
-    ) -> ! {
-        eprintln!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
-        shim_exit(255);
-    }
-);
+    declare_interrupt!(
+        fn divide_error_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("divide_error_handler");
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn debug_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("debug_handler");
+            eprintln!("{:#?}", stack_frame);
+            interrupt_trace(stack_frame);
+
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn breakpoint_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("EXCEPTION: BREAKPOINT");
+            eprintln!("{:#?}", stack_frame);
+
+            // IP points to the next instruction
+            // for the stack trace and gdb rewind it
+            unsafe { stack_frame.as_mut().instruction_pointer -= 1u64 };
+
+            interrupt_trace(stack_frame);
+
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn overflow_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("overflow_handler");
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn bound_range_exceeded_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("bound_range_exceeded_handler");
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn device_not_available_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("device_not_available_handler");
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn x87_floating_point_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("x87_floating_point_handler");
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn alignment_check_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
+            eprintln!("alignment_check_handler");
+            eprintln!("Error Code: {:?}", error_code);
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn machine_check_handler(stack_frame: &mut ExtendedInterruptStackFrame) -> ! {
+            eprintln!("machine_check_handler");
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn simd_floating_point_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("simd_floating_point_handler");
+            eprintln!("{:#?}", stack_frame);
+
+            let mxcsr: u32 = 0;
+            unsafe {
+                asm!("stmxcsr [{}]",
+                        in(reg) &mxcsr,
+                        options(nostack),
+                );
+            }
+
+            eprintln!("MXCSR: {:#b}", mxcsr);
+
+            interrupt_trace(stack_frame);
+
+            print_stack_trace();
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn virtualization_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("virtualization_handler");
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn security_exception_handler(
+            stack_frame: &mut ExtendedInterruptStackFrame,
+            error_code: u64,
+        ) {
+            eprintln!("security_exception_handler");
+            eprintln!("Error Code: {:?}", error_code);
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn invalid_tss_handler(stack_frame: &mut ExtendedInterruptStackFrame, error_code: u64) {
+            eprintln!("invalid_tss_handler {}", error_code);
+            eprintln!("{:#?}", stack_frame);
+            shim_exit(255);
+        }
+    );
+
+    declare_interrupt!(
+        fn non_maskable_interrupt_handler(stack_frame: &mut ExtendedInterruptStackFrame) {
+            eprintln!("EXCEPTION: NMI");
+            eprintln!("{:#?}", stack_frame);
+        }
+    );
+
+    declare_interrupt!(
+        fn page_fault_handler(
+            stack_frame: &mut ExtendedInterruptStackFrame,
+            error_code: x86_64::structures::idt::PageFaultErrorCode,
+        ) {
+            use x86_64::registers::control::Cr2;
+
+            eprintln!("EXCEPTION: PAGE FAULT");
+
+            eprintln!("Accessed Address: {:?}", Cr2::read());
+            eprintln!("Error Code: {:?}", error_code);
+            eprintln!("{:x?}", stack_frame);
+
+            interrupt_trace(stack_frame);
+
+            print_stack_trace();
+
+            shim_exit(255)
+        }
+    );
+
+    declare_interrupt!(
+        fn double_fault_handler(
+            stack_frame: &mut ExtendedInterruptStackFrame,
+            _error_code: u64, // Always 0
+        ) -> ! {
+            eprintln!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
+
+            interrupt_trace(stack_frame);
+
+            shim_exit(255);
+        }
+    );
+}

--- a/internal/shim-sev/src/lib.rs
+++ b/internal/shim-sev/src/lib.rs
@@ -15,8 +15,6 @@ use crate::snp::cpuid_page::CpuidPage;
 use crate::snp::ghcb::Ghcb;
 use crate::snp::secrets_page::SnpSecretsPage;
 
-use core::sync::atomic::AtomicBool;
-
 use goblin::elf::header::header64::Header;
 use primordial::Page as Page4KiB;
 use sallyport::Block;
@@ -30,6 +28,7 @@ pub mod print;
 pub mod addr;
 pub mod allocator;
 pub mod debug;
+pub mod exec;
 pub mod gdb;
 pub mod gdt;
 pub mod hostcall;
@@ -38,7 +37,6 @@ pub mod idt;
 pub mod interrupts;
 pub mod pagetables;
 pub mod paging;
-pub mod payload;
 pub mod random;
 pub mod shim_stack;
 pub mod snp;
@@ -46,8 +44,6 @@ pub mod spin;
 pub mod sse;
 pub mod syscall;
 pub mod usermode;
-
-static PAYLOAD_READY: AtomicBool = AtomicBool::new(false);
 
 extern "C" {
     /// Extern

--- a/internal/shim-sev/src/lib.rs
+++ b/internal/shim-sev/src/lib.rs
@@ -30,6 +30,7 @@ pub mod print;
 pub mod addr;
 pub mod allocator;
 pub mod debug;
+pub mod gdb;
 pub mod gdt;
 pub mod hostcall;
 pub mod hostmap;

--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -15,10 +15,10 @@ extern crate compiler_builtins;
 extern crate rcrt1;
 
 use shim_sev::addr::SHIM_VIRT_OFFSET;
+use shim_sev::exec;
 use shim_sev::gdt;
 use shim_sev::interrupts;
 use shim_sev::pagetables::{unmap_identity, PDPT, PDT_C000_0000, PML4T, PT_FFE0_0000};
-use shim_sev::payload;
 use shim_sev::print::enable_printing;
 use shim_sev::snp::C_BIT_MASK;
 use shim_sev::sse;
@@ -97,7 +97,7 @@ extern "sysv64" fn main() -> ! {
     sse::init_sse();
     interrupts::init();
 
-    payload::execute_payload()
+    exec::execute_exec()
 }
 
 /// The panic function

--- a/internal/shim-sev/src/print.rs
+++ b/internal/shim-sev/src/print.rs
@@ -11,7 +11,7 @@ struct HostWrite(HostFd);
 
 // FIXME: remove, if https://github.com/enarx/enarx/issues/831 is fleshed out
 /// Global flag allowing debug output.
-pub const TRACE: bool = false;
+pub const TRACE: bool = cfg!(feature = "dbg");
 
 /// start with printing disabled
 static mut PRINT_INHIBITOR: AtomicUsize = AtomicUsize::new(1);
@@ -147,7 +147,7 @@ macro_rules! println {
 #[macro_export]
 macro_rules! eprint {
     ($($arg:tt)*) => {
-        if $crate::print::TRACE { $crate::print::_eprint(format_args!($($arg)*)) };
+        if $crate::print::TRACE { $crate::print::_eprint(format_args!($($arg)*)) }
     };
 }
 

--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -6,9 +6,9 @@ use crate::addr::{HostVirtAddr, ShimPhysUnencryptedAddr};
 use crate::allocator::ALLOCATOR;
 use crate::debug::_enarx_asm_triple_fault;
 use crate::eprintln;
+use crate::exec::{NEXT_BRK_RWLOCK, NEXT_MMAP_RWLOCK};
 use crate::hostcall::{HostCall, HOST_CALL_ALLOC};
 use crate::paging::SHIM_PAGETABLE;
-use crate::payload::{NEXT_BRK_RWLOCK, NEXT_MMAP_RWLOCK};
 
 use core::convert::TryFrom;
 use core::mem::size_of;

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +19,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compiler_builtins"
@@ -68,6 +86,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9274b445ee572d50bdeb17a1101be829becc565b5c12b21a697af4d360b48e8d"
 
 [[package]]
+name = "gdbstub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e135587d3f6eee6fa02c4ba174270c2337424e6d852c156942c0840b3c0f5cc"
+dependencies = [
+ "cfg-if 0.1.10",
+ "log",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "gdbstub_arch"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e358b9c0e1468eae66099062e47bb502849308b987b74b5e72f1936397c33c16"
+dependencies = [
+ "gdbstub",
+ "num-traits",
+]
+
+[[package]]
 name = "goblin"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,16 +125,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "lset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efeae5282702b072b5e21cf8f430ccd3c5031c1e346321a28429523266c4a9b0"
 
 [[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
 name = "noted"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9ed3de88cf5f12b1b461eb59a5b85f60d84216207bda41bf0f0eb2d7d51d397"
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "plain"
@@ -148,8 +219,7 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59efbc99f5c98530d4151b67b6b754956b8a016b60da071a463f2d6ef71dda2"
+source = "git+https://github.com/enarx/sallyport?rev=dd42c91cc9e5cbc74f342eede3bc072f60ba11bd#dd42c91cc9e5cbc74f342eede3bc072f60ba11bd"
 dependencies = [
  "goblin",
  "libc",
@@ -186,6 +256,8 @@ dependencies = [
  "compiler_builtins",
  "const-default 1.0.0",
  "crt0stack",
+ "gdbstub",
+ "gdbstub_arch",
  "goblin",
  "libc",
  "lset",

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -10,15 +10,17 @@ name = "shim-sgx"
 test = false
 
 [features]
-gdb = [ "dbg" ]
+gdb = [ "gdbstub", "gdbstub_arch", "dbg" ]
 dbg = []
 
 [dependencies]
 compiler_builtins = { version = "0.1", default-features = false, features = [ "mem" ] }
+gdbstub_arch = { version = "0.1.1" , default-features = false, optional = true }
+gdbstub = { version = "0.5.0" , default-features = false, optional = true }
 goblin = { version = "0.4", default-features = false, features = [ "elf64" ] }
 x86_64 = { version = "^0.14.6", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
-sallyport = { version = "0.1" }
+sallyport = { git = "https://github.com/enarx/sallyport", rev = "dd42c91cc9e5cbc74f342eede3bc072f60ba11bd" }
 libc = { version = "0.2", default-features = false }
 const-default = "1.0"
 primordial = "0.3.0"

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -10,6 +10,7 @@ name = "shim-sgx"
 test = false
 
 [features]
+gdb = [ "dbg" ]
 dbg = []
 
 [dependencies]

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 name = "shim-sgx"
 test = false
 
+[features]
+dbg = []
+
 [dependencies]
 compiler_builtins = { version = "0.1", default-features = false, features = [ "mem" ] }
 goblin = { version = "0.4", default-features = false, features = [ "elf64" ] }

--- a/internal/shim-sgx/src/entry.rs
+++ b/internal/shim-sgx/src/entry.rs
@@ -79,7 +79,7 @@ fn crt0setup<'a>(
     builder.done()
 }
 
-/// The initial entry function to startup the payload code
+/// The initial entry function to startup the exec code
 ///
 /// # Safety
 ///

--- a/internal/shim-sgx/src/entry.rs
+++ b/internal/shim-sgx/src/entry.rs
@@ -99,11 +99,16 @@ pub unsafe fn entry(offset: *const ()) -> ! {
         Ok(handle) => handle,
     };
 
+    let entry = offset as u64 + hdr.e_entry;
+
+    #[cfg(feature = "gdb")]
+    crate::handler::gdb::set_bp(entry);
+
     asm!(
         "mov rsp, {SP}",
         "jmp {START}",
         SP = in(reg) &*handle,
-        START = in(reg) offset as u64 + hdr.e_entry,
+        START = in(reg) entry,
         options(noreturn)
     )
 }

--- a/internal/shim-sgx/src/handler/gdb.rs
+++ b/internal/shim-sgx/src/handler/gdb.rs
@@ -76,7 +76,7 @@ impl<'a> super::Handler<'a> {
         let mut buf = [0; 4096];
         debugln!(self, "Starting GDB session...");
         debugln!(self, "symbol-file -o {:#x} <shim>", shim_base_offset());
-        debugln!(self, "symbol-file -o {:#x} <payload>", unsafe {
+        debugln!(self, "symbol-file -o {:#x} <exec>", unsafe {
             &ENARX_EXEC_START as *const u8 as u64
         });
 

--- a/internal/shim-sgx/src/handler/gdb.rs
+++ b/internal/shim-sgx/src/handler/gdb.rs
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "gdb")]
+
+use core::convert::TryFrom;
+use core::mem::size_of;
+use core::ops::Range;
+
+use crate::{ENARX_EXEC_START, ENARX_HEAP_END, ENCL_SIZE};
+use gdbstub::arch::Arch;
+use gdbstub::target::ext::base::singlethread::SingleThreadOps;
+use gdbstub::target::ext::base::singlethread::{GdbInterrupt, ResumeAction, StopReason};
+use gdbstub::target::ext::base::BaseOps;
+use gdbstub::target::{Target, TargetResult};
+use gdbstub::Connection;
+use gdbstub_arch::x86::reg::X86_64CoreRegs;
+use primordial::Register;
+use sallyport::syscall::{
+    ProcessSyscallHandler, SyscallHandler, SYS_ENARX_GDB_PEEK, SYS_ENARX_GDB_READ,
+    SYS_ENARX_GDB_START, SYS_ENARX_GDB_WRITE,
+};
+use sallyport::Block;
+use sgx::ssa::StateSaveArea;
+use x86_64::registers::rflags::RFlags;
+
+impl<'a> super::Handler<'a> {
+    pub(crate) fn gdb_session(&mut self) {
+        use gdbstub::{DisconnectReason, GdbStubBuilder, GdbStubError};
+
+        let mut mxcsr: u32 = 0;
+        unsafe { asm!("stmxcsr [{}]", in(reg) &mut mxcsr, options(nostack)) };
+
+        let regs = X86_64CoreRegs {
+            /// RAX, RBX, RCX, RDX, RSI, RDI, RBP, RSP, r8-r15
+            regs: [
+                self.ssa.gpr.rax,
+                self.ssa.gpr.rbx,
+                self.ssa.gpr.rcx,
+                self.ssa.gpr.rdx,
+                self.ssa.gpr.rsi,
+                self.ssa.gpr.rdi,
+                self.ssa.gpr.rbp,
+                self.ssa.gpr.rsp,
+                self.ssa.gpr.r8,
+                self.ssa.gpr.r9,
+                self.ssa.gpr.r10,
+                self.ssa.gpr.r11,
+                self.ssa.gpr.r12,
+                self.ssa.gpr.r13,
+                self.ssa.gpr.r14,
+                self.ssa.gpr.r15,
+            ],
+            eflags: self.ssa.gpr.rflags as u32,
+            rip: self.ssa.gpr.rip,
+            segments: Default::default(),
+            /// FPU registers: ST0 through ST7
+            st: Default::default(),
+            fpu: Default::default(),
+            xmm: Default::default(),
+            mxcsr,
+        };
+
+        regs.regs.iter().enumerate().for_each(|(i, v)| {
+            debugln!(self, "r{} = {:#x}", i, v);
+        });
+
+        debugln!(self, "rip = {:#x}", regs.rip);
+
+        let block_ptr = self.block as *const _ as *const u8;
+        let block_range = block_ptr..unsafe { block_ptr.add(size_of::<Block>()) };
+        let ssa_ptr = self.ssa as *const _ as *const u8;
+        let ssa_range = ssa_ptr..unsafe { ssa_ptr.add(size_of::<StateSaveArea>()) };
+
+        let mut target = GdbTarget::new(regs, block_range, ssa_range);
+
+        let mut buf = [0; 4096];
+        debugln!(self, "Starting GDB session...");
+        debugln!(self, "symbol-file -o {:#x} <shim>", shim_base_offset());
+        debugln!(self, "symbol-file -o {:#x} <payload>", unsafe {
+            &ENARX_EXEC_START as *const u8 as u64
+        });
+
+        // workaround for the gdbstub main loop (will change with gdbstub-0.6
+        loop {
+            let mut gdb = GdbStubBuilder::new(self as &mut dyn Connection<Error = libc::c_int>)
+                .with_packet_buffer(&mut buf)
+                .build()
+                .unwrap();
+
+            match gdb.run(&mut target) {
+                Ok(disconnect_reason) => {
+                    match disconnect_reason {
+                        DisconnectReason::Disconnect => debugln!(self, "GDB Disconnected"),
+                        DisconnectReason::TargetExited(_) => debugln!(self, "Target exited"),
+                        DisconnectReason::TargetTerminated(_) => debugln!(self, "Target halted"),
+                        DisconnectReason::Kill => {
+                            debugln!(self, "GDB sent a kill command");
+                            self.exit(255);
+                        }
+                    }
+                    break;
+                }
+
+                Err(GdbStubError::TargetError(e)) => {
+                    debugln!(self, "resume: {:#?}", e);
+                    break;
+                }
+
+                // workaround for the gdbstub main loop (will change with gdbstub-0.6
+                Err(e) => match e {
+                    GdbStubError::ConnectionRead(_) => break,
+                    GdbStubError::ConnectionWrite(_) => break,
+                    GdbStubError::PacketParse(_) => break,
+                    GdbStubError::PacketUnexpected => break,
+                    GdbStubError::TargetMismatch => break,
+                    GdbStubError::UnsupportedStopReason => break,
+                    _ => debugln!(self, "gdbstub internal error: {:#?}", e),
+                },
+            };
+        }
+
+        target.regs.regs.iter().enumerate().for_each(|(i, v)| {
+            debugln!(self, "r{} = {:#x}", i, v);
+        });
+
+        debugln!(self, "rip = {:#x}", target.regs.rip);
+
+        // update the registers
+        self.ssa.gpr.rax = target.regs.regs[0];
+        self.ssa.gpr.rbx = target.regs.regs[1];
+        self.ssa.gpr.rcx = target.regs.regs[2];
+        self.ssa.gpr.rdx = target.regs.regs[3];
+        self.ssa.gpr.rsi = target.regs.regs[4];
+        self.ssa.gpr.rdi = target.regs.regs[5];
+        self.ssa.gpr.rbp = target.regs.regs[6];
+        self.ssa.gpr.rip = target.regs.regs[7];
+        self.ssa.gpr.r8 = target.regs.regs[8];
+        self.ssa.gpr.r9 = target.regs.regs[9];
+        self.ssa.gpr.r10 = target.regs.regs[10];
+        self.ssa.gpr.r11 = target.regs.regs[11];
+        self.ssa.gpr.r12 = target.regs.regs[12];
+        self.ssa.gpr.r13 = target.regs.regs[13];
+        self.ssa.gpr.r14 = target.regs.regs[14];
+        self.ssa.gpr.r15 = target.regs.regs[15];
+        self.ssa.gpr.rip = target.regs.rip;
+        self.ssa.gpr.rflags &= 0xFFFF_FFFF_0000_0000;
+        self.ssa.gpr.rflags |= target.regs.eflags as u64;
+    }
+}
+
+impl<'a> gdbstub::Connection for super::Handler<'a> {
+    type Error = libc::c_int;
+
+    fn read(&mut self) -> Result<u8, Self::Error> {
+        let mut buf = [0u8];
+        match self.read_exact(&mut buf) {
+            Ok(_) => Ok(buf[0]),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        let bytes_len = buf.len();
+        let mut to_read = bytes_len;
+
+        loop {
+            let next = bytes_len.checked_sub(to_read).ok_or(libc::EFAULT)?;
+
+            let [read, _] = SyscallHandler::syscall(
+                self,
+                Register::<usize>::from(buf[next..].as_mut_ptr()),
+                Register::<usize>::from(to_read),
+                0usize.into(),
+                0usize.into(),
+                0usize.into(),
+                0usize.into(),
+                SYS_ENARX_GDB_READ as _,
+            )?;
+
+            // be careful with `read` as it is untrusted
+            to_read = to_read.checked_sub(read.into()).ok_or(libc::EIO)?;
+
+            if to_read == 0 {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn write(&mut self, byte: u8) -> Result<(), Self::Error> {
+        self.write_all(&[byte])
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        let bytes_len = buf.len();
+        let mut to_write = bytes_len;
+
+        loop {
+            let next = bytes_len.checked_sub(to_write).ok_or(libc::EFAULT)?;
+
+            let [written, _] = self.syscall(
+                Register::<usize>::from(buf[next..].as_ptr()),
+                Register::<usize>::from(to_write),
+                0usize.into(),
+                0usize.into(),
+                0usize.into(),
+                0usize.into(),
+                SYS_ENARX_GDB_WRITE as _,
+            )?;
+
+            // be careful with `written` as it is untrusted
+            to_write = to_write.checked_sub(written.into()).ok_or(libc::EIO)?;
+            if to_write == 0 {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn peek(&mut self) -> Result<Option<u8>, Self::Error> {
+        let [val, _] = self.syscall(
+            0usize.into(),
+            0usize.into(),
+            0usize.into(),
+            0usize.into(),
+            0usize.into(),
+            0usize.into(),
+            SYS_ENARX_GDB_PEEK as _,
+        )?;
+
+        Ok(u8::try_from(usize::from(val)).ok())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn on_session_start(&mut self) -> Result<(), Self::Error> {
+        let [_, _] = self.syscall(
+            0usize.into(),
+            0usize.into(),
+            0usize.into(),
+            0usize.into(),
+            0usize.into(),
+            0usize.into(),
+            SYS_ENARX_GDB_START as _,
+        )?;
+
+        Ok(())
+    }
+}
+
+/// FIXME
+#[derive(Debug)]
+pub struct GdbTarget {
+    regs: X86_64CoreRegs,
+    shim_range: Range<*const u8>,
+    block_range: Range<*const u8>,
+    ssa_range: Range<*const u8>,
+}
+
+impl GdbTarget {
+    /// FIXME
+    pub fn new(
+        regs: X86_64CoreRegs,
+        block_range: Range<*const u8>,
+        ssa_range: Range<*const u8>,
+    ) -> Self {
+        let shim_range = shim_base_offset() as *const u8..unsafe { &ENARX_HEAP_END as *const u8 };
+
+        Self {
+            regs,
+            shim_range,
+            block_range,
+            ssa_range,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum GdbTargetError {
+    ResumeContinue,
+    ResumeStep,
+    ResumeContinueWithSignal,
+    ResumeStepWithSignal,
+    // ReadMemoryOutOfRange(u64),
+    WriteMemoryOutOfRange(u64),
+}
+
+impl Target for GdbTarget {
+    type Arch = gdbstub_arch::x86::X86_64_SSE;
+    type Error = GdbTargetError;
+
+    fn base_ops(&mut self) -> BaseOps<Self::Arch, Self::Error> {
+        BaseOps::SingleThread(self)
+    }
+}
+
+impl SingleThreadOps for GdbTarget {
+    fn resume(
+        &mut self,
+        action: ResumeAction,
+        _gdb_interrupt: GdbInterrupt<'_>,
+    ) -> Result<StopReason<<Self::Arch as Arch>::Usize>, Self::Error> {
+        match action {
+            ResumeAction::Continue => {
+                self.regs.eflags &= !RFlags::TRAP_FLAG.bits() as u32;
+                Err(GdbTargetError::ResumeContinue)
+            }
+            ResumeAction::Step => {
+                self.regs.eflags |= RFlags::TRAP_FLAG.bits() as u32;
+                Err(GdbTargetError::ResumeStep)
+            }
+            ResumeAction::ContinueWithSignal(_) => {
+                self.regs.eflags &= !RFlags::TRAP_FLAG.bits() as u32;
+                Err(GdbTargetError::ResumeContinueWithSignal)
+            }
+            ResumeAction::StepWithSignal(_) => {
+                self.regs.eflags |= RFlags::TRAP_FLAG.bits() as u32;
+                Err(GdbTargetError::ResumeStepWithSignal)
+            }
+        }
+    }
+
+    fn read_registers(
+        &mut self,
+        regs: &mut <Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        *regs = self.regs.clone();
+        Ok(())
+    }
+
+    fn write_registers(
+        &mut self,
+        regs: &<Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        self.regs = regs.clone();
+        Ok(())
+    }
+
+    fn read_addrs(
+        &mut self,
+        start_addr: <Self::Arch as Arch>::Usize,
+        data: &mut [u8],
+    ) -> TargetResult<(), Self> {
+        let ptr = start_addr as *const u8;
+        let ptr_end = unsafe { ptr.add(data.len()) };
+
+        if !((self.shim_range.contains(&ptr) && self.shim_range.contains(&ptr_end))
+            || (self.block_range.contains(&ptr) && self.block_range.contains(&ptr_end))
+            || (self.ssa_range.contains(&ptr) && self.ssa_range.contains(&ptr_end)))
+        {
+            return Err(gdbstub::target::TargetError::NonFatal);
+        }
+
+        let src = unsafe { core::slice::from_raw_parts(ptr, data.len()) };
+        data.copy_from_slice(src);
+        Ok(())
+    }
+
+    fn write_addrs(
+        &mut self,
+        start_addr: <Self::Arch as Arch>::Usize,
+        data: &[u8],
+    ) -> TargetResult<(), Self> {
+        let ptr = start_addr as *const u8;
+        let ptr_end = unsafe { ptr.add(data.len()) };
+
+        if !((self.shim_range.contains(&ptr) && self.shim_range.contains(&ptr_end))
+            || (self.block_range.contains(&ptr) && self.block_range.contains(&ptr_end))
+            || (self.ssa_range.contains(&ptr) && self.ssa_range.contains(&ptr_end)))
+        {
+            return Err(gdbstub::target::TargetError::Fatal(
+                GdbTargetError::WriteMemoryOutOfRange(start_addr as _),
+            ));
+        }
+
+        let ptr = start_addr as *mut u8;
+
+        let dst = unsafe { core::slice::from_raw_parts_mut(ptr, data.len()) };
+        dst.copy_from_slice(data);
+        Ok(())
+    }
+}
+
+fn shim_base_offset() -> u64 {
+    let base: u64;
+    unsafe {
+        asm!(
+            "lea    {0},    [rip + _DYNAMIC]", // rdi = address of _DYNAMIC section
+            "and    {0},    -{SIZE}         ", // rsi = relocation address
+            out(reg) base,
+            SIZE = const ENCL_SIZE,
+            options(nostack, nomem)
+        );
+    }
+    base
+}
+
+static mut TRACE_BYTE: (u64, u8) = (0, 0);
+
+pub unsafe fn set_bp(rip: u64) {
+    let ptr = rip as *mut u8;
+
+    TRACE_BYTE = (rip, ptr.read());
+    // Write INT3
+    ptr.write(0xCC);
+}
+
+pub unsafe fn unset_bp(rip: u64) -> bool {
+    let ptr = rip as *mut u8;
+
+    if rip != TRACE_BYTE.0 {
+        return false;
+    }
+
+    debug_assert_eq!(ptr.read(), 0xCC);
+
+    ptr.write(TRACE_BYTE.1);
+
+    TRACE_BYTE = (0, 0);
+
+    true
+}

--- a/internal/shim-sgx/src/handler/mod.rs
+++ b/internal/shim-sgx/src/handler/mod.rs
@@ -205,7 +205,7 @@ impl<'a> Handler<'a> {
         }
     }
 
-    /// Print out `rip` relative to the shim (S) or the payload (P) base address.
+    /// Print out `rip` relative to the shim (S) or the exec (E) base address.
     ///
     /// This can be used with `addr2line` and the executable with debug info
     /// to get the function name and line number.
@@ -218,7 +218,7 @@ impl<'a> Handler<'a> {
 
         if exec_range.contains(&rip) {
             let rip_pie = rip - enarx_exec_start;
-            debugln!(self, "P {:>#016x}", rip_pie);
+            debugln!(self, "E {:>#016x}", rip_pie);
         } else {
             let rip_pie = (shim_start - 1) & rip;
             debugln!(self, "S {:>#016x}", rip_pie);

--- a/internal/shim-sgx/src/lib.rs
+++ b/internal/shim-sgx/src/lib.rs
@@ -6,7 +6,7 @@
 //! instructions) from the enclave code and proxies them to the host.
 
 #![cfg_attr(not(test), no_std)]
-#![feature(asm)]
+#![feature(asm, asm_const, asm_sym)]
 #![feature(naked_functions)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
@@ -15,7 +15,7 @@ pub mod entry;
 pub mod handler;
 pub mod heap;
 
-use sgx::parameters::{Attributes, Features, Xfrm};
+use sgx::parameters::{Attributes, Features, MiscSelect, Xfrm};
 
 const DEBUG: bool = cfg!(feature = "dbg");
 
@@ -25,8 +25,18 @@ pub const ENCL_SIZE_BITS: u8 = 31;
 pub const ENCL_SIZE: usize = 1 << ENCL_SIZE_BITS;
 
 const XFRM: Xfrm = Xfrm::from_bits_truncate(Xfrm::X87.bits() | Xfrm::SSE.bits());
-/// FIXME: doc
+
+/// Default enclave CPU attributes
 pub const ATTR: Attributes = Attributes::new(Features::MODE64BIT, XFRM);
+
+/// Default miscelaneous SSA data selector
+pub const MISC: MiscSelect = {
+    if cfg!(dbg) {
+        MiscSelect::EXINFO
+    } else {
+        MiscSelect::empty()
+    }
+};
 
 // NOTE: You MUST take the address of these symbols for them to work!
 extern "C" {

--- a/internal/shim-sgx/src/lib.rs
+++ b/internal/shim-sgx/src/lib.rs
@@ -17,7 +17,7 @@ pub mod heap;
 
 use sgx::parameters::{Attributes, Features, Xfrm};
 
-const DEBUG: bool = false;
+const DEBUG: bool = cfg!(feature = "dbg");
 
 /// FIXME: doc
 pub const ENCL_SIZE_BITS: u8 = 31;

--- a/internal/shim-sgx/src/main.rs
+++ b/internal/shim-sgx/src/main.rs
@@ -16,7 +16,7 @@ extern crate rcrt1;
 
 use shim_sgx::{
     entry, handler, ATTR, ENARX_EXEC_START, ENARX_HEAP_END, ENARX_HEAP_START, ENCL_SIZE,
-    ENCL_SIZE_BITS,
+    ENCL_SIZE_BITS, MISC,
 };
 
 #[panic_handler]
@@ -65,8 +65,8 @@ noted! {
 
     static NOTE_PID<note::NAME, note::sgx::PID, u16> = 0;
     static NOTE_SVN<note::NAME, note::sgx::SVN, u16> = 0;
-    static NOTE_MISC<note::NAME, note::sgx::MISC, MiscSelect> = MiscSelect::empty();
-    static NOTE_MISCMASK<note::NAME, note::sgx::MISCMASK, MiscSelect> = MiscSelect::empty();
+    static NOTE_MISC<note::NAME, note::sgx::MISC, MiscSelect> = MISC;
+    static NOTE_MISCMASK<note::NAME, note::sgx::MISCMASK, MiscSelect> = MISC;
     static NOTE_ATTR<note::NAME, note::sgx::ATTR, Attributes> = ATTR;
     static NOTE_ATTRMASK<note::NAME, note::sgx::ATTRMASK, Attributes> = ATTR;
 }

--- a/internal/wasmldr/Cargo.toml
+++ b/internal/wasmldr/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 # TODO: merge these into the toplevel actions/gitignore
 exclude = [ ".gitignore", ".github/*" ]
 
+[features]
+dbg = []
+
 [dependencies]
 wasmtime = { version = "0.30", default-features = false, features = ["cranelift"] }
 wasmtime-wasi = { version = "0.30", default-features = false, features = ["sync"] }

--- a/internal/wasmldr/Cargo.toml
+++ b/internal/wasmldr/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 exclude = [ ".gitignore", ".github/*" ]
 
 [features]
+gdb = []
 dbg = []
 
 [dependencies]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -98,6 +98,10 @@ pub enum Command<'a> {
     #[allow(dead_code)]
     CpuId(&'a mut Block),
 
+    #[cfg(feature = "gdb")]
+    #[allow(dead_code)]
+    Gdb(&'a mut Block, &'a mut Option<std::net::TcpStream>),
+
     #[allow(dead_code)]
     Continue,
 }
@@ -112,3 +116,84 @@ pub static BACKENDS: Lazy<Vec<Box<dyn Backend>>> = Lazy::new(|| {
         Box::new(kvm::Backend),
     ]
 });
+
+#[cfg(feature = "gdb")]
+pub fn wait_for_gdb_connection(sockaddr: &str) -> std::io::Result<std::net::TcpStream> {
+    use std::net::TcpListener;
+
+    eprintln!("Waiting for a GDB connection on {:?}...", sockaddr);
+    let sock = TcpListener::bind(sockaddr)?;
+    let (stream, addr) = sock.accept()?;
+
+    // Blocks until a GDB client connects via TCP.
+    // i.e: Running `target remote localhost:<port>` from the GDB prompt.
+
+    eprintln!("Debugger connected from {}", addr);
+    Ok(stream) // `TcpStream` implements `gdbstub::Connection`
+}
+
+#[cfg(feature = "gdb")]
+pub fn handle_gdb(block: &mut Block, gdb_fd: &mut Option<std::net::TcpStream>, sockaddr: &str) {
+    use gdbstub::Connection;
+
+    let req = unsafe { block.msg.req };
+    match req.num.into() {
+        sallyport::syscall::SYS_ENARX_GDB_START => {
+            if gdb_fd.is_none() {
+                let mut stream = wait_for_gdb_connection(sockaddr).unwrap();
+                let res = stream
+                    .on_session_start()
+                    .map(|_| [0usize.into(), 0usize.into()])
+                    .map_err(|e| e.raw_os_error().unwrap_or(libc::EINVAL));
+                if res.is_ok() {
+                    gdb_fd.replace(stream);
+                }
+                block.msg.rep = res.into();
+            } else {
+                block.msg.rep = Ok([0usize.into(), 0usize.into()]).into();
+            }
+        }
+
+        sallyport::syscall::SYS_ENARX_GDB_PEEK => {
+            let stream = gdb_fd.as_mut().unwrap();
+
+            let ret = Connection::peek(stream)
+                .map(|v| {
+                    let v = v.map(|v| v as usize).unwrap_or(u8::MAX as usize + 1);
+                    [v.into(), 0usize.into()]
+                })
+                .map_err(|e| e.raw_os_error().unwrap_or(libc::EINVAL));
+            block.msg.rep = ret.into();
+        }
+
+        sallyport::syscall::SYS_ENARX_GDB_READ => {
+            let stream = gdb_fd.as_mut().unwrap();
+
+            let buf_ptr: *mut u8 = req.arg[0].into();
+            let buf_len: usize = req.arg[1].into();
+            let buf = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
+
+            let ret = stream
+                .read_exact(buf)
+                .map(|_| [buf_len.into(), 0usize.into()])
+                .map_err(|e| e.raw_os_error().unwrap_or(libc::EINVAL));
+
+            block.msg.rep = ret.into();
+        }
+
+        sallyport::syscall::SYS_ENARX_GDB_WRITE => {
+            let stream = gdb_fd.as_mut().unwrap();
+
+            let buf_ptr: *mut u8 = req.arg[0].into();
+            let buf_len: usize = req.arg[1].into();
+            let buf = unsafe { core::slice::from_raw_parts(buf_ptr, buf_len) };
+
+            let ret = Connection::write_all(stream, buf)
+                .map(|_| [buf_len.into(), 0usize.into()])
+                .map_err(|e| e.raw_os_error().unwrap_or(libc::EINVAL));
+            block.msg.rep = ret.into();
+        }
+
+        _ => {}
+    }
+}

--- a/src/backend/sgx/config.rs
+++ b/src/backend/sgx/config.rs
@@ -27,6 +27,11 @@ impl super::super::Config for Config {
         }
         if flags & PF_X != 0 {
             rwx |= Flags::EXECUTE;
+
+            // Debugging with gdb also involves modifying executable memory
+            if cfg!(feature = "gdb") {
+                rwx |= Flags::WRITE;
+            }
         }
 
         let m = flags & elf::pf::sgx::UNMEASURED == 0;

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -3,6 +3,8 @@
 use super::super::Command;
 
 use std::mem::MaybeUninit;
+#[cfg(feature = "gdb")]
+use std::net::TcpStream;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -18,6 +20,8 @@ pub struct Thread {
     block: Block,
     cssa: usize,
     how: usize,
+    #[cfg(feature = "gdb")]
+    gdb_fd: Option<TcpStream>,
 }
 
 impl Drop for Thread {
@@ -45,6 +49,8 @@ impl super::super::Keep for super::Keep {
             block: Block::default(),
             cssa: usize::default(),
             how: EENTER,
+            #[cfg(feature = "gdb")]
+            gdb_fd: None,
         })))
     }
 }
@@ -92,7 +98,12 @@ impl super::super::Thread for Thread {
 
         self.how = match run.function as usize {
             EENTER | ERESUME if run.vector == Vector::InvalidOpcode => EENTER,
+
+            #[cfg(feature = "gdb")]
+            EENTER | ERESUME if run.vector == Vector::Page => EENTER,
+
             EEXIT => ERESUME,
+
             _ => panic!("Unexpected AEX: {:?}", run.vector),
         };
 
@@ -118,6 +129,15 @@ impl super::super::Thread for Thread {
             if let (EENTER, ERESUME) = (how, self.how) {
                 match unsafe { self.block.msg.req }.num.into() {
                     SYS_ENARX_CPUID => return Ok(Command::CpuId(&mut self.block)),
+
+                    #[cfg(feature = "gdb")]
+                    sallyport::syscall::SYS_ENARX_GDB_START
+                    | sallyport::syscall::SYS_ENARX_GDB_PEEK
+                    | sallyport::syscall::SYS_ENARX_GDB_READ
+                    | sallyport::syscall::SYS_ENARX_GDB_WRITE => {
+                        return Ok(Command::Gdb(&mut self.block, &mut self.gdb_fd))
+                    }
+
                     _ => return Ok(Command::SysCall(&mut self.block)),
                 }
             }

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -22,4 +22,9 @@ pub struct Options {
     /// Binary to load and run inside the keep
     #[structopt(value_name = "BINARY")]
     pub binpath: PathBuf,
+
+    /// gdb options
+    #[cfg(feature = "gdb")]
+    #[structopt(long, default_value = "localhost:23456")]
+    pub gdblisten: String,
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -16,4 +16,9 @@ pub struct Options {
     /// Path of the WebAssembly module to run
     #[structopt(value_name = "MODULE", parse(from_os_str))]
     pub module: PathBuf,
+
+    /// gdb options
+    #[cfg(feature = "gdb")]
+    #[structopt(long, default_value = "localhost:23456")]
+    pub gdblisten: String,
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -78,6 +78,7 @@ fn write_stdout() {
     run_test("write_stdout", 0, None, &b"hi\n"[..], None);
 }
 
+#[cfg(not(feature = "dbg"))]
 #[test]
 #[serial]
 // v0.1.0 KEEP-CONFIG HACK: logging is hardcoded to send output to stderr,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #![cfg(not(miri))]
+#![cfg(not(feature = "gdb"))]
 
 use std::fs;
 use std::io::{Read, Write};

--- a/tests/wasmldr_tests.rs
+++ b/tests/wasmldr_tests.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #![cfg(feature = "wasmldr")]
+#![cfg(not(feature = "gdb"))]
 
 use process_control::{ChildExt, Output, Timeout};
 use serial_test::serial;


### PR DESCRIPTION
This patch series adds gdb support for enarx.

## GDB

To enable gdb support, compile enarx with the `gdb` feature:

```console
$ cargo clean
$ cargo build --features gdb
```

### KVM / SEV-SNP

Find the "shim" of the TEE. Normally this is `shim-sev`:
```console
$ find target -wholename '*linux-musl/*/shim-sev'
target/debug/build/enarx-f0e8a07172ba3be9/out/internal/shim-sev/x86_64-unknown-linux-musl/debug/shim-sev
```

Find the "exec" of the TEE. Normally this is `wasmldr`:
```console
$ find target -wholename '*linux-musl/*/wasmldr'
target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr
```

Start the TEE:
```console
$ ./target/debug/enarx run ~/git/zerooneone/target/wasm32-wasi/debug/zerooneone.wasm
[…]
Starting GDB session...
symbol-file -o 0xffffff8000000000 <shim>
add-symbol-file -o 0x7f6ffbef8000 <exec>
[…]
Waiting for a GDB connection on "localhost:23456"...
```

You can set the listen address with `--gdblisten <address>`.

Now connect with `gdb` from another terminal and load the symbols from the debug executables as mentioned by the output
with the offsets mentioned. Note: the offsets can vary for every run due to address space layout randomization (ASLR).
```console
$ gdb
[…]
(gdb) symbol-file -o 0xffffff8000000000 target/debug/build/enarx-f0e8a07172ba3be9/out/internal/shim-sev/x86_64-unknown-linux-musl/debug/shim-sev
Reading symbols from target/debug/build/enarx-f0e8a07172ba3be9/out/internal/shim-sev/x86_64-unknown-linux-musl/debug/shim-sev...

(gdb) add-symbol-file -o 0x7f6ffbef8000 target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr
add symbol table from file "target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr" with all sections offset by 0xfbef8000
(y or n) y
[…]

(gdb) target remote localhost:23456
Remote debugging using localhost:23456
[…]
0x00007f434ee83cc9 in _start ()
```

The current execution is stopped in the "exec" executable at the ELF entry point `_start`. You can now start debugging the "exec".

```console
(gdb) br wasmldr::main
Breakpoint 1 at 0x7f434efddbeb: file src/main.rs, line 72.
(gdb) cont
Continuing.

Breakpoint 1, wasmldr::main () at src/main.rs:72
72	    env_logger::Builder::from_default_env().init();
(gdb) list
67	fn main() {
68	    // KEEP-CONFIG HACK: we've inherited stdio and the shim sets
69	    // "RUST_LOG=debug", so this should make logging go to stderr.
70	    // FUTURE: we should have a keep-provided debug channel where we can
71	    // (safely, securely) send logs. Might need our own logger for that..
72	    env_logger::Builder::from_default_env().init();
73	
74	    info!("version {} starting up", env!("CARGO_PKG_VERSION"));
75	
76	    warn!("🌭DEV-ONLY BUILD, NOT FOR PRODUCTION USE🌭");
(gdb) print $pc
$1 = (*mut fn ()) 0x7f434efddbeb <wasmldr::main+11>
(gdb) stepi
0x00007f434efddbf2	72	    env_logger::Builder::from_default_env().init();
(gdb) print $pc
$2 = (*mut fn ()) 0x7f434efddbf2 <wasmldr::main+18>
(gdb) stepi
0x00007f434efddbf9	72	    env_logger::Builder::from_default_env().init();
(gdb) print $pc
$3 = (*mut fn ()) 0x7f434efddbf9 <wasmldr::main+25>
```

### SGX

Find the "shim" of the TEE. Normally this is `shim-sgx`:
```console
$ find target -wholename '*linux-musl/*/shim-sgx'
target/debug/build/enarx-f0e8a07172ba3be9/out/internal/shim-sgx/x86_64-unknown-linux-musl/debug/shim-sgx
```

Find the "exec" of the TEE. Normally this is `wasmldr`:
```console
$ find target -wholename '*linux-musl/*/wasmldr'
target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr
```

Start the TEE:

```console
$ ./target/debug/enarx run ~/git/zerooneone/target/wasm32-wasi/debug/zerooneone.wasm
[…]
Starting GDB session...
symbol-file -o 0x7fcf00000000 <shim>
symbol-file -o 0x7fcf00400000 <exec>
Waiting for a GDB connection on "localhost:23456"...
```

You can set the listen address with `--gdblisten <address>`.

Now connect with `gdb` from another terminal and load the symbols from the debug executables as mentioned by the output
with the offsets mentioned. Note: the offsets can vary for every run due to address space layout randomization (ASLR).

```console
$ gdb
[…]

(gdb) symbol-file -o 0x7fcf00400000 target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr
Reading symbols from target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr...
warning: Missing auto-load script at offset 0 in section .debug_gdb_scripts
of file /home/harald/git/enarx/enarx/target/debug/build/enarx-f0e8a07172ba3be9/out/internal/wasmldr/x86_64-unknown-linux-musl/debug/wasmldr.
Use `info auto-load python-scripts [REGEXP]' to list them.

(gdb) target remote localhost:23456
Remote debugging using localhost:23456
[…]
0x00007f434ee83cc9 in _start ()
```

The current execution is stopped in the "exec" executable at the ELF entry point `_start`. You can now start debugging the "exec".

NOTE: stepping does not work (yet) in SGX.

```console
(gdb) br wasmldr::main
Breakpoint 1 at 0x7fcf007368cb: file src/main.rs, line 72.
(gdb) cont
Continuing.

Breakpoint 1, wasmldr::main () at src/main.rs:72
72	    env_logger::Builder::from_default_env().init();
(gdb) list
67	fn main() {
68	    // KEEP-CONFIG HACK: we've inherited stdio and the shim sets
69	    // "RUST_LOG=debug", so this should make logging go to stderr.
70	    // FUTURE: we should have a keep-provided debug channel where we can
71	    // (safely, securely) send logs. Might need our own logger for that..
72	    env_logger::Builder::from_default_env().init();
73	
74	    info!("version {} starting up", env!("CARGO_PKG_VERSION"));
75	
76	    warn!("🌭DEV-ONLY BUILD, NOT FOR PRODUCTION USE🌭");
(gdb) br workload::run
Breakpoint 2 at 0x7fcf005f6c64: file src/workload.rs, line 81.
(gdb) cont
Continuing.

Breakpoint 2, wasmldr::workload::run<alloc::string::String, alloc::string::String, alloc::vec::Vec<u8, alloc::alloc::Global>, alloc::vec::Vec<alloc::string::String, alloc::alloc::Global>, alloc::vec::Vec<(alloc::string::String, alloc::string::String), alloc::alloc::Global>> (bytes=..., args=..., envs=...) at src/workload.rs:81
81	    debug!("configuring wasmtime engine");
(gdb) list
76	pub fn run<T: AsRef<str>, U: AsRef<str>>(
77	    bytes: impl AsRef<[u8]>,
78	    args: impl IntoIterator<Item = T>,
79	    envs: impl IntoIterator<Item = (U, U)>,
80	) -> Result<Box<[wasmtime::Val]>> {
81	    debug!("configuring wasmtime engine");
82	    let mut config = wasmtime::Config::new();
83	    // Support module-linking (https://github.com/webassembly/module-linking)
84	    config.wasm_module_linking(true);
85	    // module-linking requires multi-memory
```
