### PR TITLE
feat: enable SGX attestation tests only if AESMD is running

### DIFF
--- a/src/backend/sgx/attestation.rs
+++ b/src/backend/sgx/attestation.rs
@@ -286,8 +286,8 @@ pub fn get_quote(report: &[u8], akid: Vec<u8>, out_buf: &mut [u8]) -> Result<usi
 mod tests {
     use super::*;
 
+    #[cfg_attr(not(host_can_test_attestation), ignore)]
     #[test]
-    #[cfg_attr(not(host_can_test_sgx), ignore)]
     fn request_target_info() {
         assert_eq!(std::path::Path::new(AESM_SOCKET).exists(), true);
 

--- a/tests/c_integration_tests.rs
+++ b/tests/c_integration_tests.rs
@@ -126,6 +126,7 @@ fn read_udp() {
     run_test("read_udp", 0, input.as_slice(), input.as_slice(), None);
 }
 
+#[cfg_attr(not(host_can_test_attestation), ignore)]
 #[test]
 #[serial]
 fn get_att() {
@@ -133,6 +134,7 @@ fn get_att() {
 }
 
 #[cfg(feature = "backend-sgx")]
+#[cfg_attr(not(host_can_test_attestation), ignore)]
 #[test]
 #[serial]
 fn sgx_get_att_quote() {
@@ -140,6 +142,7 @@ fn sgx_get_att_quote() {
 }
 
 #[cfg(feature = "backend-sgx")]
+#[cfg_attr(not(host_can_test_attestation), ignore)]
 #[test]
 #[serial]
 fn sgx_get_att_quote_size() {


### PR DESCRIPTION
```
    feat: enable SGX attestation tests only if AESMD is running
    
    Attestation tests require attestation infrastructure in place, which is
    not always the situation in your developer platform. Having them enabled
    by default weakens the contributor experience because it makes cargo
    test usage tedious. Improve this by disabling attestation tests only if
    AESMD is running. Completely ignore two ioctl tests, as they are
    unstable, and the functionality will migrate to the sgx crate.
    
    Closes: #1524
    Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>
```