### PR TITLE
fix(test): use `/usr/bin/env` shebang

### DIFF
--- a/helper/parse-trace.sh
+++ b/helper/parse-trace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SHIM="$1"
 PAYLOAD="$2"

--- a/helper/test-enarx-wasm.sh
+++ b/helper/test-enarx-wasm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! command -v "${ENARX_BIN[0]}" &> /dev/null; then
   if [ -x $(dirname $0)/../target/release/enarx ]; then

--- a/helper/test-enarx.sh
+++ b/helper/test-enarx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if ! [ -x "$ENARX_BIN" ]; then
   (cd ..; cargo build -q)


### PR DESCRIPTION
On NixOS, neither `/bin/sh` nor `/usr/bin/bash` exists. This means, when
developing on NixOS with the given `flake.nix`, calling `cargo test`
partly fails as the given path in the helper scripts' shebang does not
exist.

For some compatibility, NixOS offers `/usr/bin/env`. Therefore, this
commit uses `/usr/bin/env` to call `sh` and `bash` relative to `PATH`.

Signed-off-by: Vincent Haupert <mail@vincent-haupert.de>