### PR TITLE
fix(kvm): add the missing CPUID checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "protobuf",
  "protobuf-codegen-pure",
  "rand",
+ "raw-cpuid",
  "reqwest",
  "sallyport",
  "semver",
@@ -960,6 +961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "929f54e29691d4e6a9cc558479de70db7aa3d98cd6fe7ab86d7507aa2886b9d2"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ reqwest = { version = "0.11", features = [ "blocking" ], optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 atty = "0.2"
+raw-cpuid = "10.2.0"
 
 # h2 is an indirect dependency, to be specified when checking with `-Z minimal-versions`
 # h2 is a dependency of hyper, which is a dep of reqwest

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -13,6 +13,7 @@ use super::Loader;
 
 use anyhow::Result;
 use mmarinus::{perms, Map};
+use raw_cpuid::CpuId;
 
 use std::arch::x86_64::__cpuid_count;
 use std::sync::{Arc, RwLock};
@@ -39,7 +40,11 @@ impl crate::backend::Backend for Backend {
 
     #[inline]
     fn have(&self) -> bool {
-        self.data().iter().all(|x| x.pass)
+        let cpuid = CpuId::new();
+
+        let has_sgx2 = cpuid.get_sgx_info().map_or(false, |finfo| finfo.has_sgx2());
+
+        has_sgx2 && self.data().iter().all(|x| x.pass)
     }
 
     fn data(&self) -> Vec<super::Datum> {


### PR DESCRIPTION
Check for RDRAND, FSGSBASE and ADX with the help of raw-cpuid crate.

Closes: #1468
Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
