### PR TITLE
Rename `has_sgx` to `host_can_test_sgx` and add `host_can_test_sev`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -262,4 +262,14 @@ fn main() {
             println!("cargo:rustc-cfg=host_can_test_sgx");
         }
     }
+
+    if std::path::Path::new("/dev/sev").exists() {
+        // Not expected to fail, as the file exists.
+        let metadata = fs::metadata("/dev/sev").unwrap();
+        let file_type = metadata.file_type();
+
+        if file_type.is_char_device() {
+            println!("cargo:rustc-cfg=host_can_test_sev");
+        }
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -259,7 +259,7 @@ fn main() {
         let file_type = metadata.file_type();
 
         if file_type.is_char_device() {
-            println!("cargo:rustc-cfg=has_sgx");
+            println!("cargo:rustc-cfg=host_can_test_sgx");
         }
     }
 }

--- a/src/backend/sgx/attestation.rs
+++ b/src/backend/sgx/attestation.rs
@@ -302,11 +302,12 @@ pub fn get_attestation(
     }
 }
 
-#[cfg(all(test, has_sgx))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(not(host_can_test_sgx), ignore)]
     fn request_target_info() {
         assert_eq!(std::path::Path::new(AESM_SOCKET).exists(), true);
 

--- a/tests/rust_integration_tests.rs
+++ b/tests/rust_integration_tests.rs
@@ -96,6 +96,7 @@ fn unix_echo() {
 
 #[cfg(feature = "backend-sev")]
 #[test]
+#[cfg_attr(not(host_can_test_sev), ignore)]
 #[serial]
 fn rust_sev_attestation() {
     run_crate(


### PR DESCRIPTION
To indicate that the configuration flag is only for testing rename  `has_sgx` to `host_can_test_sgx`.

Also add `host_can_test_sev` for SEV.

Also use the configuration flags to mark tests with `#[ignore]` to show that the tests exist, but were ignored.