### PR TITLE
Fix `cargo doc` warnings.

### DIFF
--- a/src/backend/sgx/ioctls.rs
+++ b/src/backend/sgx/ioctls.rs
@@ -2,7 +2,7 @@
 
 //! This module implements Intel SGX-related IOCTLs using the iocuddle crate.
 //! All references to Section or Tables are from
-//! https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3d-part-4-manual.pdf
+//! [Intel® 64 and IA-32 Architectures Software Developer’s Manual Volume 3D: System Programming Guide, Part 4](https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3d-part-4-manual.pdf)
 
 #![allow(dead_code)]
 

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 ///
 /// The binary must be a statically linked position-independent executable,
 /// compiled with flags like `-nostdlib -static-pie -fPIC`. No commandline
-/// arguments are passed, the program's argv[0] will be `/init`, and the
+/// arguments are passed, the program's `argv[0]` will be `/init`, and the
 /// environment is empty except for `LANG=C`.
 ///
 /// This subcommand is hidden from the main help because it's unlikely to be

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,21 +27,27 @@
 //!
 //! Install the Webassembly rust toolchain:
 //!
-//!     $ rustup target install wasm32-wasi
+//! ```sh
+//! $ rustup target install wasm32-wasi
+//! ```
 //!
 //! Create simple rust program:
 //!
-//!     $ cargo init --bin hello-world
-//!     $ cd hello-world
-//!     $ echo 'fn main() { println!("Hello, Enarx!"); }' > src/main.rs
-//!     $ cargo build --release --target=wasm32-wasi
+//! ```sh
+//! $ cargo init --bin hello-world
+//! $ cd hello-world
+//! $ echo 'fn main() { println!("Hello, Enarx!"); }' > src/main.rs
+//! $ cargo build --release --target=wasm32-wasi
+//! ```
 //!
 //! Assuming you did install the `enarx` binary and have it in your `$PATH`, you can
 //! now run the Webassembly program in an Enarx keep.
 //!
-//!     $ enarx run target/wasm32-wasi/release/hello-world.wasm
-//!     […]
-//!     Hello, Enarx!
+//! ```sh
+//! $ enarx run target/wasm32-wasi/release/hello-world.wasm
+//! […]
+//! Hello, Enarx!
+//! ```
 //!
 //! If you want to suppress the debug output, add `2>/dev/null`.
 //!
@@ -51,13 +57,17 @@
 //! appropriate deployment backend. To see what backends are supported on your
 //! system, run:
 //!
-//!     $ enarx info
+//! ```sh
+//! $ enarx info
+//! ```
 //!
 //! You can manually select a backend with the `--backend` option, or by
 //! setting the `ENARX_BACKEND` environment variable:
 //!
-//!     $ enarx run --backend=sgx target/wasm32-wasi/release/hello-world.wasm
-//!     $ ENARX_BACKEND=sgx enarx run target/wasm32-wasi/release/hello-world.wasm
+//! ```sh
+//! $ enarx run --backend=sgx target/wasm32-wasi/release/hello-world.wasm
+//! $ ENARX_BACKEND=sgx enarx run target/wasm32-wasi/release/hello-world.wasm
+//! ```
 
 #![deny(clippy::all)]
 #![deny(missing_docs)]


### PR DESCRIPTION
Closes #1308 

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
