### PR TITLE
feat(shim-sgx): enable AVX2 and AVX512 usage in the enclave

### DIFF
--- a/internal/shim-sgx/src/lib.rs
+++ b/internal/shim-sgx/src/lib.rs
@@ -28,7 +28,14 @@ pub const ENCL_SIZE_BITS: u8 = 31;
 /// FIXME: doc
 pub const ENCL_SIZE: usize = 1 << ENCL_SIZE_BITS;
 
-const XFRM: Xfrm = Xfrm::from_bits_truncate(Xfrm::X87.bits() | Xfrm::SSE.bits());
+const XFRM: Xfrm = Xfrm::from_bits_truncate(
+    Xfrm::X87.bits()
+        | Xfrm::SSE.bits()
+        | Xfrm::AVX.bits()
+        | Xfrm::OPMASK.bits()
+        | Xfrm::ZMM_HI256.bits()
+        | Xfrm::HI16_ZMM.bits(),
+);
 
 /// Default enclave CPU attributes
 pub const ATTR: Attributes = Attributes::new(Features::MODE64BIT, XFRM);


### PR DESCRIPTION
Support setting `RUSTFLAGS='-C target-cpu=x86-64-v4'` and passing all
tests.

SGX masks the XCR0 register with the `xfrm` mask, so any non set bit
feature is not allowed.

Fixes: https://github.com/enarx/enarx/issues/1190

Signed-off-by: Harald Hoyer <harald@profian.com>

