### PR TITLE
fix(examples/tcp_server): promptly echo back input

### DIFF
--- a/examples/tcp_server/README.md
+++ b/examples/tcp_server/README.md
@@ -90,7 +90,14 @@ You'll see our welcome message and anything you type will be printed here.
 
 Then from another shell:
 ```
-$ echo ECHO | nc 127.0.0.1 9000
+$ echo ECHO | ncat 127.0.0.1 9000
+Hello world!
+ECHO
+```
+
+or, if you don't have `ncat`:
+```
+$ echo ECHO | netcat -q 1 127.0.0.1 9000
 Hello world!
 ECHO
 ```

--- a/examples/tcp_server/src/main.rs
+++ b/examples/tcp_server/src/main.rs
@@ -161,6 +161,9 @@ fn handle_connection_event(
                     break;
                 }
                 Ok(n) => {
+                    // echo back what we received and ignore any errors while doing so
+                    let _ = connection.write_all(&received_data[bytes_read..(bytes_read + n)]);
+
                     bytes_read += n;
                     if bytes_read == received_data.len() {
                         received_data.resize(received_data.len() + 1024, 0);
@@ -182,8 +185,6 @@ fn handle_connection_event(
             } else {
                 println!("Received (none UTF-8) data: {:?}", received_data);
             }
-
-            let _ = connection.write_all(received_data)?;
         }
 
         if connection_closed {


### PR DESCRIPTION
The original `OpenBSD netcat` version does not issue
`shutdown(_, SHUT_WR)`, when the input pipe is closed.

Therefore the tcp_server input loop is never ended and nothing is echo'd
back.

To end with `netcat` the README.md is updated accordingly.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
