### PR TITLE
fix(shim-sev): guard unused `use`

### DIFF
--- a/internal/shim-sev/src/interrupts.rs
+++ b/internal/shim-sev/src/interrupts.rs
@@ -4,6 +4,7 @@
 
 #[cfg(feature = "dbg")]
 use crate::debug::{interrupt_trace, print_stack_trace};
+#[cfg(any(debug_assertions, feature = "dbg"))]
 use crate::eprintln;
 #[cfg(feature = "dbg")]
 use crate::hostcall::shim_exit;


### PR DESCRIPTION
With debug_assertions, otherwise `cargo build --release` will give a
warning.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
