### PR TITLE
Rework the existing heap implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,12 +177,12 @@ dependencies = [
  "mmarinus",
  "nbytes",
  "openssl",
- "primordial",
+ "primordial 0.4.0",
  "process_control",
  "protobuf",
  "protobuf-codegen-pure",
  "reqwest",
- "sallyport",
+ "sallyport 0.1.0 (git+https://github.com/enarx/sallyport?rev=5b4eca36b41e910ed9ff683adc5ddc0554cdf09c)",
  "semver",
  "serial_test",
  "sgx",
@@ -799,6 +799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55d6312462222758b3fb6c7e84d819ce87c315c446e0e2c11b0b9258dedd3f25"
 
 [[package]]
+name = "primordial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3146f8670eff948342703c5e866cdb6d092032207a7fc2dd53c4c3fef480cfe"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,11 +1010,21 @@ checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 [[package]]
 name = "sallyport"
 version = "0.1.0"
+source = "git+https://github.com/enarx/sallyport?rev=5b4eca36b41e910ed9ff683adc5ddc0554cdf09c#5b4eca36b41e910ed9ff683adc5ddc0554cdf09c"
+dependencies = [
+ "goblin",
+ "libc",
+ "primordial 0.4.0",
+]
+
+[[package]]
+name = "sallyport"
+version = "0.1.0"
 source = "git+https://github.com/enarx/sallyport?rev=dd42c91cc9e5cbc74f342eede3bc072f60ba11bd#dd42c91cc9e5cbc74f342eede3bc072f60ba11bd"
 dependencies = [
  "goblin",
  "libc",
- "primordial",
+ "primordial 0.3.0",
 ]
 
 [[package]]
@@ -1141,7 +1157,7 @@ name = "sev_attestation"
 version = "0.1.0"
 dependencies = [
  "memoffset",
- "sallyport",
+ "sallyport 0.1.0 (git+https://github.com/enarx/sallyport?rev=dd42c91cc9e5cbc74f342eede3bc072f60ba11bd)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,9 +542,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.110"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58a4469763e4e3a906c4ed786e1c70512d16aa88f84dded826da42640fc6a1c"
+checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
 name = "lock_api"
@@ -776,9 +776,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a3ea4f0dd7f1f3e512cf97bf100819aa547f36a6eccac8dbaae839eb92363e"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "plain"
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+checksum = "254df5081ce98661a883445175e52efe99d1cb2a5552891d965d2f5d0cad1c16"
 
 [[package]]
 name = "sallyport"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ dbg = []
 x86_64 = { version = "^0.14.6", default-features = false, optional = true }
 sgx = { version = "0.3.0", features = ["openssl"], optional = true }
 const-default = { version = "1.0", features = [ "derive" ] }
-primordial = { version = "0.3", features = ["alloc"] }
-sallyport = { git = "https://github.com/enarx/sallyport", rev = "dd42c91cc9e5cbc74f342eede3bc072f60ba11bd", features = [ "asm" ] }
+primordial = { version = "0.4", features = ["alloc"] }
+sallyport = { git = "https://github.com/enarx/sallyport", rev = "5b4eca36b41e910ed9ff683adc5ddc0554cdf09c", features = [ "asm" ] }
 kvm-bindings = { version = "0.5", optional = true }
 kvm-ioctls = { version = "0.11", optional = true }
 gdbstub = { version = "0.5.0", optional = true }

--- a/internal/shim-sev/Cargo.lock
+++ b/internal/shim-sev/Cargo.lock
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "primordial"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d6312462222758b3fb6c7e84d819ce87c315c446e0e2c11b0b9258dedd3f25"
+checksum = "b3146f8670eff948342703c5e866cdb6d092032207a7fc2dd53c4c3fef480cfe"
 
 [[package]]
 name = "proc-macro-crate"
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sallyport?rev=dd42c91cc9e5cbc74f342eede3bc072f60ba11bd#dd42c91cc9e5cbc74f342eede3bc072f60ba11bd"
+source = "git+https://github.com/enarx/sallyport?rev=5b4eca36b41e910ed9ff683adc5ddc0554cdf09c#5b4eca36b41e910ed9ff683adc5ddc0554cdf09c"
 dependencies = [
  "goblin",
  "libc",

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -22,8 +22,8 @@ goblin = { version = "0.4", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
 spinning = { version = "0.1", default-features = false }
 libc = { version = "0.2.50", default-features = false }
-primordial = "0.3"
-sallyport = { git = "https://github.com/enarx/sallyport", rev = "dd42c91cc9e5cbc74f342eede3bc072f60ba11bd" }
+primordial = "0.4"
+sallyport = { git = "https://github.com/enarx/sallyport", rev = "5b4eca36b41e910ed9ff683adc5ddc0554cdf09c" }
 xsave = "2.0.0"
 noted = "1.0.0"
 nbytes = "0.1"

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -154,9 +154,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "primordial"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d6312462222758b3fb6c7e84d819ce87c315c446e0e2c11b0b9258dedd3f25"
+checksum = "b3146f8670eff948342703c5e866cdb6d092032207a7fc2dd53c4c3fef480cfe"
 
 [[package]]
 name = "proc-macro-crate"
@@ -199,7 +199,7 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sallyport?rev=dd42c91cc9e5cbc74f342eede3bc072f60ba11bd#dd42c91cc9e5cbc74f342eede3bc072f60ba11bd"
+source = "git+https://github.com/enarx/sallyport?rev=5b4eca36b41e910ed9ff683adc5ddc0554cdf09c#5b4eca36b41e910ed9ff683adc5ddc0554cdf09c"
 dependencies = [
  "goblin",
  "libc",

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.110"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58a4469763e4e3a906c4ed786e1c70512d16aa88f84dded826da42640fc6a1c"
+checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
 name = "log"

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -105,6 +105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +166,9 @@ name = "primordial"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3146f8670eff948342703c5e866cdb6d092032207a7fc2dd53c4c3fef480cfe"
+dependencies = [
+ "const-default",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -207,6 +219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "scroll"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,8 +264,18 @@ dependencies = [
  "rcrt1",
  "sallyport",
  "sgx",
+ "spinning",
  "x86_64",
  "xsave",
+]
+
+[[package]]
+name = "spinning"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -20,10 +20,10 @@ gdbstub = { version = "0.5.0" , default-features = false, optional = true }
 goblin = { version = "0.4", default-features = false, features = [ "elf64" ] }
 x86_64 = { version = "^0.14.6", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
-sallyport = { git = "https://github.com/enarx/sallyport", rev = "dd42c91cc9e5cbc74f342eede3bc072f60ba11bd" }
+sallyport = { git = "https://github.com/enarx/sallyport", rev = "5b4eca36b41e910ed9ff683adc5ddc0554cdf09c" }
 libc = { version = "0.2.50", default-features = false }
 const-default = "1.0"
-primordial = "0.3.0"
+primordial = "0.4.0"
 noted = "^1.0.0"
 xsave = "^2.0.0"
 rcrt1 = "1.0.0"

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -18,12 +18,13 @@ compiler_builtins = { version = "0.1.65", default-features = false, features = [
 gdbstub_arch = { version = "0.1.1" , default-features = false, optional = true }
 gdbstub = { version = "0.5.0" , default-features = false, optional = true }
 goblin = { version = "0.4", default-features = false, features = [ "elf64" ] }
+primordial = { version = "^0.4.0", features = ["const-default"] }
 x86_64 = { version = "^0.14.6", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
 sallyport = { git = "https://github.com/enarx/sallyport", rev = "5b4eca36b41e910ed9ff683adc5ddc0554cdf09c" }
+spinning = { version = "0.1", default-features = false }
 libc = { version = "0.2.50", default-features = false }
 const-default = "1.0"
-primordial = "0.4.0"
 noted = "^1.0.0"
 xsave = "^2.0.0"
 rcrt1 = "1.0.0"

--- a/internal/shim-sgx/layout.ld
+++ b/internal/shim-sgx/layout.ld
@@ -69,7 +69,5 @@ SECTIONS {
 
     /* HEAP */
     . = ALIGN(128M);
-    HIDDEN(ENARX_HEAP_START = .);
-    .enarx.heap (NOLOAD) : { . += 128M; } :heap =0
-    HIDDEN(ENARX_HEAP_END = .);
+    .enarx.heap (NOLOAD) : { *(.enarx.heap) } :heap =0
 }

--- a/internal/shim-sgx/src/handler/gdb.rs
+++ b/internal/shim-sgx/src/handler/gdb.rs
@@ -6,7 +6,8 @@ use core::convert::TryFrom;
 use core::mem::size_of;
 use core::ops::Range;
 
-use crate::{ENARX_EXEC_START, ENARX_HEAP_END, ENCL_SIZE};
+use crate::heap::HEAP;
+use crate::{ENARX_EXEC_START, ENCL_SIZE};
 use gdbstub::arch::Arch;
 use gdbstub::target::ext::base::singlethread::SingleThreadOps;
 use gdbstub::target::ext::base::singlethread::{GdbInterrupt, ResumeAction, StopReason};
@@ -266,7 +267,9 @@ impl GdbTarget {
         block_range: Range<*const u8>,
         ssa_range: Range<*const u8>,
     ) -> Self {
-        let shim_range = shim_base_offset() as *const u8..unsafe { &ENARX_HEAP_END as *const u8 };
+        let start = shim_base_offset() as *const u8;
+        let end = HEAP.read().range().end;
+        let shim_range = start..end;
 
         Self {
             regs,

--- a/internal/shim-sgx/src/handler/memory.rs
+++ b/internal/shim-sgx/src/handler/memory.rs
@@ -8,7 +8,7 @@ impl<'a> MemorySyscallHandler for super::Handler<'a> {
     fn brk(&mut self, addr: *const u8) -> sallyport::Result {
         self.trace("brk", 1);
 
-        let ret = self.heap.brk(addr as _);
+        let ret = crate::heap::HEAP.write().brk(addr as _);
         Ok([ret.into(), Default::default()])
     }
 
@@ -38,7 +38,7 @@ impl<'a> MemorySyscallHandler for super::Handler<'a> {
     ) -> sallyport::Result {
         self.trace("mmap", 6);
 
-        let ret = self.heap.mmap::<libc::c_void>(
+        let ret = crate::heap::HEAP.write().mmap::<libc::c_void>(
             addr.as_ptr() as _,
             length,
             prot,
@@ -54,7 +54,8 @@ impl<'a> MemorySyscallHandler for super::Handler<'a> {
     fn munmap(&mut self, addr: UntrustedRef<'_, u8>, length: libc::size_t) -> sallyport::Result {
         self.trace("munmap", 2);
 
-        self.heap
+        crate::heap::HEAP
+            .write()
             .munmap::<libc::c_void>(addr.as_ptr() as _, length)?;
         Ok(Default::default())
     }

--- a/internal/shim-sgx/src/handler/mod.rs
+++ b/internal/shim-sgx/src/handler/mod.rs
@@ -35,9 +35,7 @@ use core::fmt::Write;
 use core::mem::size_of;
 use core::ptr::read_unaligned;
 
-use crate::heap::Heap;
-use crate::{DEBUG, ENARX_EXEC_END, ENARX_EXEC_START, ENARX_HEAP_END, ENCL_SIZE};
-use lset::Line;
+use crate::{DEBUG, ENARX_EXEC_END, ENARX_EXEC_START, ENCL_SIZE};
 use sallyport::syscall::*;
 use sallyport::{request, Block};
 use sgx::ssa::StateSaveArea;
@@ -52,7 +50,6 @@ const OP_CPUID: u16 = 0xa20f;
 pub struct Handler<'a> {
     block: &'a mut Block,
     ssa: &'a mut StateSaveArea,
-    heap: Heap,
 }
 
 impl<'a> Write for Handler<'a> {
@@ -76,12 +73,8 @@ impl<'a> Write for Handler<'a> {
 }
 
 impl<'a> Handler<'a> {
-    fn new(ssa: &'a mut StateSaveArea, block: &'a mut Block, heap: Line<usize>) -> Self {
-        Self {
-            ssa,
-            block,
-            heap: unsafe { Heap::new(heap.into()) },
-        }
+    fn new(ssa: &'a mut StateSaveArea, block: &'a mut Block) -> Self {
+        Self { ssa, block }
     }
 
     /// Finish handling an exception
@@ -98,8 +91,8 @@ impl<'a> Handler<'a> {
     }
 
     /// Handle an exception
-    pub fn handle(ssa: &'a mut StateSaveArea, block: &'a mut Block, heap: Line<usize>) {
-        let mut h = Self::new(ssa, block, heap);
+    pub fn handle(ssa: &'a mut StateSaveArea, block: &'a mut Block) {
+        let mut h = Self::new(ssa, block);
 
         match h.ssa.vector() {
             Some(ExceptionVector::InvalidOpcode) => {
@@ -227,22 +220,22 @@ impl<'a> Handler<'a> {
 
     /// Print a stack trace with the old `rbp` stack frame pointers
     unsafe fn print_stack_trace(&mut self, rip: u64, mut rbp: u64) {
-        let shim_start = ENCL_SIZE as u64;
-        let shim_end = &ENARX_HEAP_END as *const _ as u64;
-
-        let shim_range = shim_start..shim_end;
+        // TODO: parse the elf and actually find the text sections.
+        let encl_start = self as *const _ as u64 / ENCL_SIZE as u64 * ENCL_SIZE as u64;
+        let encl_end = encl_start + ENCL_SIZE as u64;
+        let encl_range = encl_start..encl_end;
 
         debugln!(self, "TRACE:");
 
         self.print_rip(rip);
 
-        //Maximum 64 frames
+        // Maximum 64 frames
         for _frame in 0..64 {
             if rbp == 0 || rbp & 7 != 0 {
                 break;
             }
 
-            if !shim_range.contains(&rbp) {
+            if !encl_range.contains(&rbp) {
                 debugln!(self, "invalid rbp: {:>#016x}", rbp);
                 break;
             }

--- a/internal/shim-sgx/src/lib.rs
+++ b/internal/shim-sgx/src/lib.rs
@@ -6,8 +6,11 @@
 //! instructions) from the enclave code and proxies them to the host.
 
 #![cfg_attr(not(test), no_std)]
+#![allow(incomplete_features)]
 #![feature(asm, asm_const, asm_sym)]
+#![feature(generic_const_exprs)]
 #![feature(naked_functions)]
+#![feature(const_mut_refs)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
@@ -45,8 +48,4 @@ extern "C" {
     pub static ENARX_EXEC_START: u8;
     /// Extern
     pub static ENARX_EXEC_END: u8;
-    /// Extern
-    pub static ENARX_HEAP_START: u8;
-    /// Extern
-    pub static ENARX_HEAP_END: u8;
 }

--- a/internal/shim-sgx/src/main.rs
+++ b/internal/shim-sgx/src/main.rs
@@ -17,10 +17,7 @@ extern crate compiler_builtins;
 #[allow(unused_extern_crates)]
 extern crate rcrt1;
 
-use shim_sgx::{
-    entry, handler, ATTR, ENARX_EXEC_START, ENARX_HEAP_END, ENARX_HEAP_START, ENCL_SIZE,
-    ENCL_SIZE_BITS, MISC,
-};
+use shim_sgx::{entry, handler, ATTR, ENARX_EXEC_START, ENCL_SIZE, ENCL_SIZE_BITS, MISC};
 
 #[panic_handler]
 #[cfg(not(test))]
@@ -272,14 +269,9 @@ pub unsafe extern "sysv64" fn _start() -> ! {
 unsafe extern "C" fn main(port: &mut sallyport::Block, ssas: &mut [StateSaveArea; 3], cssa: usize) {
     ssas[cssa].extra[0] = 1; // Enable exceptions
 
-    let heap = lset::Line::new(
-        &ENARX_HEAP_START as *const _ as usize,
-        &ENARX_HEAP_END as *const _ as usize,
-    );
-
     match cssa {
         0 => entry::entry(&ENARX_EXEC_START as *const u8 as _),
-        1 => handler::Handler::handle(&mut ssas[0], port, heap),
+        1 => handler::Handler::handle(&mut ssas[0], port),
         n => handler::Handler::finish(&mut ssas[n - 1]),
     }
 

--- a/internal/wasmldr/Cargo.lock
+++ b/internal/wasmldr/Cargo.lock
@@ -490,9 +490,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.110"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58a4469763e4e3a906c4ed786e1c70512d16aa88f84dded826da42640fc6a1c"
+checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
 name = "linux-raw-sys"


### PR DESCRIPTION
The heap is now allocated from within Rust. It is also now a global protected by a lock. This means we can reference it directly from any code. This is useful preparation before landing allocators.