### PR TITLE
build(deps): nightly toolchain update, nix fixes, CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,3 +83,11 @@ jobs:
           - name: debug
           - name: release
             flag: --release
+
+  nix:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v16
+    - run: nix flake check
+    - run: nix develop --ignore-environment -c cargo build

--- a/flake.lock
+++ b/flake.lock
@@ -8,15 +8,16 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1645511046,
-        "narHash": "sha256-c9dl1gLtgrIPieaviW1EpQk5LkXgP+2gHpEp7vX8/nY=",
-        "owner": "nix-community",
+        "lastModified": 1645538813,
+        "narHash": "sha256-NSWEv+Zh4z1AjSHN8zKvndWRiT79FVG9JGMkpoiedus=",
+        "owner": "rvolosatovs",
         "repo": "fenix",
-        "rev": "972ccdaa28b811150391e21397f4bf93ded601cd",
+        "rev": "088f90901c7d6930065905e191859d0319982f5a",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "rvolosatovs",
+        "ref": "fix/rustc-patch",
         "repo": "fenix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1644387840,
-        "narHash": "sha256-g3On+GqjP5YRlseypyJxOM/Dz9bKW3iTbV0Nfz5Py6I=",
+        "lastModified": 1645511046,
+        "narHash": "sha256-c9dl1gLtgrIPieaviW1EpQk5LkXgP+2gHpEp7vX8/nY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f950cc5036dc2a6631d39e0887e9f6a9a92c4dd9",
+        "rev": "972ccdaa28b811150391e21397f4bf93ded601cd",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644359234,
-        "narHash": "sha256-u/sBnRgrFrn9W8gZMS6vN3ZnJsoTvbws968TpqwlDJQ=",
+        "lastModified": 1645433236,
+        "narHash": "sha256-4va4MvJ076XyPp5h8sm5eMQvCrJ6yZAbBmyw95dGyw4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5051e2b5fe9fab43a64f0e0d06b62c81a890b90",
+        "rev": "7f9b6e2babf232412682c09e57ed666d8f84ac2d",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1644363050,
-        "narHash": "sha256-zSFcwYnhqoJzckV3eKvSCBcdT2nQu9+J5h0ShXZNIak=",
+        "lastModified": 1645480664,
+        "narHash": "sha256-1+6YSK1hn6PX5qC3JwjrYktMwtq5GeFgNbyaGzk8Kuo=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "7c2d7035a6a0217a8162ce7ba889097933746d98",
+        "rev": "c0ee2f23ff70349704dfe8448027a41b7788eb37",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,14 +12,11 @@
     # NOTE: musl is only supported on Linux.
     with flake-utils.lib; eachSystem [ system.x86_64-linux ] (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ ];
-        };
+        pkgs = import nixpkgs { inherit system; };
 
         rust = fenix.packages."${system}".fromToolchainFile {
           file = ./rust-toolchain.toml;
-          sha256 = "0939qjwhpk366pnf3lbsbnmlj0h5x8nskbcz2lyjwhz4f2hna7w5";
+          sha256 = "sha256-Pj2xMSZ/rG2+oene4ym6h7qnWrPNLMsKobywbadwl9A=";
         };
 
         buildInputs = (with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   inputs.flake-utils.url = github:numtide/flake-utils;
   inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.fenix.url = github:nix-community/fenix;
+  inputs.fenix.url = github:rvolosatovs/fenix?ref=fix/rustc-patch;
 
   outputs = { self, nixpkgs, fenix, flake-utils, ... }:
     # NOTE: musl is only supported on Linux.

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     # NOTE: musl is only supported on Linux.
     with flake-utils.lib; eachSystem [ system.x86_64-linux ] (system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = nixpkgs.legacyPackages.${system};
 
         rust = fenix.packages."${system}".fromToolchainFile {
           file = ./rust-toolchain.toml;

--- a/helper/test-enarx-wasm.sh
+++ b/helper/test-enarx-wasm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! command -v "${ENARX_BIN[0]}" &> /dev/null; then
   if [ -x $(dirname $0)/../target/release/enarx ]; then

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-02-08"
+channel = "nightly-2022-02-22"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "wasm32-wasi"]
 profile = "minimal"


### PR DESCRIPTION
- Fix Nix development environment
- Run `cargo build` via Nix on CI to test the development environment
- Update rust nightly
- Update Nix flake

Switched to using a custom Nix Rust tooling fork until https://github.com/nix-community/fenix/issues/67 is fixed (https://github.com/nix-community/fenix/pull/68 PR filed)