### PR TITLE
ci: Add wasm integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           target: x86_64-unknown-linux-musl
           toolchain: nightly
           override: true
+      - run: rustup target add wasm32-wasi
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,6 +1604,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
+name = "wasmsimple"
+version = "0.1.0"
+
+[[package]]
 name = "wast"
 version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,5 +76,5 @@ walkdir = "2"
 wat = { version = "1.0" }
 
 [workspace]
-members = [ "integration/sev_attestation", "integration/simple" ]
+members = [ "integration/sev_attestation", "integration/simple", "integration/wasm" ]
 exclude = [ "internal/shim-sev", "internal/shim-sgx", "internal/wasmldr" ]

--- a/helper/test-enarx-wasm.sh
+++ b/helper/test-enarx-wasm.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if ! [ -f "$ENARX_BIN" ]; then
+  (cd ..; cargo build -q)
+  ENARX_BIN=$(dirname $0)/../target/debug/enarx
+fi
+
+"$ENARX_BIN" run "$@"

--- a/integration/simple/.cargo/config
+++ b/integration/simple/.cargo/config
@@ -6,4 +6,4 @@ rustflags = [
     "-C", "relocation-model=pic",
     "-C", "force-frame-pointers=yes",
 ]
-runner = "../../helper/test-enarx.sh"  # Searches `PATH` for `foo`.
+runner = "../../helper/test-enarx.sh"

--- a/integration/wasm/.cargo/config
+++ b/integration/wasm/.cargo/config
@@ -1,0 +1,5 @@
+[build]
+target = "wasm32-wasi"
+
+[target.wasm32-wasi]
+runner = "../../helper/test-enarx-wasm.sh"

--- a/integration/wasm/Cargo.toml
+++ b/integration/wasm/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "wasmsimple"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name="echo"
+path="src/echo.rs"
+
+[[bin]]
+name="memspike"
+path="src/memspike.rs"
+
+[[bin]]
+name="memory_stress_test"
+path="src/memory_stress_test.rs"
+
+[[bin]]
+name="zerooneone"
+path="src/zerooneone.rs"
+
+[dependencies]

--- a/integration/wasm/rust-toolchain.toml
+++ b/integration/wasm/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+targets = ["wasm32-wasi"]
+profile = "minimal"

--- a/integration/wasm/src/echo.rs
+++ b/integration/wasm/src/echo.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{self, Read, Write};
+
+fn main() -> io::Result<()> {
+    let mut buffer = Vec::new();
+    std::io::stdin().read_to_end(&mut buffer)?;
+    std::io::stdout().write_all(&buffer)?;
+    Ok(())
+}

--- a/integration/wasm/src/memory_stress_test.rs
+++ b/integration/wasm/src/memory_stress_test.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const SIZE_32M: usize = 1024 * 1024 * 32;
+
+fn main() {
+    let mut ret = 0;
+    let mut size: usize = 1;
+    while size < SIZE_32M {
+        let mut vec = Vec::with_capacity(size);
+        vec.push(0u8);
+        ret += vec.pop().unwrap();
+        size *= 2;
+        drop(vec);
+    }
+
+    for _i in 0..100 {
+        let mut vec = Vec::with_capacity(size);
+        vec.push(0u8);
+        ret += vec.pop().unwrap();
+        drop(vec);
+    }
+
+    while size > 0 {
+        let mut vec = Vec::with_capacity(size);
+        vec.push(0u8);
+        ret += vec.pop().unwrap();
+        size /= 2;
+        drop(vec);
+    }
+
+    assert_eq!(ret, 0);
+}

--- a/integration/wasm/src/memspike.rs
+++ b/integration/wasm/src/memspike.rs
@@ -8,6 +8,6 @@ use std::collections::TryReserveError;
 
 fn main() -> Result<(), TryReserveError> {
     let mut alloc: Vec<u8> = Vec::new();
-    let _ = alloc.try_reserve(40_000_000)?;
+    let _ = alloc.try_reserve(16_000_000)?;
     Ok(())
 }

--- a/integration/wasm/src/zerooneone.rs
+++ b/integration/wasm/src/zerooneone.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Author: Mike Bursell <mike@profian.com>
+// https://github.com/MikeCamel/zerooneone/
+
+use std::io::{stdin, stdout, Read, Result, Write};
+
+const INPUT: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+const OUTPUT: &[u8] = b"NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm";
+
+fn main() -> Result<()> {
+    let std_in = stdin();
+    let mut std_out = stdout();
+
+    for result in std_in.bytes() {
+        let input = result?;
+
+        // If the input is in the Latin alphabet, do ROT13.
+        // Otherwise, output the input unmodified.
+        let output = match INPUT.iter().position(|b| b == &input) {
+            Some(index) => OUTPUT[index],
+            None => input,
+        };
+
+        std_out.write_all(&[output])?;
+    }
+
+    Ok(())
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "nightly"
-targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "wasm32-wasi"]
 profile = "minimal"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -110,12 +110,15 @@ fn echo() {
     for i in 0..input.capacity() {
         input.push(i as _);
     }
+
+    let expected_input = input.clone();
+
     run_crate(
         "integration/simple",
         "echo",
         0,
-        input.as_slice(),
-        input.as_slice(),
+        input,
+        expected_input.as_slice(),
         None,
     );
 }
@@ -169,7 +172,7 @@ fn unix_echo() {
         "integration/simple",
         "unix_echo",
         0,
-        tmpdir.path().as_os_str().as_bytes(),
+        Vec::from(tmpdir.path().as_os_str().as_bytes()),
         None,
         None,
     );

--- a/tests/wasmldr_tests.rs
+++ b/tests/wasmldr_tests.rs
@@ -10,7 +10,7 @@ use std::process::{Command, Stdio};
 use std::time::Duration;
 
 pub mod common;
-use common::{check_output, CRATE, KEEP_BIN, OUT_DIR, TEST_BINS_OUT, TIMEOUT_SECS};
+use common::{check_output, run_crate, CRATE, KEEP_BIN, OUT_DIR, TEST_BINS_OUT, TIMEOUT_SECS};
 
 fn create(path: &Path) {
     match std::fs::create_dir(&path) {
@@ -144,4 +144,55 @@ fn no_export() {
     // This module has no exported functions, so we get Error::ExportNotFound,
     // which wasmldr maps to EX_DATAERR (65) at process exit.
     run_wasm_test("no_export.wasm", 65, None, None, None);
+}
+
+#[test]
+fn echo() {
+    let mut input: Vec<u8> = Vec::with_capacity(2 * 1024);
+
+    for i in 0..input.capacity() {
+        input.push(i as _);
+    }
+
+    let expected_input = input.clone();
+
+    run_crate(
+        "integration/wasm",
+        "echo",
+        0,
+        input,
+        expected_input.as_slice(),
+        None,
+    );
+}
+
+#[test]
+fn memspike() {
+    run_crate("integration/wasm", "memspike", 0, None, None, None);
+}
+
+#[test]
+fn memory_stress_test() {
+    run_crate(
+        "integration/wasm",
+        "memory_stress_test",
+        0,
+        None,
+        None,
+        None,
+    );
+}
+
+#[test]
+fn zerooneone() {
+    let input = Vec::from("Good morning, that's a nice tnetennba.\n0118 999 881 999 119 725 3\n");
+
+    run_crate(
+        "integration/wasm",
+        "zerooneone",
+        0,
+        input,
+        &b"Tbbq zbeavat, gung'f n avpr gargraaon.\n0118 999 881 999 119 725 3\n"[..],
+        None,
+    );
 }


### PR DESCRIPTION
Similar to the `integration/simple` tests, use a cargo runner script, to
simply add integration tests.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
