### PR TITLE
sev: Migrate from KvmEncRegion to kvm_enc_region

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -60,6 +60,7 @@ fn build_cc_tests(in_path: &Path, out_path: &Path) {
             .arg("-static-pie")
             .arg("-fPIC")
             .arg("-fno-omit-frame-pointer")
+            .arg("-fno-stack-protector")
             .arg("-g")
             .arg("-o")
             .arg(output)

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -15,7 +15,7 @@ use data::{
     kvm_version, sev_enabled_in_kernel, CPUIDS,
 };
 use kvm_ioctls::VmFd;
-use snp::launch::linux::KvmEncRegion;
+use kvm_bindings::bindings::kvm_enc_region;
 
 mod builder;
 mod cpuid_page;
@@ -29,7 +29,11 @@ struct SnpKeepPersonality {
 
 impl KeepPersonality for SnpKeepPersonality {
     fn map(vm_fd: &mut VmFd, region: &Region) -> std::io::Result<()> {
-        KvmEncRegion::new(region.backing()).register(vm_fd)?;
+        let memory_region = kvm_enc_region {
+            addr: region.backing().as_ptr() as _,
+            size: region.backing().len() as _,
+        };
+        vm_fd.register_enc_memory_region(&memory_region).unwrap();
         Ok(())
     }
 }


### PR DESCRIPTION
Use kvm_enc_region provided by the standard library in the place of ad-hoc
KvmEncRegion.

Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
