### PR TITLE
Remove `Cargo.lock` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 target/
-Cargo.lock
 .idea/
 .vscode/


### PR DESCRIPTION
The file is already checked in since f7f5bb9
Although, it was (mistakenly?) added to `.gitignore` in 5f6a17b, which had no effect.

In any case, since we provide a compiled binary, rather than a library external parties can depend on, we *should* check-in our lock file.