### PR TITLE
feat(sgx): reset EPCM permissions to PROT_NONE before mprotect()

### DIFF
--- a/src/backend/sgx/ioctls.rs
+++ b/src/backend/sgx/ioctls.rs
@@ -27,10 +27,6 @@ pub const ENCLAVE_SET_ATTRIBUTE: Ioctl<Write, &SetAttribute<'_>> = unsafe { SGX.
 
 /// SGX_IOC_VEPC_REMOVE_ALL (0x04) is not used by Enarx.
 
-/// SGX_IOC_ENCLAVE_RELAX_PERMISSIONS
-pub const ENCLAVE_RELAX_PERMISSIONS: Ioctl<WriteRead, &RelaxPermissions<'_>> =
-    unsafe { SGX.write_read(0x05) };
-
 /// SGX_IOC_ENCLAVE_RESTRICT_PERMISSIONS
 pub const ENCLAVE_RESTRICT_PERMISSIONS: Ioctl<WriteRead, &RestrictPermissions<'_>> =
     unsafe { SGX.write_read(0x06) };
@@ -116,39 +112,6 @@ impl<'a> SetAttribute<'a> {
 #[repr(C)]
 #[derive(Debug)]
 /// SGX_IOC_ENCLAVE_RELAX_PERMISSIONS parameter structure
-pub struct RelaxPermissions<'a> {
-    /// In: starting page offset
-    offset: u64,
-    /// In: length of the address range (multiple of the page size)
-    length: u64,
-    /// In: SECINFO containing the relaxed permissions
-    secinfo: u64,
-    /// Out: length of the address range successfully changed
-    count: u64,
-    phantom: PhantomData<&'a ()>,
-}
-
-impl<'a> RelaxPermissions<'a> {
-    /// Create a new RelaxPermissions instance.
-    pub fn new(offset: usize, length: usize, secinfo: &'a SecInfo) -> Self {
-        Self {
-            offset: offset as _,
-            length: length as _,
-            secinfo: secinfo as *const _ as _,
-            count: 0,
-            phantom: PhantomData,
-        }
-    }
-
-    /// Read count attribute.
-    pub fn count(&self) -> u64 {
-        self.count
-    }
-}
-
-#[repr(C)]
-#[derive(Debug)]
-/// SGX_IOC_ENCLAVE_RELAX_PERMISSIONS parameter structure
 pub struct RestrictPermissions<'a> {
     /// In: starting page offset
     offset: u64,
@@ -190,28 +153,6 @@ impl<'a> RestrictPermissions<'a> {
 #[cfg(all(test, host_can_test_sgx))]
 mod tests {
     use super::*;
-
-    #[test]
-    fn relax_permissions() {
-        use sgx::page::{Flags, SecInfo};
-        use std::fs::OpenOptions;
-
-        let mut device_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open("/dev/sgx_enclave")
-            .unwrap();
-
-        let secinfo = SecInfo::reg(Flags::empty());
-        let mut parameters = RelaxPermissions::new(0, 0, &secinfo);
-
-        let ret = match ENCLAVE_RELAX_PERMISSIONS.ioctl(&mut device_file, &mut parameters) {
-            Ok(_) => 0,
-            Err(err) => err.raw_os_error().unwrap(),
-        };
-
-        assert_eq!(ret, libc::EINVAL);
-    }
 
     #[test]
     fn restrict_permissions() {


### PR DESCRIPTION
Set EPCM permissions to PROT_NONE before mprotect(). This allows the shim
to adjust them properly with EMODPE. This flow has the advantage that pages
are either completely inaccessible or accessible with the exactly correct
permissions.

Closes: #1501
Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
