### PR TITLE
feat(shim-sev): get rid of paste! macro

### DIFF
--- a/internal/shim-sev/Cargo.lock
+++ b/internal/shim-sev/Cargo.lock
@@ -381,7 +381,6 @@ dependencies = [
  "memoffset",
  "nbytes",
  "noted",
- "paste",
  "primordial",
  "rcrt1",
  "sallyport",

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -36,7 +36,6 @@ bitflags = "1.3.2"
 lock_api = "0.4.5"
 aes-gcm = { version = "0.9.4", features = ["aes"], default-features = false  }
 const-default = { version = "1.0", features = [ "derive" ] }
-paste = "1.0.5"
 
 [dev-dependencies]
 memoffset = "0.6.1"


### PR DESCRIPTION
Using an inner function enables the removal of the paste crate.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
