### PR TITLE
Display system info using `uname` in `enarx info`.

### DIFF
--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -2,6 +2,7 @@
 
 pub use kvm_bindings::kvm_userspace_memory_region as KvmUserspaceMemoryRegion;
 
+use super::probe::common::system_info;
 use super::Loader;
 use data::{dev_kvm, kvm_version, CPUIDS};
 use mem::Region;
@@ -83,7 +84,7 @@ impl crate::backend::Backend for Backend {
     }
 
     fn data(&self) -> Vec<super::Datum> {
-        let mut data = vec![dev_kvm(), kvm_version()];
+        let mut data = vec![system_info(), dev_kvm(), kvm_version()];
         data.extend(CPUIDS.iter().map(|c| c.into()));
         data
     }

--- a/src/backend/probe/common.rs
+++ b/src/backend/probe/common.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::backend::Datum;
+
+use libc::{uname, utsname};
+use std::{ffi::CStr, io, mem::MaybeUninit, os::raw::c_char, str::Utf8Error};
+
+pub fn system_info() -> Datum {
+    fn system_info_string(utsname: utsname) -> Result<String, Utf8Error> {
+        fn array_to_str(array: &'_ [c_char; 65]) -> Result<&'_ str, Utf8Error> {
+            unsafe { CStr::from_ptr(array.as_ptr()) }.to_str()
+        }
+
+        Ok(format!(
+            "{} {} {} {} {} {}",
+            array_to_str(&utsname.sysname)?,
+            array_to_str(&utsname.nodename)?,
+            array_to_str(&utsname.release)?,
+            array_to_str(&utsname.version)?,
+            array_to_str(&utsname.machine)?,
+            array_to_str(&utsname.domainname)?,
+        ))
+    }
+
+    let mut utsname = MaybeUninit::uninit();
+
+    Datum {
+        name: "System Info".to_string(),
+        pass: true,
+        info: if unsafe { uname(utsname.as_mut_ptr()) } != 0 {
+            Some(format!("[{}]", io::Error::last_os_error()))
+        } else {
+            Some(
+                system_info_string(unsafe { utsname.assume_init() })
+                    .unwrap_or_else(|e| format!("[utf8 error: {}]", e)),
+            )
+        },
+        mesg: None,
+    }
+}

--- a/src/backend/probe/mod.rs
+++ b/src/backend/probe/mod.rs
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod common;
 pub mod x86_64;

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -5,6 +5,7 @@ pub use snp::firmware::Firmware;
 
 use super::kvm::mem::Region;
 use super::kvm::{Keep, KeepPersonality};
+use super::probe::common::system_info;
 use super::Loader;
 
 use std::sync::Arc;
@@ -59,6 +60,7 @@ impl super::Backend for Backend {
 
     fn data(&self) -> Vec<super::Datum> {
         let mut data = vec![
+            system_info(),
             dev_sev(),
             sev_enabled_in_kernel(),
             dev_sev_readable(),

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -7,6 +7,7 @@ mod hasher;
 mod ioctls;
 mod thread;
 
+use super::probe::common::system_info;
 use super::Loader;
 
 use anyhow::Result;
@@ -41,7 +42,7 @@ impl crate::backend::Backend for Backend {
     }
 
     fn data(&self) -> Vec<super::Datum> {
-        let mut data = vec![data::dev_sgx_enclave()];
+        let mut data = vec![system_info(), data::dev_sgx_enclave()];
 
         data.extend(data::CPUIDS.iter().map(|c| c.into()));
 


### PR DESCRIPTION
- Uses the `uname` syscall to retrieve the system info.
- Adds a `errno` dependency for displaying errors nicely.

Closes #1206

![image](https://user-images.githubusercontent.com/51100439/151979483-9f7f6f1b-45a1-4e45-884a-50f09d766ad7.png)

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
