### PR TITLE
Add --json flag to `enarx info`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,8 @@ dependencies = [
  "reqwest",
  "sallyport 0.1.0 (git+https://github.com/enarx/sallyport?rev=fa4c6eea1c8dab54a8b8843a498b6fb883c006dd)",
  "semver",
+ "serde",
+ "serde_json",
  "serial_test",
  "sgx",
  "spinning",
@@ -1118,15 +1120,29 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.133"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
  "itoa 1.0.1",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ log = "0.4"
 spinning = "0.1.0"
 env_logger = "0.9"
 reqwest = { version = "0.11", features = [ "blocking" ], optional = true }
+serde = { version = "1.0.133", features = ["derive"] }
+serde_json = "1.0.75"
 
 # h2 is an indirect dependency, to be specified when checking with `-Z minimal-versions`
 # h2 is a dependency of hyper, which is a dep of reqwest

--- a/src/backend/binary.rs
+++ b/src/backend/binary.rs
@@ -42,7 +42,7 @@ impl<'a> Binary<'a> {
             return Err(anyhow!("unsupported ELF header: e_machine"));
         }
 
-        if elf.header.e_version != EV_CURRENT.into() {
+        if elf.header.e_version != EV_CURRENT as u32 {
             return Err(anyhow!("unsupported ELF header: e_version"));
         }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use anyhow::{Error, Result};
 use mmarinus::{perms, Map};
 use sallyport::Block;
+use serde::ser::{Serialize, SerializeStruct, Serializer};
 use spinning::Lazy;
 
 trait Config: Sized {
@@ -67,6 +68,16 @@ pub trait Backend: Sync + Send {
     }
 }
 
+impl Serialize for dyn Backend {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut backend = serializer.serialize_struct("Backend", 2)?;
+        backend.serialize_field("backend", self.name())?;
+        backend.serialize_field("data", &self.data())?;
+        backend.end()
+    }
+}
+
+#[derive(serde::Serialize)]
 pub struct Datum {
     /// The name of this datum.
     pub name: String,

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -6,34 +6,44 @@ use std::ops::Deref;
 
 /// Show details about backend support on this system
 #[derive(StructOpt, Debug)]
-pub struct Options {}
+pub struct Options {
+    #[structopt(short, long)]
+    /// Emit JSON rather than human-readable output
+    json: bool,
+}
 
 impl Options {
     /// Display nicely-formatted info about each backend
     pub fn display(self) -> Result<()> {
         use colorful::*;
 
-        for backend in BACKENDS.deref() {
-            println!("Backend: {}", backend.name());
+        let backends = BACKENDS.deref();
 
-            let data = backend.data();
+        if self.json {
+            println!("{}", serde_json::to_string_pretty(&backends)?);
+        } else {
+            for backend in backends {
+                println!("Backend: {}", backend.name());
 
-            for datum in &data {
-                let icon = match datum.pass {
-                    true => "✔".green(),
-                    false => "✗".red(),
-                };
+                let data = backend.data();
 
-                if let Some(info) = datum.info.as_ref() {
-                    println!(" {} {}: {}", icon, datum.name, info);
-                } else {
-                    println!(" {} {}", icon, datum.name);
+                for datum in &data {
+                    let icon = match datum.pass {
+                        true => "✔".green(),
+                        false => "✗".red(),
+                    };
+
+                    if let Some(info) = datum.info.as_ref() {
+                        println!(" {} {}: {}", icon, datum.name, info);
+                    } else {
+                        println!(" {} {}", icon, datum.name);
+                    }
                 }
-            }
 
-            for datum in &data {
-                if let Some(mesg) = datum.mesg.as_ref() {
-                    println!("\n{}\n", mesg);
+                for datum in &data {
+                    if let Some(mesg) = datum.mesg.as_ref() {
+                        println!("\n{}\n", mesg);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Running `enarx info --json` now yields the following:
```
[
  {
    "backend": "sgx",
    "data": [
      {
        "name": "Driver",
        "pass": true,
        "info": "/dev/sgx_enclave",
        "mesg": null
      },
      {
        "name": "CPU Manufacturer",
        "pass": true,
        "info": "GenuineIntel",
        "mesg": null
      },
      {
        "name": " SGX Support",
        "pass": true,
        "info": null,
        "mesg": null
      },
      {
        "name": "  Version 1",
        "pass": true,
        "info": null,
        "mesg": null
      },
      {
        "name": "  Version 2",
        "pass": true,
        "info": null,
        "mesg": null
      },
      {
        "name": "  FLC Support",
        "pass": true,
        "info": null,
        "mesg": null
      },
      {
        "name": "  Max Size (32-bit)",
        "pass": true,
        "info": "2 GiB",
        "mesg": null
      },
      {
        "name": "  Max Size (64-bit)",
        "pass": true,
        "info": "64 PiB",
        "mesg": null
      },
      {
        "name": "  MiscSelect",
        "pass": true,
        "info": "EXINFO",
        "mesg": null
      },
      {
        "name": "  Features",
        "pass": true,
        "info": "DEBUG | MODE64BIT | PROVISIONING_KEY | EINIT_KEY | KSS",
        "mesg": null
      },
      {
        "name": "  Xfrm",
        "pass": true,
        "info": "X87 | SSE | AVX | YMM | OPMASK | ZMM_HI256 | HI16_ZMM | MPK",
        "mesg": null
      },
      {
        "name": "  EPC Size",
        "pass": true,
        "info": "7 GiB",
        "mesg": null
      }
    ]
  },
  {
    "backend": "sev",
    "data": [
      {
        "name": "Driver",
        "pass": false,
        "info": "/dev/sev",
        "mesg": null
      },
      {
        "name": " SEV is enabled in host kernel",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": " /dev/sev is readable by user",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": " /dev/sev is writable by user",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": "Driver",
        "pass": true,
        "info": "/dev/kvm",
        "mesg": null
      },
      {
        "name": " API Version",
        "pass": true,
        "info": "12",
        "mesg": null
      },
      {
        "name": "MEMLOCK rlimit allows for",
        "pass": true,
        "info": "~9664 keeps (soft limit = 50668856320 bytes, hard limit = 50668856320 bytes)",
        "mesg": null
      },
      {
        "name": "CPU Manufacturer",
        "pass": false,
        "info": "GenuineIntel",
        "mesg": null
      },
      {
        "name": " Microcode support",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": " Secure Memory Encryption (SME)",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": "  Physical address bit reduction",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": "  C-bit location in page table entry",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": " Secure Encrypted Virtualization (SEV)",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": "  Number of encrypted guests supported simultaneously",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": "  Minimum ASID value for SEV-enabled, SEV-ES disabled guest",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": " Secure Encrypted Virtualization Encrypted State (SEV-ES)",
        "pass": false,
        "info": null,
        "mesg": null
      },
      {
        "name": " Page Flush MSR available",
        "pass": false,
        "info": null,
        "mesg": null
      }
    ]
  },
  {
    "backend": "kvm",
    "data": [
      {
        "name": "Driver",
        "pass": true,
        "info": "/dev/kvm",
        "mesg": null
      },
      {
        "name": " API Version",
        "pass": true,
        "info": "12",
        "mesg": null
      }
    ]
  }
]
```
Compare the output of `enarx info` on the same machine:
```
Backend: sgx
 ✔ Driver: /dev/sgx_enclave
 ✔ CPU Manufacturer: GenuineIntel
 ✔  SGX Support
 ✔   Version 1
 ✔   Version 2
 ✔   FLC Support
 ✔   Max Size (32-bit): 2 GiB
 ✔   Max Size (64-bit): 64 PiB
 ✔   MiscSelect: EXINFO
 ✔   Features: DEBUG | MODE64BIT | PROVISIONING_KEY | EINIT_KEY | KSS
 ✔   Xfrm: X87 | SSE | AVX | YMM | OPMASK | ZMM_HI256 | HI16_ZMM | MPK
 ✔   EPC Size: 7 GiB
Backend: sev
 ✗ Driver: /dev/sev
 ✗  SEV is enabled in host kernel
 ✗  /dev/sev is readable by user
 ✗  /dev/sev is writable by user
 ✔ Driver: /dev/kvm
 ✔  API Version: 12
 ✔ MEMLOCK rlimit allows for: ~9664 keeps (soft limit = 50668856320 bytes, hard limit = 50668856320 bytes)
 ✗ CPU Manufacturer: GenuineIntel
 ✗  Microcode support
 ✗  Secure Memory Encryption (SME)
 ✗   Physical address bit reduction
 ✗   C-bit location in page table entry
 ✗  Secure Encrypted Virtualization (SEV)
 ✗   Number of encrypted guests supported simultaneously
 ✗   Minimum ASID value for SEV-enabled, SEV-ES disabled guest
 ✗  Secure Encrypted Virtualization Encrypted State (SEV-ES)
 ✗  Page Flush MSR available
Backend: kvm
 ✔ Driver: /dev/kvm
 ✔  API Version: 12
```

Closes #1008.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
