### PR TITLE
fix(shim-sev): Turn all `static mut` globals into `RacyCell`

### DIFF
--- a/internal/shim-sev/src/lib.rs
+++ b/internal/shim-sev/src/lib.rs
@@ -13,12 +13,9 @@
 #![warn(rust_2018_idioms)]
 
 use crate::snp::cpuid_page::CpuidPage;
-use crate::snp::ghcb::Ghcb;
-use crate::snp::secrets_page::SnpSecretsPage;
 
 use goblin::elf::header::header64::Header;
 use primordial::Page as Page4KiB;
-use sallyport::Block;
 
 #[macro_use]
 pub mod testaso;
@@ -47,10 +44,6 @@ pub mod usermode;
 
 extern "C" {
     /// Extern
-    pub static mut _ENARX_SALLYPORT_START: Block;
-    /// Extern
-    pub static _ENARX_SALLYPORT_END: Page4KiB;
-    /// Extern
     pub static _ENARX_MEM_START: Page4KiB;
     /// Extern
     pub static _ENARX_SHIM_START: Page4KiB;
@@ -60,8 +53,4 @@ extern "C" {
     pub static _ENARX_EXEC_END: Page4KiB;
     /// Extern
     pub static _ENARX_CPUID: CpuidPage;
-    /// Extern
-    pub static mut _ENARX_GHCB: Ghcb;
-    /// Extern
-    pub static mut _ENARX_SECRETS: SnpSecretsPage;
 }

--- a/internal/shim-sev/src/snp/ghcb.rs
+++ b/internal/shim-sev/src/snp/ghcb.rs
@@ -9,8 +9,7 @@ use crate::addr::SHIM_VIRT_OFFSET;
 use crate::pagetables::{clear_c_bit_address_range, smash};
 use crate::snp::secrets_page::SECRETS;
 use crate::snp::{pvalidate, PvalidateSize};
-use crate::spin::RwLocked;
-use crate::_ENARX_GHCB;
+use crate::spin::{RacyCell, RwLocked};
 
 use core::arch::asm;
 use core::mem::size_of;
@@ -268,16 +267,31 @@ pub unsafe fn vmgexit_msr(request_code: u64, value: u64, expected_response: u64)
 }
 
 /// A handle to the GHCB block
-pub struct GhcbHandle {
-    ghcb: &'static mut Ghcb,
+pub struct GhcbHandle<'a> {
+    ghcb: &'a mut Ghcb,
 }
 
 /// The global Enarx GHCB
-pub static GHCB: Lazy<RwLocked<GhcbHandle>> =
-    Lazy::new(|| RwLocked::<GhcbHandle>::new(GhcbHandle::new(unsafe { &mut _ENARX_GHCB })));
+///
+/// # Safety
+///
+/// `GHCB` is the only way to get an instance of the static `_ENARX_GHCB` struct.
+/// It is guarded by `RwLocked`.
+pub static GHCB: Lazy<RwLocked<GhcbHandle<'_>>> = Lazy::new(|| {
+    extern "C" {
+        /// Extern
+        pub static _ENARX_GHCB: RacyCell<Ghcb>;
+    }
 
-impl GhcbHandle {
-    fn new(ghcb: &'static mut Ghcb) -> Self {
+    unsafe {
+        let ghcb_uninit = _ENARX_GHCB.get();
+        ghcb_uninit.write(Ghcb::DEFAULT);
+        RwLocked::<GhcbHandle<'_>>::new(GhcbHandle::new(&mut *ghcb_uninit))
+    }
+});
+
+impl<'a> GhcbHandle<'a> {
+    fn new(ghcb: &'a mut Ghcb) -> Self {
         let ghcb_virt = VirtAddr::from_ptr(ghcb);
 
         ghcb_msr_make_page_shared(ghcb_virt);
@@ -384,7 +398,7 @@ impl GhcbHandle {
     }
 }
 
-impl RwLocked<GhcbHandle> {
+impl RwLocked<GhcbHandle<'_>> {
     /// GHCB IOIO_PROT
     pub fn do_io_out(&self, portnumber: u16, value: u16) {
         const IOIO_TYPE_OUT: u64 = 0;
@@ -577,12 +591,18 @@ impl Default for GhcbExtHandle {
     }
 }
 
-static mut GHCBEXTHANDLE: GhcbExtHandle = <GhcbExtHandle as ConstDefault>::DEFAULT;
-
 /// The global Enarx GHCB Ext
+///
+/// # Safety
+/// `GHCB_EXT` is the only way to get an instance of the static `GHCBEXTHANDLE`.
+/// It is guarded by `RwLocked`.
 pub static GHCB_EXT: Lazy<RwLocked<&mut GhcbExtHandle>> = Lazy::new(|| unsafe {
-    GHCBEXTHANDLE.init();
-    RwLocked::<&mut GhcbExtHandle>::new(&mut GHCBEXTHANDLE)
+    static GHCBEXTHANDLE: RacyCell<GhcbExtHandle> =
+        RacyCell::new(<GhcbExtHandle as ConstDefault>::DEFAULT);
+
+    let ghcb_ext_handle_mut = &mut (*GHCBEXTHANDLE.get());
+    ghcb_ext_handle_mut.init();
+    RwLocked::<&mut GhcbExtHandle>::new(ghcb_ext_handle_mut)
 });
 
 impl GhcbExtHandle {

--- a/internal/shim-sev/src/spin.rs
+++ b/internal/shim-sev/src/spin.rs
@@ -2,7 +2,41 @@
 
 //! wrapper around spinning types to permit trait implementations.
 
+use core::cell::UnsafeCell;
 use spinning::{Mutex, MutexGuard, RawMutex, RawRwLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// Cell type that should be preferred over a `static mut` is better to use in a
+/// `static`
+///
+/// Based on [@bstrie comment](issue-53639-bstrie)
+/// [issue-53639-bstrie]: https://github.com/rust-lang/rust/issues/53639#issuecomment-888435728
+///
+/// # Safety
+///
+/// The idea here being that callers of `RacyCell::get` could only turn that *mut into a reference,
+/// if you can guarantee the usual reference safety invariants as demonstrated in
+/// [this example for UnsafeCell::get](https://doc.rust-lang.org/std/cell/struct.UnsafeCell.html#examples),
+/// with the added rub that you also have to uphold those invariants while taking threads into account,
+/// which means that almost nobody can actually safely cast this *mut to a reference
+/// (which helps to illustrate the problem with static mut here),
+/// so you're better off just working with the raw pointer
+/// (ideally by wrapping it in your own synchronization logic).
+#[repr(transparent)]
+pub struct RacyCell<T>(UnsafeCell<T>);
+
+impl<T> RacyCell<T> {
+    /// Create a new RacyCell
+    pub const fn new(value: T) -> Self {
+        RacyCell(UnsafeCell::new(value))
+    }
+
+    /// Gets a mutable pointer to the wrapped value.
+    pub fn get(&self) -> *mut T {
+        self.0.get()
+    }
+}
+
+unsafe impl<T> Sync for RacyCell<T> {}
 
 /// A wrapper around spinning::Mutex to permit trait implementations.
 pub struct Locked<A> {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/53639#issuecomment-888435728

Related: https://github.com/enarx/enarx/issues/1405

Signed-off-by: Harald Hoyer <harald@profian.com>
