### PR TITLE
fix: cargo fix --edition-idioms

### DIFF
--- a/internal/shim-sev/src/allocator.rs
+++ b/internal/shim-sev/src/allocator.rs
@@ -61,7 +61,7 @@ pub struct EnarxAllocator {
 }
 
 impl core::fmt::Debug for EnarxAllocator {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         f.debug_struct("EnarxAllocator")
             .field("last_alloc", &self.last_alloc)
             .field("max_alloc", &self.max_alloc)

--- a/internal/shim-sev/src/gdb.rs
+++ b/internal/shim-sev/src/gdb.rs
@@ -147,7 +147,7 @@ impl Target for GdbTarget<'_> {
     type Arch = gdbstub_arch::x86::X86_64_SSE;
     type Error = GdbTargetError;
 
-    fn base_ops(&mut self) -> BaseOps<Self::Arch, Self::Error> {
+    fn base_ops(&mut self) -> BaseOps<'_, Self::Arch, Self::Error> {
         BaseOps::SingleThread(self)
     }
 }

--- a/internal/shim-sev/src/interrupts.rs
+++ b/internal/shim-sev/src/interrupts.rs
@@ -58,7 +58,7 @@ impl Deref for ExtendedInterruptStackFrame {
 
 impl fmt::Debug for ExtendedInterruptStackFrame {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.value.fmt(f)
     }
 }

--- a/internal/shim-sev/src/lib.rs
+++ b/internal/shim-sev/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 #![feature(asm, asm_const, asm_sym, naked_functions)]
+#![warn(rust_2018_idioms)]
 
 use crate::snp::cpuid_page::CpuidPage;
 use crate::snp::ghcb::Ghcb;

--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -8,10 +8,13 @@
 #![deny(clippy::all)]
 #![deny(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
+#![warn(rust_2018_idioms)]
 #![no_main]
 #![feature(asm, asm_const, asm_sym, naked_functions)]
 
+#[allow(unused_extern_crates)]
 extern crate compiler_builtins;
+#[allow(unused_extern_crates)]
 extern crate rcrt1;
 
 use shim_sev::addr::SHIM_VIRT_OFFSET;
@@ -108,7 +111,7 @@ extern "sysv64" fn main() -> ! {
 /// if it can't print the panic and exit normally with an error code.
 #[panic_handler]
 #[cfg(not(test))]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
     use core::sync::atomic::AtomicBool;
     use shim_sev::debug::_enarx_asm_triple_fault;
     #[cfg(feature = "dbg")]

--- a/internal/shim-sev/src/print.rs
+++ b/internal/shim-sev/src/print.rs
@@ -66,7 +66,7 @@ impl fmt::Write for HostWrite {
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn _print(args: fmt::Arguments) {
+pub fn _print(args: fmt::Arguments<'_>) {
     use fmt::Write;
 
     if !is_printing_enabled() {
@@ -81,7 +81,7 @@ pub fn _print(args: fmt::Arguments) {
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn _eprint(args: fmt::Arguments) {
+pub fn _eprint(args: fmt::Arguments<'_>) {
     use fmt::Write;
 
     if !is_printing_enabled() {

--- a/internal/shim-sev/src/spin.rs
+++ b/internal/shim-sev/src/spin.rs
@@ -20,7 +20,7 @@ impl<A> Locked<A> {
 
     /// get a [`MutexGuard`](spinning::MutexGuard)
     #[inline]
-    pub fn lock(&self) -> MutexGuard<A> {
+    pub fn lock(&self) -> MutexGuard<'_, A> {
         self.inner.lock()
     }
 }
@@ -41,13 +41,13 @@ impl<A> RwLocked<A> {
 
     /// get a [`RwLockReadGuard`](spinning::RwLockReadGuard)
     #[inline]
-    pub fn read(&self) -> RwLockReadGuard<A> {
+    pub fn read(&self) -> RwLockReadGuard<'_, A> {
         self.inner.read()
     }
 
     /// get a [`RwLockWriteGuard`](spinning::RwLockWriteGuard)
     #[inline]
-    pub fn write(&self) -> RwLockWriteGuard<A> {
+    pub fn write(&self) -> RwLockWriteGuard<'_, A> {
         self.inner.write()
     }
 }

--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -241,7 +241,7 @@ impl BaseSyscallHandler for Handler {
         Register::<usize>::from(HostVirtAddr::from(phys_unencrypted)).into()
     }
 
-    fn new_cursor(&mut self) -> Cursor {
+    fn new_cursor(&mut self) -> Cursor<'_> {
         self.hostcall.as_mut_block().cursor()
     }
 
@@ -259,9 +259,9 @@ impl BaseSyscallHandler for Handler {
 impl EnarxSyscallHandler for Handler {
     fn get_attestation(
         &mut self,
-        nonce: UntrustedRef<u8>,
+        nonce: UntrustedRef<'_, u8>,
         nonce_len: libc::size_t,
-        buf: UntrustedRefMut<u8>,
+        buf: UntrustedRefMut<'_, u8>,
         buf_len: libc::size_t,
     ) -> sallyport::Result {
         self.trace("get_attestation", 4);
@@ -335,7 +335,7 @@ impl ProcessSyscallHandler for Handler {
 }
 
 impl MemorySyscallHandler for Handler {
-    fn mprotect(&mut self, addr: UntrustedRef<u8>, len: usize, prot: i32) -> sallyport::Result {
+    fn mprotect(&mut self, addr: UntrustedRef<'_, u8>, len: usize, prot: i32) -> sallyport::Result {
         self.trace("mprotect", 3);
         let addr = addr.as_ptr();
 
@@ -380,7 +380,7 @@ impl MemorySyscallHandler for Handler {
 
     fn mmap(
         &mut self,
-        addr: UntrustedRef<u8>,
+        addr: UntrustedRef<'_, u8>,
         length: usize,
         prot: i32,
         flags: i32,
@@ -437,7 +437,7 @@ impl MemorySyscallHandler for Handler {
         }
     }
 
-    fn munmap(&mut self, addr: UntrustedRef<u8>, length: usize) -> sallyport::Result {
+    fn munmap(&mut self, addr: UntrustedRef<'_, u8>, length: usize) -> sallyport::Result {
         self.trace("munmap", 2);
 
         let addr = addr.validate_slice(length, self).ok_or(libc::EINVAL)?;

--- a/internal/shim-sgx/src/handler/base.rs
+++ b/internal/shim-sgx/src/handler/base.rs
@@ -9,7 +9,7 @@ impl<'a> BaseSyscallHandler for super::Handler<'a> {
         buf as _
     }
 
-    fn new_cursor(&mut self) -> Cursor {
+    fn new_cursor(&mut self) -> Cursor<'_> {
         self.block.cursor()
     }
 

--- a/internal/shim-sgx/src/handler/enarx.rs
+++ b/internal/shim-sgx/src/handler/enarx.rs
@@ -10,9 +10,9 @@ impl<'a> EnarxSyscallHandler for super::Handler<'a> {
     // For more on this syscall, see: https://github.com/enarx/enarx/issues/966
     fn get_attestation(
         &mut self,
-        hash: UntrustedRef<u8>,
+        hash: UntrustedRef<'_, u8>,
         hash_len: libc::size_t,
-        _buf: UntrustedRefMut<u8>,
+        _buf: UntrustedRefMut<'_, u8>,
         _buf_len: libc::size_t,
     ) -> sallyport::Result {
         self.trace("get_att", 0);

--- a/internal/shim-sgx/src/handler/file.rs
+++ b/internal/shim-sgx/src/handler/file.rs
@@ -9,7 +9,7 @@ impl<'a> FileSyscallHandler for super::Handler<'a> {
     fn readv(
         &mut self,
         fd: libc::c_int,
-        iovec: UntrustedRef<libc::iovec>,
+        iovec: UntrustedRef<'_, libc::iovec>,
         iovcnt: libc::c_int,
     ) -> sallyport::Result {
         self.trace("readv", 3);
@@ -64,7 +64,7 @@ impl<'a> FileSyscallHandler for super::Handler<'a> {
     fn writev(
         &mut self,
         fd: libc::c_int,
-        iovec: UntrustedRef<libc::iovec>,
+        iovec: UntrustedRef<'_, libc::iovec>,
         iovcnt: libc::c_int,
     ) -> sallyport::Result {
         self.trace("writev", 3);

--- a/internal/shim-sgx/src/handler/gdb.rs
+++ b/internal/shim-sgx/src/handler/gdb.rs
@@ -291,7 +291,7 @@ impl Target for GdbTarget {
     type Arch = gdbstub_arch::x86::X86_64_SSE;
     type Error = GdbTargetError;
 
-    fn base_ops(&mut self) -> BaseOps<Self::Arch, Self::Error> {
+    fn base_ops(&mut self) -> BaseOps<'_, Self::Arch, Self::Error> {
         BaseOps::SingleThread(self)
     }
 }

--- a/internal/shim-sgx/src/handler/memory.rs
+++ b/internal/shim-sgx/src/handler/memory.rs
@@ -17,7 +17,7 @@ impl<'a> MemorySyscallHandler for super::Handler<'a> {
     // What you get is what you get. Fake success.
     fn mprotect(
         &mut self,
-        _addr: UntrustedRef<u8>,
+        _addr: UntrustedRef<'_, u8>,
         _len: libc::size_t,
         _prot: libc::c_int,
     ) -> sallyport::Result {
@@ -29,7 +29,7 @@ impl<'a> MemorySyscallHandler for super::Handler<'a> {
     /// Do a mmap() system call
     fn mmap(
         &mut self,
-        addr: UntrustedRef<u8>,
+        addr: UntrustedRef<'_, u8>,
         length: libc::size_t,
         prot: libc::c_int,
         flags: libc::c_int,
@@ -51,7 +51,7 @@ impl<'a> MemorySyscallHandler for super::Handler<'a> {
     }
 
     /// Do a munmap() system call
-    fn munmap(&mut self, addr: UntrustedRef<u8>, length: libc::size_t) -> sallyport::Result {
+    fn munmap(&mut self, addr: UntrustedRef<'_, u8>, length: libc::size_t) -> sallyport::Result {
         self.trace("munmap", 2);
 
         self.heap

--- a/internal/shim-sgx/src/lib.rs
+++ b/internal/shim-sgx/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(naked_functions)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
+#![warn(rust_2018_idioms)]
 
 pub mod entry;
 pub mod handler;

--- a/internal/shim-sgx/src/main.rs
+++ b/internal/shim-sgx/src/main.rs
@@ -9,9 +9,12 @@
 #![feature(asm, asm_const, asm_sym, naked_functions)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
+#![warn(rust_2018_idioms)]
 #![no_main]
 
+#[allow(unused_extern_crates)]
 extern crate compiler_builtins;
+#[allow(unused_extern_crates)]
 extern crate rcrt1;
 
 use shim_sgx::{
@@ -22,7 +25,7 @@ use shim_sgx::{
 #[panic_handler]
 #[cfg(not(test))]
 #[allow(clippy::empty_loop)]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
     loop {}
 }
 

--- a/internal/wasmldr/src/main.rs
+++ b/internal/wasmldr/src/main.rs
@@ -45,6 +45,7 @@
 //!
 #![deny(missing_docs)]
 #![deny(clippy::all)]
+#![warn(rust_2018_idioms)]
 
 mod cli;
 mod workload;

--- a/src/backend/binary.rs
+++ b/src/backend/binary.rs
@@ -63,7 +63,7 @@ impl<'a> Binary<'a> {
         Ok(Self(bytes, elf))
     }
 
-    fn segments(&self, relocate: usize) -> impl Iterator<Item = Segment> {
+    fn segments(&self, relocate: usize) -> impl Iterator<Item = Segment<'_>> {
         assert_eq!(relocate % Page::SIZE, 0);
 
         self.headers(PT_LOAD).map(move |phdr| {
@@ -169,8 +169,8 @@ impl<T: Mapper> Loader for T {
         let mut loader: Self = Self::Config::new(&sbin, &ebin)?.try_into()?;
 
         // Get an array of all final segment locations (relocated).
-        let ssegs: Vec<Segment> = sbin.segments(0).collect();
-        let esegs: Vec<Segment> = ebin.segments(slot.start).collect();
+        let ssegs: Vec<Segment<'_>> = sbin.segments(0).collect();
+        let esegs: Vec<Segment<'_>> = ebin.segments(slot.start).collect();
 
         // Ensure no segments overlap in memory.
         let mut sorted: Vec<_> = ssegs.iter().chain(esegs.iter()).collect();

--- a/src/backend/kvm/config.rs
+++ b/src/backend/kvm/config.rs
@@ -13,7 +13,7 @@ impl super::super::Config for Config {
         flags
     }
 
-    fn new(shim: &super::super::Binary, _exec: &super::super::Binary) -> Result<Self> {
+    fn new(shim: &super::super::Binary<'_>, _exec: &super::super::Binary<'_>) -> Result<Self> {
         let sallyport_headers = shim.headers(PT_LOAD).filter(|p| p.p_flags & SALLYPORT != 0);
 
         if sallyport_headers.count() != 1 {

--- a/src/backend/kvm/thread.rs
+++ b/src/backend/kvm/thread.rs
@@ -105,7 +105,7 @@ impl<P: KeepPersonality> Thread<P> {
 }
 
 impl<P: KeepPersonality> super::super::Thread for Thread<P> {
-    fn enter(&mut self) -> Result<Command> {
+    fn enter(&mut self) -> Result<Command<'_>> {
         let vcpu_fd = self.vcpu_fd.as_mut().unwrap();
         match vcpu_fd.run()? {
             VcpuExit::IoOut(KVM_SYSCALL_TRIGGER_PORT, data) => {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -26,7 +26,7 @@ trait Config: Sized {
     type Flags;
 
     fn flags(flags: u32) -> Self::Flags;
-    fn new(shim: &Binary, exec: &Binary) -> Result<Self>;
+    fn new(shim: &Binary<'_>, exec: &Binary<'_>) -> Result<Self>;
 }
 
 trait Mapper: Sized + TryFrom<Self::Config, Error = Error> {
@@ -88,7 +88,7 @@ pub trait Keep {
 
 pub trait Thread {
     /// Enters the keep.
-    fn enter(&mut self) -> Result<Command>;
+    fn enter(&mut self) -> Result<Command<'_>>;
 }
 
 pub enum Command<'a> {

--- a/src/backend/sev/snp/firmware/linux.rs
+++ b/src/backend/sev/snp/firmware/linux.rs
@@ -23,10 +23,10 @@ impl_const_id! {
 const SEV: Group = Group::new(b'S');
 
 /// Get the CPU's unique ID that can be used for getting a certificate for the CEK public key.
-const GET_ID: Ioctl<WriteRead, &Command<GetId<'_>>> = unsafe { SEV.write_read(0) };
+const GET_ID: Ioctl<WriteRead, &Command<'_, GetId<'_>>> = unsafe { SEV.write_read(0) };
 
 /// Return information about the current status and capabilities of the SEV-SNP platform.
-const SNP_PLATFORM_STATUS: Ioctl<WriteRead, &Command<SnpPlatformStatus>> =
+const SNP_PLATFORM_STATUS: Ioctl<WriteRead, &Command<'_, SnpPlatformStatus>> =
     unsafe { SEV.write_read(0) };
 
 /// Get the CPU's unique ID that can be used for getting

--- a/src/backend/sev/snp/firmware/mod.rs
+++ b/src/backend/sev/snp/firmware/mod.rs
@@ -69,7 +69,7 @@ impl From<Vec<u8>> for Identifier {
 }
 
 impl std::fmt::Display for Identifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for b in self.0.iter() {
             write!(f, "{:02X}", b)?;
         }
@@ -133,7 +133,7 @@ pub struct Build {
 }
 
 impl std::fmt::Display for Build {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}.{}", self.version, self.build)
     }
 }

--- a/src/backend/sev/snp/launch/linux.rs
+++ b/src/backend/sev/snp/launch/linux.rs
@@ -40,20 +40,23 @@ const ENC_OP: Ioctl<WriteRead, &c_ulong> = unsafe { KVM.write_read(0xBA) };
 // that ioctl.
 
 /// Corresponds to the `KVM_MEMORY_ENCRYPT_REG_REGION` ioctl
-pub const ENC_REG_REGION: Ioctl<Write, &KvmEncRegion> =
-    unsafe { KVM.read::<KvmEncRegion>(0xBB).lie() };
+pub const ENC_REG_REGION: Ioctl<Write, &KvmEncRegion<'_>> =
+    unsafe { KVM.read::<KvmEncRegion<'_>>(0xBB).lie() };
 
 /// Initialize the SEV-SNP platform in KVM.
-pub const SNP_INIT: Ioctl<WriteRead, &Command<Init>> = unsafe { ENC_OP.lie() };
+pub const SNP_INIT: Ioctl<WriteRead, &Command<'_, Init>> = unsafe { ENC_OP.lie() };
 
 /// Initialize the flow to launch a guest.
-pub const SNP_LAUNCH_START: Ioctl<WriteRead, &Command<LaunchStart>> = unsafe { ENC_OP.lie() };
+pub const SNP_LAUNCH_START: Ioctl<WriteRead, &Command<'_, LaunchStart<'_>>> =
+    unsafe { ENC_OP.lie() };
 
 /// Insert pages into the guest physical address space.
-pub const SNP_LAUNCH_UPDATE: Ioctl<WriteRead, &Command<LaunchUpdate>> = unsafe { ENC_OP.lie() };
+pub const SNP_LAUNCH_UPDATE: Ioctl<WriteRead, &Command<'_, LaunchUpdate<'_>>> =
+    unsafe { ENC_OP.lie() };
 
 /// Complete the guest launch flow.
-pub const SNP_LAUNCH_FINISH: Ioctl<WriteRead, &Command<LaunchFinish>> = unsafe { ENC_OP.lie() };
+pub const SNP_LAUNCH_FINISH: Ioctl<WriteRead, &Command<'_, LaunchFinish<'_>>> =
+    unsafe { ENC_OP.lie() };
 
 /// Corresponds to the kernel struct `kvm_enc_region`
 ///
@@ -159,7 +162,7 @@ pub struct LaunchStart<'a> {
 }
 
 impl From<Start<'_>> for LaunchStart<'_> {
-    fn from(start: Start) -> Self {
+    fn from(start: Start<'_>) -> Self {
         Self {
             policy: start.policy.into(),
             ma_uaddr: if let Some(addr) = start.ma_uaddr {
@@ -209,7 +212,7 @@ pub struct LaunchUpdate<'a> {
 }
 
 impl From<Update<'_>> for LaunchUpdate<'_> {
-    fn from(update: Update) -> Self {
+    fn from(update: Update<'_>) -> Self {
         Self {
             start_gfn: update.start_gfn,
             uaddr: update.uaddr.as_ptr() as _,
@@ -251,7 +254,7 @@ pub struct LaunchFinish<'a> {
 }
 
 impl From<Finish<'_, '_>> for LaunchFinish<'_> {
-    fn from(finish: Finish) -> Self {
+    fn from(finish: Finish<'_, '_>) -> Self {
         let id_block = if let Some(addr) = finish.id_block {
             addr.as_ptr() as u64
         } else {

--- a/src/backend/sev/snp/launch/mod.rs
+++ b/src/backend/sev/snp/launch/mod.rs
@@ -66,7 +66,7 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<New, U, V> {
     }
 
     /// Initialize the flow to launch a guest.
-    pub fn start(mut self, start: Start) -> Result<Launcher<Started, U, V>> {
+    pub fn start(mut self, start: Start<'_>) -> Result<Launcher<Started, U, V>> {
         let mut launch_start = LaunchStart::from(start);
         let mut cmd = Command::from_mut(&mut self.sev, &mut launch_start);
 
@@ -86,7 +86,7 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<New, U, V> {
 
 impl<U: AsRawFd, V: AsRawFd> Launcher<Started, U, V> {
     /// Encrypt guest SNP data.
-    pub fn update_data(&mut self, update: Update) -> Result<()> {
+    pub fn update_data(&mut self, update: Update<'_>) -> Result<()> {
         let launch_update_data = LaunchUpdate::from(update);
         let mut cmd = Command::from(&mut self.sev, &launch_update_data);
 
@@ -100,7 +100,7 @@ impl<U: AsRawFd, V: AsRawFd> Launcher<Started, U, V> {
     }
 
     /// Complete the SNP launch process.
-    pub fn finish(mut self, finish: Finish) -> Result<(U, V)> {
+    pub fn finish(mut self, finish: Finish<'_, '_>) -> Result<(U, V)> {
         let launch_finish = LaunchFinish::from(finish);
         let mut cmd = Command::from(&mut self.sev, &launch_finish);
 

--- a/src/backend/sev/snp/mod.rs
+++ b/src/backend/sev/snp/mod.rs
@@ -270,7 +270,7 @@ pub struct Version {
 }
 
 impl std::fmt::Display for Version {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}.{}", self.major, self.minor)
     }
 }

--- a/src/backend/sgx/config.rs
+++ b/src/backend/sgx/config.rs
@@ -44,7 +44,7 @@ impl super::super::Config for Config {
         (si, m)
     }
 
-    fn new(shim: &super::super::Binary, _exec: &super::super::Binary) -> Result<Self> {
+    fn new(shim: &super::super::Binary<'_>, _exec: &super::super::Binary<'_>) -> Result<Self> {
         unsafe {
             let params: Parameters = Parameters {
                 misc: Masked {

--- a/src/backend/sgx/ioctls.rs
+++ b/src/backend/sgx/ioctls.rs
@@ -15,15 +15,15 @@ use sgx::signature::Signature;
 const SGX: Group = Group::new(0xA4);
 
 /// IOCTL identifier for ECREATE (see Section 41-21)
-pub const ENCLAVE_CREATE: Ioctl<Write, &Create> = unsafe { SGX.write(0x00) };
+pub const ENCLAVE_CREATE: Ioctl<Write, &Create<'_>> = unsafe { SGX.write(0x00) };
 
 /// IOCTL identifier for EADD (see Section 41-11)
-pub const ENCLAVE_ADD_PAGES: Ioctl<WriteRead, &AddPages> = unsafe { SGX.write_read(0x01) };
+pub const ENCLAVE_ADD_PAGES: Ioctl<WriteRead, &AddPages<'_>> = unsafe { SGX.write_read(0x01) };
 
 /// IOCTL identifier for EINIT (see Section 41-35)
-pub const ENCLAVE_INIT: Ioctl<Write, &Init> = unsafe { SGX.write(0x02) };
+pub const ENCLAVE_INIT: Ioctl<Write, &Init<'_>> = unsafe { SGX.write(0x02) };
 
-pub const ENCLAVE_SET_ATTRIBUTE: Ioctl<Write, &SetAttribute> = unsafe { SGX.write(0x03) };
+pub const ENCLAVE_SET_ATTRIBUTE: Ioctl<Write, &SetAttribute<'_>> = unsafe { SGX.write(0x03) };
 pub const PAGE_MODP: Ioctl<Write, &PageModPerms> = unsafe { SGX.write(0x05) };
 pub const PAGE_MODT: Ioctl<Write, &PageModType> = unsafe { SGX.write(0x06) };
 pub const PAGE_REMOVE: Ioctl<Write, &PageRemove> = unsafe { SGX.write(0x07) };

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -56,7 +56,7 @@ impl super::super::Keep for super::Keep {
 }
 
 impl super::super::Thread for Thread {
-    fn enter(&mut self) -> Result<Command> {
+    fn enter(&mut self) -> Result<Command<'_>> {
         let mut run: Run = unsafe { MaybeUninit::zeroed().assume_init() };
         run.tcs = self.tcs as u64;
         let how = self.how;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,9 @@
 
 #![deny(clippy::all)]
 #![deny(missing_docs)]
+#![warn(rust_2018_idioms)]
+// protobuf-codegen-pure would generate warnings
+#![allow(elided_lifetimes_in_paths)]
 #![feature(asm)]
 
 mod backend;


### PR DESCRIPTION
and add clippy warnings `#[warn(rust_2018_idioms)]`

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
