### PR TITLE
fix: helper/test-enarx.sh

### DIFF
--- a/helper/test-enarx.sh
+++ b/helper/test-enarx.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env sh
 
-if ! [ -x "$ENARX_BIN" ]; then
-  (cd ..; cargo build -q)
-  ENARX_BIN=$(dirname $0)/../target/debug/enarx
+if ! command -v "${ENARX_BIN[0]}" &> /dev/null; then
+  if [ -x $(dirname $0)/../target/release/enarx ]; then
+    ENARX_BIN=$(dirname $0)/../target/release/enarx
+  elif [ -x $(dirname $0)/../target/debug/enarx ]; then
+    ENARX_BIN=$(dirname $0)/../target/debug/enarx
+  else
+    (cd $(dirname $0); cd ..; cargo build -q)
+    ENARX_BIN=$(dirname $0)/../target/release/enarx
+  fi
 fi
 
 "$ENARX_BIN" exec "$@"


### PR DESCRIPTION
For manual testing of rust crates, search for an enarx binary in more
locations before doing a cargo build.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
