### PR TITLE
fix(shim-sev): guard unused imports with `cfg`

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -7,8 +7,9 @@ use crate::spin::{Locked, RacyCell};
 
 use core::arch::asm;
 use core::mem::size_of;
-use libc::{SYS_write, STDERR_FILENO, STDOUT_FILENO};
 
+#[cfg(feature = "dbg")]
+use libc::{SYS_write, STDERR_FILENO, STDOUT_FILENO};
 use sallyport::guest;
 use sallyport::guest::Handler;
 use sallyport::item::enarxcall::SYS_GETATT;


### PR DESCRIPTION
Some imports are only used in `feature = dbg`.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
