### PR TITLE
fix(shim-kvm): change `RwLocked<&mut T>` to `Locked<&mut T>`

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -3,7 +3,7 @@
 //! syscall interface layer between assembler and rust
 
 use crate::hostcall::{HostCall, UserMemScope};
-use crate::spin::{RacyCell, RwLocked};
+use crate::spin::{Locked, RacyCell};
 
 use core::arch::asm;
 use core::mem::size_of;
@@ -102,10 +102,10 @@ pub unsafe extern "sysv64" fn _syscall_enter() -> ! {
 
 /// Thread local storage
 /// FIXME: when using multithreading
-pub static THREAD_TLS: Lazy<RwLocked<&mut guest::ThreadLocalStorage>> = Lazy::new(|| unsafe {
+pub static THREAD_TLS: Lazy<Locked<&mut guest::ThreadLocalStorage>> = Lazy::new(|| unsafe {
     static TLSHANDLE: RacyCell<guest::ThreadLocalStorage> =
         RacyCell::new(guest::ThreadLocalStorage::new());
-    RwLocked::<&mut guest::ThreadLocalStorage>::new(&mut (*TLSHANDLE.get()))
+    Locked::<&mut guest::ThreadLocalStorage>::new(&mut (*TLSHANDLE.get()))
 });
 
 /// Handle a syscall in rust
@@ -124,7 +124,7 @@ extern "sysv64" fn syscall_rust(
     #[cfg(feature = "dbg")]
     eprintln!("syscall {} …", nr);
 
-    let mut tls = THREAD_TLS.write();
+    let mut tls = THREAD_TLS.lock();
     let mut h = HostCall::try_new(&mut tls).unwrap();
 
     let usermemscope = UserMemScope;


### PR DESCRIPTION
`RwLocked::read()` for a mutable borrow is equal to `RwLocked::write()`,
so don't do that and use a Mutex with `Locked`.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
