### PR TITLE
fix(shim-sev): guard custom panic with "not(test)"

### DIFF
--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -24,7 +24,7 @@ use shim_sev::snp::C_BIT_MASK;
 use shim_sev::sse;
 
 use core::mem::size_of;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::Ordering;
 
 use noted::noted;
 use primordial::Page;
@@ -107,7 +107,9 @@ extern "sysv64" fn main() -> ! {
 /// Reverts to a triple fault, which causes a `#VMEXIT` and a KVM shutdown,
 /// if it can't print the panic and exit normally with an error code.
 #[panic_handler]
-pub fn panic(_info: &core::panic::PanicInfo) -> ! {
+#[cfg(not(test))]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    use core::sync::atomic::AtomicBool;
     use shim_sev::debug::_enarx_asm_triple_fault;
     #[cfg(feature = "dbg")]
     use shim_sev::print::{self, is_printing_enabled};


### PR DESCRIPTION
vscode does not like it otherwise

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
