### PR TITLE
ci(sgx): fix sgx_get_att* tests

### DIFF
--- a/tests/c-tests/sgx_get_att_quote.c
+++ b/tests/c-tests/sgx_get_att_quote.c
@@ -9,7 +9,7 @@
  * the returned Quote in buf match expected values. */
 
 int main(void) {
-    int* nonce[64]; /* empty pseudo-hash value to embed in SGX Quote */
+    unsigned char nonce[64]; /* empty pseudo-hash value to embed in SGX Quote */
     unsigned char buf[4598];
     size_t technology;
     int i;

--- a/tests/c-tests/sgx_get_att_quote_size.c
+++ b/tests/c-tests/sgx_get_att_quote_size.c
@@ -9,12 +9,10 @@
  * Quote size. */
 
 int main(void) {
-    int* nonce = NULL;
-    int* buf = NULL;
     size_t technology;
     ssize_t expected = 4598;
 
-    ssize_t size = get_att(nonce, sizeof(nonce), buf, sizeof(buf), &technology);
+    ssize_t size = get_att(NULL, 0, NULL, 0, &technology);
 
     if (size < 0)
         return !(errno == ENOSYS);


### PR DESCRIPTION
sgx_get_att_quote_size was not using `buffer length == 0` to request the
real needed buffer length and therefore `EINVAL` was returned.

sgx_get_att_quote was using the wrong nonce length != 64 and therefore
`EINVAL` was returned.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
