### PR TITLE
fix[sgx]: Document xchg usage in uarch.rs

### DIFF
--- a/internal/shim-sgx/src/uarch.rs
+++ b/internal/shim-sgx/src/uarch.rs
@@ -137,6 +137,11 @@ impl TargetInfo {
         // will be initialized by the CPU as the next step.
         let mut report = core::mem::MaybeUninit::<Report>::uninit();
 
+        // In Rust inline assembly rbx is not preserved by the compiler, even
+        // when part of the input list. It is one of the callee saved registers
+        // dictated by:
+        //
+        // https://github.com/hjl-tools/x86-psABI/wiki/x86-64-psABI-1.0.pdf
         unsafe {
             asm!(
                 "xchg       {RBX}, rbx",


### PR DESCRIPTION
Closes: #1322
Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
