### PR TITLE
fix(wasmldr): handle `addr` field for `tcp_listen` config

### DIFF
--- a/internal/wasmldr/src/workload.rs
+++ b/internal/wasmldr/src/workload.rs
@@ -221,7 +221,7 @@ pub(crate) mod test {
         let results: Vec<i32> = workload::run(&bytes, &config::Config::default())
             .unwrap()
             .iter()
-            .map(|v| v.unwrap_i32())
+            .map(wasmtime::Val::unwrap_i32)
             .collect();
 
         assert_eq!(results, vec![1]);

--- a/internal/wasmldr/src/workload.rs
+++ b/internal/wasmldr/src/workload.rs
@@ -113,7 +113,7 @@ pub fn run(bytes: impl AsRef<[u8]>, ldr_config: &config::Config) -> Result<Vec<w
     debug!("Processing loader config {:#?}", &ldr_config);
 
     if let Some(ref files) = ldr_config.files {
-        for file in files.iter() {
+        for file in files {
             match (file.type_.as_ref(), file.name.as_ref()) {
                 ("stdio", "stdin") => wasi = wasi.inherit_stdin(),
                 ("stdio", "stdout") => wasi = wasi.inherit_stdout(),

--- a/tests/wasmldr_tests.rs
+++ b/tests/wasmldr_tests.rs
@@ -292,6 +292,7 @@ name = "stderr"
 
 [[files]]
 type = "tcp_listen"
+addr = "127.0.0.1"
 port = {}
 name = "TEST_TCP_LISTEN"
     "#,


### PR DESCRIPTION
The `addr` field was not taken into account and `127.0.0.1` was used hard coded.

Additional commits:
* small nitpick fixes for @bstrie 
* ci(wasmldr): harden wasmldr_tests::check_listen_fd

