### PR TITLE
fix: sallyport dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "protobuf",
  "protobuf-codegen-pure",
  "reqwest",
- "sallyport 0.1.0 (git+https://github.com/enarx/sallyport?rev=167a7b5a626e88f42083d2644ff5423e8e66b17a)",
+ "sallyport 0.1.0 (git+https://github.com/enarx/sallyport?rev=fa4c6eea1c8dab54a8b8843a498b6fb883c006dd)",
  "semver",
  "serial_test",
  "sgx",
@@ -1016,21 +1016,30 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 [[package]]
 name = "sallyport"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sallyport?rev=167a7b5a626e88f42083d2644ff5423e8e66b17a#167a7b5a626e88f42083d2644ff5423e8e66b17a"
-dependencies = [
- "goblin",
- "libc",
- "primordial 0.4.0",
-]
-
-[[package]]
-name = "sallyport"
-version = "0.1.0"
 source = "git+https://github.com/enarx/sallyport?rev=dd42c91cc9e5cbc74f342eede3bc072f60ba11bd#dd42c91cc9e5cbc74f342eede3bc072f60ba11bd"
 dependencies = [
  "goblin",
  "libc",
  "primordial 0.3.0",
+]
+
+[[package]]
+name = "sallyport"
+version = "0.1.0"
+source = "git+https://github.com/enarx/sallyport?rev=fa4c6eea1c8dab54a8b8843a498b6fb883c006dd#fa4c6eea1c8dab54a8b8843a498b6fb883c006dd"
+dependencies = [
+ "goblin",
+ "libc",
+ "primordial 0.4.0",
+ "sallyport 0.2.0",
+]
+
+[[package]]
+name = "sallyport"
+version = "0.2.0"
+source = "git+https://github.com/enarx/sallyport?rev=fa4c6eea1c8dab54a8b8843a498b6fb883c006dd#fa4c6eea1c8dab54a8b8843a498b6fb883c006dd"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ x86_64 = { version = "^0.14.7", default-features = false, optional = true }
 sgx = { version = "0.3.0", features = ["openssl"], optional = true }
 const-default = { version = "1.0", features = [ "derive" ] }
 primordial = { version = "0.4", features = ["alloc"] }
-sallyport = { git = "https://github.com/enarx/sallyport", rev = "167a7b5a626e88f42083d2644ff5423e8e66b17a", features = [ "asm" ] }
+sallyport = { version = "0.1.0", git = "https://github.com/enarx/sallyport", rev = "fa4c6eea1c8dab54a8b8843a498b6fb883c006dd", features = [ "asm" ] }
 kvm-bindings = { version = "0.5", optional = true }
 kvm-ioctls = { version = "0.11", optional = true }
 gdbstub = { version = "0.5.0", optional = true }

--- a/internal/shim-sev/Cargo.lock
+++ b/internal/shim-sev/Cargo.lock
@@ -335,11 +335,20 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sallyport?rev=167a7b5a626e88f42083d2644ff5423e8e66b17a#167a7b5a626e88f42083d2644ff5423e8e66b17a"
+source = "git+https://github.com/enarx/sallyport?rev=fa4c6eea1c8dab54a8b8843a498b6fb883c006dd#fa4c6eea1c8dab54a8b8843a498b6fb883c006dd"
 dependencies = [
  "goblin",
  "libc",
  "primordial",
+ "sallyport 0.2.0",
+]
+
+[[package]]
+name = "sallyport"
+version = "0.2.0"
+source = "git+https://github.com/enarx/sallyport?rev=fa4c6eea1c8dab54a8b8843a498b6fb883c006dd#fa4c6eea1c8dab54a8b8843a498b6fb883c006dd"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -383,7 +392,7 @@ dependencies = [
  "noted",
  "primordial",
  "rcrt1",
- "sallyport",
+ "sallyport 0.1.0",
  "spinning",
  "x86_64",
  "xsave",

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -23,7 +23,7 @@ crt0stack = { version = "0.1", default-features = false }
 spinning = { version = "0.1", default-features = false }
 libc = { version = "0.2.50", default-features = false }
 primordial = "0.4"
-sallyport = { git = "https://github.com/enarx/sallyport", rev = "167a7b5a626e88f42083d2644ff5423e8e66b17a" }
+sallyport = { version = "0.1.0", git = "https://github.com/enarx/sallyport", rev = "fa4c6eea1c8dab54a8b8843a498b6fb883c006dd" }
 xsave = { git = "https://github.com/enarx/xsave", rev = "4819a862953c114a69f1ff7153b41bb558f96365" }
 noted = "1.0.0"
 nbytes = "0.1"

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -211,11 +211,20 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sallyport?rev=167a7b5a626e88f42083d2644ff5423e8e66b17a#167a7b5a626e88f42083d2644ff5423e8e66b17a"
+source = "git+https://github.com/enarx/sallyport?rev=fa4c6eea1c8dab54a8b8843a498b6fb883c006dd#fa4c6eea1c8dab54a8b8843a498b6fb883c006dd"
 dependencies = [
  "goblin",
  "libc",
  "primordial",
+ "sallyport 0.2.0",
+]
+
+[[package]]
+name = "sallyport"
+version = "0.2.0"
+source = "git+https://github.com/enarx/sallyport?rev=fa4c6eea1c8dab54a8b8843a498b6fb883c006dd#fa4c6eea1c8dab54a8b8843a498b6fb883c006dd"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -262,7 +271,7 @@ dependencies = [
  "noted",
  "primordial",
  "rcrt1",
- "sallyport",
+ "sallyport 0.1.0",
  "sgx",
  "spinning",
  "x86_64",

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -21,7 +21,7 @@ goblin = { version = "0.4", default-features = false, features = [ "elf64" ] }
 primordial = { version = "^0.4.0", features = ["const-default"] }
 x86_64 = { version = "^0.14.7", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
-sallyport = { git = "https://github.com/enarx/sallyport", rev = "167a7b5a626e88f42083d2644ff5423e8e66b17a" }
+sallyport = { version = "0.1.0", git = "https://github.com/enarx/sallyport", rev = "fa4c6eea1c8dab54a8b8843a498b6fb883c006dd" }
 spinning = { version = "0.1", default-features = false }
 libc = { version = "0.2.50", default-features = false }
 const-default = "1.0"


### PR DESCRIPTION
commit 6ea4aefabb590ea37da32b4648ffee7d3d3e09ae specified a sallyport
version on a distinct branch without the `v2` subcrate, because
`version` was not used and I thought cargo was confused.

With `version` specified cargo does the right thing and selects the
sallyport version from the main directory.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
