### PR TITLE
chore(ci): temporarily disable SEV tests in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         backend:
-          - {name: sev, host: [self-hosted, linux, sev-snp]}
+          # - {name: sev, host: [self-hosted, linux, sev-snp]}
           - {name: sgx, host: [self-hosted, linux, sgx]}
           - {name: kvm, host: [self-hosted, linux]}
         profile:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         backend:
-          - {name: sev, host: [self-hosted, linux, sev-snp]}
+          # - {name: sev, host: [self-hosted, linux, sev-snp]}
           - {name: sgx, host: [self-hosted, linux, sgx]}
           - {name: kvm, host: [self-hosted, linux]}
         profile:


### PR DESCRIPTION
Disable tests on SEV-SNP hardware until connectivity restored.
Ref #1508 