### PR TITLE
fix(wasmldr): make rust Hello World work again

### DIFF
--- a/internal/wasmldr/src/workload.rs
+++ b/internal/wasmldr/src/workload.rs
@@ -89,7 +89,7 @@ pub fn run<T: AsRef<str>, U: AsRef<str>>(
     config.static_memory_maximum_size(0);
     config.static_memory_guard_size(0);
     config.dynamic_memory_guard_size(0);
-    config.dynamic_memory_reserved_for_growth(0);
+    config.dynamic_memory_reserved_for_growth(16 * 1024 * 1024);
 
     let engine = wasmtime::Engine::new(&config).or(Err(Error::ConfigurationError))?;
 


### PR DESCRIPTION
Also works with https://github.com/MikeCamel/zerooneone/

Reason still unknown...

Maybe needs proper guard pages and memory permissions.

Fixes: https://github.com/enarx/enarx/issues/1229

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
