### PR TITLE
fix(tests): remove `const` modifier for `accept4`

### DIFF
--- a/tests/c-tests/libc.h
+++ b/tests/c-tests/libc.h
@@ -294,7 +294,7 @@ int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
     return rax;
 }
 
-int accept4(int sockfd, const struct sockaddr *addr, socklen_t *addrlen, int flags) {
+int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags) {
     int rax;
     register int r10 __asm__("r10") = flags;
 


### PR DESCRIPTION
See accept4(2) for details: https://linux.die.net/man/2/accept

Signed-off-by: Vincent Haupert <mail@vincent-haupert.de>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
