### PR TITLE
ci: cancel old workflows, if PR is updated

### DIFF
--- a/.github/workflows/commisery.yml
+++ b/.github/workflows/commisery.yml
@@ -13,9 +13,13 @@
 # limitations under the License.
 
 name: Commisery
-on: 
+on:
   pull_request:
     types: [edited, opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -25,7 +29,7 @@ jobs:
   commit-message:
     name: Conventional Commit Message Checker (Commisery)
     runs-on: ubuntu-latest
-    steps:       
+    steps:
     - name: Check-out the repo under $GITHUB_WORKSPACE
       uses: actions/checkout@v2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,11 @@
-on: [push, pull_request]
 name: lint
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     name: cargo fmt (${{ matrix.crate.name }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
-on: [push, pull_request]
 name: test
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: enarx ${{ matrix.backend.name }} nightly ${{ matrix.profile.name }}


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
