### PR TITLE
fix(sgx): instead of constant for quote size, use get_quote_size()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,10 +810,9 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 [[package]]
 name = "sallyport"
 version = "0.3.0"
-source = "git+https://github.com/enarx/sallyport?rev=e8bd9ad033353df881e8ae8a7aafcff99c745c46#e8bd9ad033353df881e8ae8a7aafcff99c745c46"
+source = "git+https://github.com/enarx/sallyport?rev=92c696ff296cf06b54f68c56aa6d24553e8ed476#92c696ff296cf06b54f68c56aa6d24553e8ed476"
 dependencies = [
  "goblin",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ x86_64 = { version = "^0.14.8", default-features = false, optional = true }
 sgx = { version = "0.3.0", features = ["openssl"], optional = true }
 const-default = { version = "1.0", features = [ "derive" ] }
 primordial = { version = "0.4", features = ["alloc"] }
-sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "e8bd9ad033353df881e8ae8a7aafcff99c745c46" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "92c696ff296cf06b54f68c56aa6d24553e8ed476" }
 kvm-bindings = { version = "0.5", optional = true }
 kvm-ioctls = { version = "0.11", optional = true }
 gdbstub = { version = "0.5.0", optional = true }

--- a/internal/shim-kvm/Cargo.lock
+++ b/internal/shim-kvm/Cargo.lock
@@ -345,10 +345,9 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.3.0"
-source = "git+https://github.com/enarx/sallyport?rev=e8bd9ad033353df881e8ae8a7aafcff99c745c46#e8bd9ad033353df881e8ae8a7aafcff99c745c46"
+source = "git+https://github.com/enarx/sallyport?rev=92c696ff296cf06b54f68c56aa6d24553e8ed476#92c696ff296cf06b54f68c56aa6d24553e8ed476"
 dependencies = [
  "goblin 0.5.1",
- "libc",
 ]
 
 [[package]]

--- a/internal/shim-kvm/Cargo.toml
+++ b/internal/shim-kvm/Cargo.toml
@@ -23,7 +23,7 @@ crt0stack = { version = "0.1", default-features = false }
 spinning = { version = "0.1", default-features = false }
 libc = { version = "0.2.119", default-features = false }
 primordial = "0.4"
-sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "e8bd9ad033353df881e8ae8a7aafcff99c745c46" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "92c696ff296cf06b54f68c56aa6d24553e8ed476" }
 xsave = { version = "2.0.2" }
 noted = "1.0.0"
 nbytes = "0.1"

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -230,10 +230,9 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.3.0"
-source = "git+https://github.com/enarx/sallyport?rev=e8bd9ad033353df881e8ae8a7aafcff99c745c46#e8bd9ad033353df881e8ae8a7aafcff99c745c46"
+source = "git+https://github.com/enarx/sallyport?rev=92c696ff296cf06b54f68c56aa6d24553e8ed476#92c696ff296cf06b54f68c56aa6d24553e8ed476"
 dependencies = [
  "goblin 0.5.1",
- "libc",
 ]
 
 [[package]]

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -21,7 +21,7 @@ goblin = { version = "0.5", default-features = false, features = [ "elf64" ] }
 primordial = { version = "^0.4.0", features = ["const-default"] }
 x86_64 = { version = "^0.14.8", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
-sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "e8bd9ad033353df881e8ae8a7aafcff99c745c46" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "92c696ff296cf06b54f68c56aa6d24553e8ed476" }
 spinning = { version = "0.1", default-features = false }
 libc = { version = "0.2.119", default-features = false }
 const-default = "1.0"

--- a/internal/shim-sgx/src/handler/mod.rs
+++ b/internal/shim-sgx/src/handler/mod.rs
@@ -37,7 +37,7 @@ use libc::{c_int, c_ulong, off_t, size_t};
 
 use sallyport::guest::Handler as _;
 use sallyport::guest::{self, Platform, ThreadLocalStorage};
-use sallyport::item::enarxcall::sgx::{Report, ReportData, TargetInfo, QUOTE_SIZE, TECH};
+use sallyport::item::enarxcall::sgx::{Report, ReportData, TargetInfo, TECH};
 use sallyport::item::enarxcall::SYS_GETATT;
 use sallyport::item::syscall::{ARCH_GET_FS, ARCH_GET_GS, ARCH_SET_FS, ARCH_SET_GS};
 
@@ -255,15 +255,17 @@ impl<'a> Handler<'a> {
         buf: usize,
         buf_len: usize,
     ) -> Result<[usize; 2], libc::c_int> {
+        let quote_size = self.get_sgx_quote_size()?;
+
         if buf == 0 {
-            return Ok([QUOTE_SIZE, TECH]);
+            return Ok([quote_size, TECH]);
         }
 
         if buf_len > isize::MAX as usize {
             return Err(libc::EINVAL);
         }
 
-        if buf_len < QUOTE_SIZE {
+        if buf_len < quote_size {
             return Err(libc::EMSGSIZE);
         }
 

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -14,6 +14,7 @@ use std::mem::{size_of, MaybeUninit};
 use std::net::TcpStream;
 use std::sync::Arc;
 
+use crate::backend::sgx::attestation::get_quote_size;
 use anyhow::{Context, Result};
 use sallyport::host::{deref_aligned, deref_slice};
 use sallyport::item;
@@ -138,6 +139,17 @@ fn sgx_enarxcall<'a>(enarxcall: &'a mut Payload, data: &'a mut [u8]) -> Result<O
 
             let akid = get_attestation_key_id().context("error obtaining attestation key id")?;
             *ret = get_quote(report_buf, akid, quote_buf).context("error getting quote")?;
+
+            Ok(None)
+        }
+
+        item::Enarxcall {
+            num: item::enarxcall::Number::GetSgxQuoteSize,
+            ret,
+            ..
+        } => {
+            let akid = get_attestation_key_id().context("error obtaining attestation key id")?;
+            *ret = get_quote_size(akid).context("error getting quote size")?;
 
             Ok(None)
         }

--- a/tests/c-tests/get_att.c
+++ b/tests/c-tests/get_att.c
@@ -5,11 +5,10 @@
 #include <errno.h>
 
 int main(void) {
-    unsigned char nonce[64]; /* correct hash length for SGX */
-    unsigned char buf[4598];
+    unsigned char nonce[64];
     size_t technology;
 
-    ssize_t size = get_att(nonce, sizeof(nonce), buf, sizeof(buf), &technology);
+    ssize_t size = get_att(nonce, sizeof(nonce), NULL, 0, &technology);
 
     if (size >= 0) {
 	switch (technology) {

--- a/tests/c-tests/sgx_get_att_quote_size.c
+++ b/tests/c-tests/sgx_get_att_quote_size.c
@@ -5,21 +5,19 @@
 #include <errno.h>
 
 /* This test will be run only for SGX. It is designed to request a
- * Quote size from get_attestation() and check that against the expected
- * Quote size. */
+ * Quote size from get_attestation()  */
 
 int main(void) {
     size_t technology;
-    ssize_t expected = 4598;
 
     ssize_t size = get_att(NULL, 0, NULL, 0, &technology);
 
-    if (size < 0)
-        return !(errno == ENOSYS);
-    
+    if (size <= 0)
+        return 1;
+
     /* this test is SGX-specific, so just return success if not running on SGX */
     if (technology != TEE_SGX)
         return 0;
 
-    return (size != expected);
+    return 0;
 }

--- a/tests/sev_attestation/Cargo.toml
+++ b/tests/sev_attestation/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "e8bd9ad033353df881e8ae8a7aafcff99c745c46" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "92c696ff296cf06b54f68c56aa6d24553e8ed476" }
 
 [dev-dependencies]
 memoffset = "0.6.4"


### PR DESCRIPTION
The quote size is not a constant, so use the GetQuoteSizeEx protobuf
protocol to get the quote size.

Fixes: https://github.com/enarx/enarx/issues/1534

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
