### PR TITLE
fix: be more specific about Cargo `includes`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Enarx Keep Loader"
 readme = "README.md"
 keywords = ["sgx", "sev", "kvm", "tee"]
 categories = ["os", "os::linux-apis", "network-programming", "hardware-support"]
-include = [ "src", "internal", "build.rs", "LICENSE", "README.md", "rust-toolchain.toml" ]
+include = [ "/src", "/internal", "!/internal/*/target", "/build.rs", "/LICENSE", "/README.md", "/rust-toolchain.toml" ]
 
 [badges]
 # See https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section


### PR DESCRIPTION
Define paths more specific:
* /foo matches any file or directory with the name foo only in the root of the package.
* ! prefix negates a pattern.

See: https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
