### PR TITLE
Release enarx 0.1.3 tied to rust 1.57

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           components: rustfmt
-          toolchain: nightly
+          toolchain: 1.57
           profile: minimal
           override: true
       - uses: actions-rs/cargo@v1
@@ -29,6 +29,8 @@ jobs:
   clippy:
     name: cargo clippy (${{ matrix.crate.name }})
     runs-on: ubuntu-20.04
+    env:
+      RUSTC_BOOTSTRAP: 1
     steps:
       - run: sudo apt update
       - run: sudo apt install -y musl-tools
@@ -37,7 +39,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
-          toolchain: nightly
+          toolchain: 1.57
           profile: minimal
           target: x86_64-unknown-linux-musl
           override: true
@@ -63,6 +65,8 @@ jobs:
   clippy-single-backends:
     name: cargo clippy (enarx ${{ matrix.backend.name }} ${{ matrix.profile.name }})
     runs-on: ubuntu-20.04
+    env:
+      RUSTC_BOOTSTRAP: 1
     steps:
       - run: sudo apt update
       - run: sudo apt install -y musl-tools
@@ -71,7 +75,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
-          toolchain: nightly
+          toolchain: 1.57
           profile: minimal
           target: x86_64-unknown-linux-musl
           override: true
@@ -103,7 +107,7 @@ jobs:
       - run: for i in internal/*; do (cd $i; [[ -f Cargo.tml ]] && cp Cargo.tml Cargo.toml); done
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.57
           profile: minimal
           override: true
       - run: cargo install cargo-readme

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,11 @@ on: [push, pull_request]
 name: test
 jobs:
   main:
-    name: enarx ${{ matrix.backend.name }} nightly ${{ matrix.profile.name }}
+    name: enarx ${{ matrix.backend.name }} 1.57 ${{ matrix.profile.name }}
     runs-on: ${{ matrix.backend.host }}
     env:
         ENARX_BACKEND: ${{ matrix.backend.name }}
+        RUSTC_BOOTSTRAP: 1
     steps:
       - run: sudo apt update
       - run: sudo apt install -y musl-tools
@@ -13,7 +14,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-musl
-          toolchain: nightly
+          toolchain: 1.57
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -32,8 +33,10 @@ jobs:
             flag: --release
 
   internal:
-    name: ${{ matrix.crate }} nightly ${{ matrix.profile.name }}
+    name: ${{ matrix.crate }} 1.57 ${{ matrix.profile.name }}
     runs-on: ubuntu-20.04
+    env:
+      RUSTC_BOOTSTRAP: 1
     steps:
       - run: sudo apt update
       - run: sudo apt install -y musl-tools
@@ -42,7 +45,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly
+          toolchain: 1.57
           override: true
       - run: cargo test ${{ matrix.profile.flag }} --target x86_64-unknown-linux-gnu
         working-directory: internal/${{ matrix.crate }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "enarx"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enarx"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Enarx Project Developers"]
 license = "Apache-2.0"
 edition = "2018"

--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,12 @@ fn rerun_src(path: impl AsRef<Path>) {
 fn build_rs_tests(in_path: &Path, out_path: &Path) {
     let filtered_env: HashMap<String, String> = std::env::vars()
         .filter(|&(ref k, _)| {
-            k == "TERM" || k == "TZ" || k == "LANG" || k == "PATH" || k == "RUSTUP_HOME"
+            k == "TERM"
+                || k == "TZ"
+                || k == "LANG"
+                || k == "PATH"
+                || k == "RUSTUP_HOME"
+                || k == "RUSTC_BOOTSTRAP"
         })
         .collect();
 
@@ -146,7 +151,12 @@ fn cargo_build_bin(
 
     let filtered_env: HashMap<String, String> = std::env::vars()
         .filter(|&(ref k, _)| {
-            k == "TERM" || k == "TZ" || k == "LANG" || k == "PATH" || k == "RUSTUP_HOME"
+            k == "TERM"
+                || k == "TZ"
+                || k == "LANG"
+                || k == "PATH"
+                || k == "RUSTUP_HOME"
+                || k == "RUSTC_BOOTSTRAP"
         })
         .collect();
 

--- a/internal/shim-sev/src/lib.rs
+++ b/internal/shim-sev/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(clippy::all)]
 #![deny(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
-#![feature(asm, asm_const, asm_sym, naked_functions)]
+#![feature(asm, naked_functions)]
 
 use crate::snp::cpuid_page::CpuidPage;
 use crate::snp::ghcb::Ghcb;

--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -9,7 +9,7 @@
 #![deny(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 #![no_main]
-#![feature(asm, asm_const, asm_sym, naked_functions)]
+#![feature(asm, naked_functions)]
 
 extern crate compiler_builtins;
 extern crate rcrt1;

--- a/internal/shim-sgx/src/main.rs
+++ b/internal/shim-sgx/src/main.rs
@@ -6,7 +6,7 @@
 //! instructions) from the enclave code and proxies them to the host.
 
 #![no_std]
-#![feature(asm, asm_const, asm_sym, naked_functions)]
+#![feature(asm, naked_functions)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
 #![no_main]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "1.57"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 profile = "minimal"


### PR DESCRIPTION
Tie the enarx build process to a stable, officially released version.

To be installed with:
```
$ rustup component add rustfmt --toolchain 1.57-x86_64-unknown-linux-gnu
$ RUSTC_BOOTSTRAP=1 cargo +1.57 install --bin enarx -- enarx
```

Fixes: https://github.com/enarx/enarx/issues/1096