### PR TITLE
feat(backend-kvm): be more verbose on KVM errors

### DIFF
--- a/src/backend/kvm/thread.rs
+++ b/src/backend/kvm/thread.rs
@@ -5,7 +5,7 @@ use super::KeepPersonality;
 
 use std::sync::{Arc, RwLock};
 
-use anyhow::{anyhow, Result};
+use anyhow::{bail, Result};
 use kvm_ioctls::{VcpuExit, VcpuFd};
 use mmarinus::{perms, Kind, Map};
 use primordial::{Address, Register};
@@ -149,17 +149,16 @@ impl<P: KeepPersonality> super::super::Thread for Thread<P> {
                 self.keep.write().unwrap().sallyports[block_nr].replace(block_virt);
                 ret
             }
-
             #[cfg(debug_assertions)]
-            reason => Err(anyhow!(
-                "{:?} {:#x?} {:#x?}",
+            reason => bail!(
+                "KVM error: {:?} {:#x?} {:#x?}",
                 reason,
                 vcpu_fd.get_regs(),
                 vcpu_fd.get_sregs()
-            )),
+            ),
 
             #[cfg(not(debug_assertions))]
-            reason => Err(anyhow!("{:?}", reason)),
+            reason => bail!("KVM error: {:?}", reason),
         }
     }
 }


### PR DESCRIPTION
When the shim causes an unhandled exception, the error message was very
cryptic. At least display where it was coming from.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
