### PR TITLE
Add an opt-in script for pre-push fmt/clippy hooks

### DIFF
--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -xe
+
+# Run linting checks (not completely exhaustive)
+cargo clippy --all-features --manifest-path=Cargo.toml -- -D warnings
+cargo clippy --target=x86_64-unknown-linux-musl --all-features --manifest-path=internal/shim-sgx/Cargo.toml -- -D warnings
+cargo clippy --target=x86_64-unknown-linux-musl --all-features --manifest-path=internal/shim-sev/Cargo.toml -- -D warnings
+cargo clippy --target=x86_64-unknown-linux-musl --all-features --manifest-path=internal/wasmldr/Cargo.toml -- -D warnings
+
+# Run formatting tests
+cargo fmt -- --check
+cargo fmt --manifest-path=internal/shim-sgx/Cargo.toml -- --check
+cargo fmt --manifest-path=internal/shim-sev/Cargo.toml -- --check
+cargo fmt --manifest-path=internal/wasmldr/Cargo.toml -- --check
+
+exit 0

--- a/.git-hooks/toggle.sh
+++ b/.git-hooks/toggle.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# This script allows users to easily opt-in to git hooks.
+set -e
+
+if [ -f ".git/hooks/pre-push" ]; then
+    echo "It looks like a pre-push hook is already installed."
+    read -e -p "Would you like to delete it? [y/N] " choice
+    [[ "$choice" == [Yy]* ]] || exit 0
+    echo "Removing hook"
+    rm .git/hooks/pre-push
+else
+    echo "This will install a pre-push Git hook for cargo fmt/clippy (read-only checks)."
+    echo "This will prevent you from pushing if either fail (but can be bypassed with --no-verify)."
+    read -e -p "Would you like to install it? [y/N] " choice
+    [[ "$choice" == [Yy]* ]] || exit 0
+    echo "Installing hook"
+    cp .git-hooks/pre-push .git/hooks/
+fi


### PR DESCRIPTION
This will run `cargo clippy` and `cargo fmt` checks in a read-only
way on `enarx` and internal crates.

Run `.git-hooks/toggle.sh` to try it.

Related to #1286 

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
