### PR TITLE
fix(sev): tighten bounds on unsafe impl Sync for RacyCell

### DIFF
--- a/internal/shim-sev/src/spin.rs
+++ b/internal/shim-sev/src/spin.rs
@@ -36,7 +36,7 @@ impl<T> RacyCell<T> {
     }
 }
 
-unsafe impl<T> Sync for RacyCell<T> {}
+unsafe impl<T: Sync> Sync for RacyCell<T> {}
 
 /// A wrapper around spinning::Mutex to permit trait implementations.
 pub struct Locked<A> {


### PR DESCRIPTION
Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
