### PR TITLE
build(nix): add `enarx` package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,3 +91,4 @@ jobs:
     - uses: cachix/install-nix-action@v16
     - run: nix flake check
     - run: nix develop --ignore-environment -c cargo build
+    - run: nix build -L

--- a/flake.lock
+++ b/flake.lock
@@ -53,6 +53,26 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1639947939,
+        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1645433236,
@@ -74,6 +94,7 @@
         "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
+        "naersk": "naersk",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,9 @@
 
             nativeBuildInputs = [ pkgs.pkg-config ];
             buildInputs = [ pkgs.openssl ];
+
+            cargoTestOptions = x: x ++ [ "-- --skip check_listen_fd" ];
+            doCheck = true;
           };
 
         defaultPackage = self.packages.${system}.enarx;

--- a/flake.nix
+++ b/flake.nix
@@ -17,36 +17,28 @@
         pkgs = nixpkgs.legacyPackages.${system};
 
         rust = fenix.packages."${system}".fromToolchainFile {
-          file = ./rust-toolchain.toml;
+          file = "${self}/rust-toolchain.toml";
           sha256 = "sha256-tBwy9v6pwct/riRxF9mSt6VmdL3KzmKHtBNTyFgbfqk=";
         };
-
-        buildInputs = (with pkgs; [
-          gcc11
-          openssl.dev
-          musl.dev
-        ]) ++ [
-          rust
-        ];
-
-        nativeBuildInputs = with pkgs; [
-          pkg-config
-        ];
-
-        unsetEnv = pkgs.lib.concatMapStringsSep "\n" (var: "unset ${var}") [
-          "NIX_LDFLAGS_FOR_TARGET"
-          "NIX_CFLAGS_COMPILE_FOR_TARGET"
-        ];
-
-        stdenv = pkgs.stdenvNoCC;
-
-        stdenvOverride = { inherit stdenv; };
       in
       {
-        devShell = pkgs.mkShell.override stdenvOverride {
-          inherit buildInputs nativeBuildInputs;
+        devShell = pkgs.mkShell.override { stdenv = pkgs.stdenvNoCC; } {
+          buildInputs = (with pkgs; [
+            gcc11
+            openssl
+            musl
+          ]) ++ [
+            rust
+          ];
 
-          shellHook = unsetEnv;
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+
+          shellHook = ''
+            unset NIX_LDFLAGS_FOR_TARGET
+            unset NIX_CFLAGS_COMPILE_FOR_TARGET
+          '';
         };
 
         packages.enarx =

--- a/flake.nix
+++ b/flake.nix
@@ -84,8 +84,15 @@
             nativeBuildInputs = [ pkgs.pkg-config ];
             buildInputs = [ pkgs.openssl ];
 
-            cargoTestOptions = x: x ++ [ "-- --skip check_listen_fd" ];
             doCheck = true;
+            preCheck = ''
+              if [[ -e /dev/kvm ]]; then
+                export cargo_test_options="$cargo_test_options -- --skip check_listen_fd"
+              else
+                header "No KVM support, running only unit tests"
+                export cargo_test_options="$cargo_test_options --bins"
+              fi
+            '';
           };
 
         defaultPackage = self.packages.${system}.enarx;


### PR DESCRIPTION
This PR adds a package `enarx` to the project's flake. It allows building `enarx` with full 
Nix sandboxing and gives strong reproducibility guarantees. Also, it makes it easy to use the `enarx` binary on Nix-enabled systems.

The following command builds the package through Nix and brings the `enarx` binary into scope:

```ShellSession
# nix shell 'github:yaxitech/enarx/nix-build'
...
# enarx info
Version 0.2.1 starting up
Backend: sgx
 ✔ System Info: Linux sgx-cont 5.4.0-99-generic #112-Ubuntu SMP Thu Feb 3 13:50:55 UTC 2022 x86_64 (none)
 ✔ Driver: /dev/sgx_enclave
 ✔ CPU: Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz | GenuineIntel
 ✔  SGX Support
 ✔   Version 1
 ✗   Version 2
 ✔   FLC Support
 ✔   Max Size (32-bit): 2 GiB
 ✔   Max Size (64-bit): 64 GiB
 ✔   MiscSelect: (empty)
 ✔   Features: DEBUG | MODE64BIT | PROVISIONING_KEY | EINIT_KEY
 ✔   Xfrm: X87 | SSE | AVX | YMM | BNDREG | BNDCSR
 ✔   EPC Size: 94 MiB
...
```

The PR also does some refactoring regarding the Nix development shell (`nix develop`).

I'm also happy to extend [the documentation](https://github.com/enarx/enarx.github.io/blob/main/docs/Installation/Enarx.md#install-from-nix) accordingly.
