### PR TITLE
refactor(shims): replace libc crate with vendored libc

### DIFF
--- a/internal/shim-kvm/Cargo.lock
+++ b/internal/shim-kvm/Cargo.lock
@@ -388,7 +388,6 @@ dependencies = [
  "gdbstub",
  "gdbstub_arch",
  "goblin 0.5.1",
- "libc",
  "linked_list_allocator",
  "lock_api",
  "lset",

--- a/internal/shim-kvm/Cargo.toml
+++ b/internal/shim-kvm/Cargo.toml
@@ -21,7 +21,6 @@ gdbstub = { version = "0.5.0" , default-features = false, optional = true }
 goblin = { version = "0.5", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
 spinning = { version = "0.1", default-features = false }
-libc = { version = "0.2.120", default-features = false }
 primordial = "0.4"
 sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "92c696ff296cf06b54f68c56aa6d24553e8ed476" }
 xsave = { version = "2.0.2" }

--- a/internal/shim-kvm/src/gdb.rs
+++ b/internal/shim-kvm/src/gdb.rs
@@ -9,6 +9,7 @@ use crate::hostcall::{HostCall, SHIM_LOCAL_STORAGE};
 use crate::interrupts::ExtendedInterruptStackFrameValue;
 
 use core::arch::asm;
+use core::ffi::c_int;
 use core::sync::atomic::Ordering;
 
 use crate::addr::SHIM_VIRT_OFFSET;
@@ -22,6 +23,7 @@ use gdbstub::target::{Target, TargetError, TargetResult};
 use gdbstub::{DisconnectReason, GdbStubBuilder, GdbStubError};
 use gdbstub_arch::x86::reg::X86_64CoreRegs;
 use sallyport::guest::Handler;
+use sallyport::libc::EIO;
 use x86_64::registers::rflags::RFlags;
 use x86_64::structures::paging::Translate;
 use x86_64::VirtAddr;
@@ -35,18 +37,18 @@ impl GdbConnection {
 }
 
 impl gdbstub::Connection for GdbConnection {
-    type Error = libc::c_int;
+    type Error = c_int;
 
     fn read(&mut self) -> Result<u8, Self::Error> {
         let mut tls = SHIM_LOCAL_STORAGE.write();
-        let mut host_call = HostCall::try_new(&mut tls).ok_or(libc::EIO)?;
+        let mut host_call = HostCall::try_new(&mut tls).ok_or(EIO)?;
 
         host_call.gdb_read()
     }
 
     fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
         let mut tls = SHIM_LOCAL_STORAGE.write();
-        let mut host_call = HostCall::try_new(&mut tls).ok_or(libc::EIO)?;
+        let mut host_call = HostCall::try_new(&mut tls).ok_or(EIO)?;
 
         for byte in buf.iter_mut() {
             *byte = host_call.gdb_read()?;
@@ -61,7 +63,7 @@ impl gdbstub::Connection for GdbConnection {
 
     fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
         let mut tls = SHIM_LOCAL_STORAGE.write();
-        let mut host_call = HostCall::try_new(&mut tls).ok_or(libc::EIO)?;
+        let mut host_call = HostCall::try_new(&mut tls).ok_or(EIO)?;
 
         host_call.gdb_write_all(buf)?;
         Ok(())
@@ -69,7 +71,7 @@ impl gdbstub::Connection for GdbConnection {
 
     fn peek(&mut self) -> Result<Option<u8>, Self::Error> {
         let mut tls = SHIM_LOCAL_STORAGE.write();
-        let mut host_call = HostCall::try_new(&mut tls).ok_or(libc::EIO)?;
+        let mut host_call = HostCall::try_new(&mut tls).ok_or(EIO)?;
         host_call.gdb_peek()
     }
 
@@ -79,7 +81,7 @@ impl gdbstub::Connection for GdbConnection {
 
     fn on_session_start(&mut self) -> Result<(), Self::Error> {
         let mut tls = SHIM_LOCAL_STORAGE.write();
-        let mut host_call = HostCall::try_new(&mut tls).ok_or(libc::EIO)?;
+        let mut host_call = HostCall::try_new(&mut tls).ok_or(EIO)?;
         host_call.gdb_on_session_start()
     }
 }

--- a/internal/shim-kvm/src/lib.rs
+++ b/internal/shim-kvm/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(clippy::all)]
 #![cfg_attr(not(test), deny(clippy::integer_arithmetic))]
 #![deny(missing_docs)]
-#![feature(asm_const, asm_sym, naked_functions)]
+#![feature(asm_const, asm_sym, c_size_t, core_ffi_c, naked_functions)]
 #![warn(rust_2018_idioms)]
 
 use crate::snp::cpuid_page::CpuidPage;

--- a/internal/shim-kvm/src/print.rs
+++ b/internal/shim-kvm/src/print.rs
@@ -7,6 +7,8 @@ use crate::hostcall::{self, HostFd};
 use core::fmt;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+use sallyport::libc::{STDERR_FILENO, STDOUT_FILENO};
+
 struct HostWrite(HostFd);
 
 // FIXME: remove, if https://github.com/enarx/enarx/issues/831 is fleshed out
@@ -74,7 +76,7 @@ pub fn _print(args: fmt::Arguments<'_>) {
         return;
     }
 
-    HostWrite(unsafe { HostFd::from_raw_fd(libc::STDOUT_FILENO) })
+    HostWrite(unsafe { HostFd::from_raw_fd(STDOUT_FILENO) })
         .write_fmt(args)
         .expect("Printing via Host fd 1 failed");
 }
@@ -89,7 +91,7 @@ pub fn _eprint(args: fmt::Arguments<'_>) {
         return;
     }
 
-    HostWrite(unsafe { HostFd::from_raw_fd(libc::STDERR_FILENO) })
+    HostWrite(unsafe { HostFd::from_raw_fd(STDERR_FILENO) })
         .write_fmt(args)
         .expect("Printing via Host fd 2 failed");
 }

--- a/internal/shim-kvm/src/snp/ghcb.rs
+++ b/internal/shim-kvm/src/snp/ghcb.rs
@@ -19,6 +19,7 @@ use aes_gcm::AeadInPlace;
 use aes_gcm::NewAead;
 use aes_gcm::{Aes256Gcm, Key, Nonce, Tag};
 use const_default::ConstDefault;
+use sallyport::libc::EINVAL;
 use spinning::Lazy;
 use x86_64::registers::model_specific::Msr;
 use x86_64::structures::paging::{Page, Size4KiB};
@@ -748,11 +749,11 @@ impl Locked<&mut GhcbExtHandle> {
     /// Get an attestation report via the GHCB shared page protocol
     pub fn get_report(&self, version: u8, nonce: &[u8], response: &mut [u8]) -> Result<usize, u64> {
         if nonce.len() != 64 {
-            return Err(libc::EINVAL as _);
+            return Err(EINVAL as _);
         }
 
         if response.len() < SNP_ATTESTATION_LEN_MAX {
-            return Err(libc::EINVAL as _);
+            return Err(EINVAL as _);
         }
 
         let mut this = self.lock();

--- a/internal/shim-kvm/src/syscall.rs
+++ b/internal/shim-kvm/src/syscall.rs
@@ -8,11 +8,11 @@ use crate::spin::{Locked, RacyCell};
 use core::arch::asm;
 use core::mem::size_of;
 
-#[cfg(feature = "dbg")]
-use libc::{SYS_write, STDERR_FILENO, STDOUT_FILENO};
 use sallyport::guest;
 use sallyport::guest::Handler;
 use sallyport::item::enarxcall::SYS_GETATT;
+#[cfg(feature = "dbg")]
+use sallyport::libc::{SYS_write, STDERR_FILENO, STDOUT_FILENO};
 use spinning::Lazy;
 
 #[repr(C)]

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -280,7 +280,6 @@ dependencies = [
  "gdbstub",
  "gdbstub_arch",
  "goblin 0.5.1",
- "libc",
  "lset",
  "memoffset",
  "noted",

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -23,7 +23,6 @@ x86_64 = { version = "^0.14.8", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
 sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "92c696ff296cf06b54f68c56aa6d24553e8ed476" }
 spinning = { version = "0.1", default-features = false }
-libc = { version = "0.2.120", default-features = false }
 const-default = "1.0"
 noted = "^1.0.0"
 xsave = { version = "2.0.2" }

--- a/internal/shim-sgx/src/entry.rs
+++ b/internal/shim-sgx/src/entry.rs
@@ -6,13 +6,14 @@ use core::arch::asm;
 
 use crt0stack::{Builder, Entry, Handle, OutOfSpace};
 use goblin::elf::header::{header64::Header, ELFMAG};
+use sallyport::libc::SYS_exit;
 
 fn exit(code: usize) -> ! {
     loop {
         unsafe {
             asm!(
                 "syscall",
-                in("rax") libc::SYS_exit,
+                in("rax") SYS_exit,
                 in("rdi") code
             );
         }

--- a/internal/shim-sgx/src/handler/gdb.rs
+++ b/internal/shim-sgx/src/handler/gdb.rs
@@ -3,6 +3,7 @@
 #![cfg(feature = "gdb")]
 
 use core::arch::asm;
+use core::ffi::c_int;
 use core::mem::size_of;
 use core::ops::Range;
 
@@ -78,7 +79,7 @@ impl<'a> super::Handler<'a> {
 
         // workaround for the gdbstub main loop (will change with gdbstub-0.6
         loop {
-            let mut gdb = GdbStubBuilder::new(self as &mut dyn Connection<Error = libc::c_int>)
+            let mut gdb = GdbStubBuilder::new(self as &mut dyn Connection<Error = c_int>)
                 .with_packet_buffer(&mut buf)
                 .build()
                 .unwrap();
@@ -146,7 +147,7 @@ impl<'a> super::Handler<'a> {
 }
 
 impl<'a> gdbstub::Connection for super::Handler<'a> {
-    type Error = libc::c_int;
+    type Error = c_int;
 
     fn read(&mut self) -> Result<u8, Self::Error> {
         self.gdb_read()

--- a/internal/shim-sgx/src/handler/mod.rs
+++ b/internal/shim-sgx/src/handler/mod.rs
@@ -28,18 +28,18 @@ pub(crate) mod usermem;
 
 use core::arch::asm;
 use core::arch::x86_64::CpuidResult;
-use core::ffi::c_void;
+use core::ffi::{c_int, c_size_t, c_ulong, c_void};
 use core::fmt::Write;
 use core::mem::size_of;
 use core::ptr::read_unaligned;
 use core::ptr::NonNull;
-use libc::{c_int, c_ulong, off_t, size_t};
 
 use sallyport::guest::Handler as _;
 use sallyport::guest::{self, Platform, ThreadLocalStorage};
 use sallyport::item::enarxcall::sgx::{Report, ReportData, TargetInfo, TECH};
 use sallyport::item::enarxcall::SYS_GETATT;
 use sallyport::item::syscall::{ARCH_GET_FS, ARCH_GET_GS, ARCH_SET_FS, ARCH_SET_GS};
+use sallyport::libc::{off_t, EINVAL, EMSGSIZE, ENOSYS, STDERR_FILENO};
 
 use crate::handler::usermem::UserMemScope;
 use crate::{DEBUG, ENARX_EXEC_END, ENARX_EXEC_START, ENCL_SIZE};
@@ -64,7 +64,7 @@ impl<'a> Write for Handler<'a> {
         let mut written = 0;
         while written < len {
             written += self
-                .write(libc::STDERR_FILENO, &buf[written..])
+                .write(STDERR_FILENO, &buf[written..])
                 .map_err(|_| core::fmt::Error)? as usize;
         }
         Ok(())
@@ -112,9 +112,9 @@ impl guest::Handler for Handler<'_> {
         match code {
             ARCH_SET_FS => self.ssa.gpr.fsbase = addr,
             ARCH_SET_GS => self.ssa.gpr.gsbase = addr,
-            ARCH_GET_FS => return Err(libc::ENOSYS),
-            ARCH_GET_GS => return Err(libc::ENOSYS),
-            _ => return Err(libc::EINVAL),
+            ARCH_GET_FS => return Err(ENOSYS),
+            ARCH_GET_GS => return Err(ENOSYS),
+            _ => return Err(EINVAL),
         }
         Ok(())
     }
@@ -136,7 +136,7 @@ impl guest::Handler for Handler<'_> {
         &mut self,
         _platform: &impl Platform,
         _addr: NonNull<c_void>,
-        _length: size_t,
+        _length: c_size_t,
         _advice: c_int,
     ) -> sallyport::Result<()> {
         Ok(())
@@ -148,7 +148,7 @@ impl guest::Handler for Handler<'_> {
         &mut self,
         _platform: &impl Platform,
         _addr: NonNull<c_void>,
-        _len: size_t,
+        _len: c_size_t,
         _prot: c_int,
     ) -> sallyport::Result<()> {
         Ok(())
@@ -158,13 +158,13 @@ impl guest::Handler for Handler<'_> {
         &mut self,
         _platform: &impl Platform,
         addr: Option<NonNull<c_void>>,
-        length: size_t,
+        length: c_size_t,
         prot: c_int,
         flags: c_int,
         fd: c_int,
         offset: off_t,
     ) -> sallyport::Result<NonNull<c_void>> {
-        Ok(NonNull::new(crate::heap::HEAP.write().mmap::<libc::c_void>(
+        Ok(NonNull::new(crate::heap::HEAP.write().mmap::<c_void>(
             addr.map(|v| v.as_ptr() as usize).unwrap_or(0),
             length,
             prot,
@@ -179,11 +179,11 @@ impl guest::Handler for Handler<'_> {
         &mut self,
         _platform: &impl Platform,
         addr: NonNull<c_void>,
-        length: size_t,
+        length: c_size_t,
     ) -> sallyport::Result<()> {
         crate::heap::HEAP
             .write()
-            .munmap::<libc::c_void>(addr.as_ptr() as _, length)
+            .munmap::<c_void>(addr.as_ptr() as _, length)
     }
 }
 
@@ -254,7 +254,7 @@ impl<'a> Handler<'a> {
         hash_len: usize,
         buf: usize,
         buf_len: usize,
-    ) -> Result<[usize; 2], libc::c_int> {
+    ) -> Result<[usize; 2], c_int> {
         let quote_size = self.get_sgx_quote_size()?;
 
         if buf == 0 {
@@ -262,15 +262,15 @@ impl<'a> Handler<'a> {
         }
 
         if buf_len > isize::MAX as usize {
-            return Err(libc::EINVAL);
+            return Err(EINVAL);
         }
 
         if buf_len < quote_size {
-            return Err(libc::EMSGSIZE);
+            return Err(EMSGSIZE);
         }
 
         if hash_len != 64 {
-            return Err(libc::EINVAL);
+            return Err(EINVAL);
         }
 
         let hash = {

--- a/internal/shim-sgx/src/handler/usermem.rs
+++ b/internal/shim-sgx/src/handler/usermem.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::slice;
-use libc::EINVAL;
 use sallyport::guest::Platform;
+use sallyport::libc::EINVAL;
 use sallyport::util::ptr::is_aligned_non_null;
 
 /// Memory validation scope
@@ -16,7 +16,7 @@ impl Platform for UserMemScope {
     /// * not borrowed already
     /// and registers the memory as borrowed mutably.
     ///
-    /// Returns a mutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
+    /// Returns a mutable borrow if valid, otherwise [`EINVAL`](https://man7.org/linux/man-pages/man3/errno.3.html).
     ///
     /// [the ptr module documentation]: core::ptr#safety
     #[inline]
@@ -36,7 +36,7 @@ impl Platform for UserMemScope {
     /// * not borrowed already
     /// and registers the memory as borrowed.
     ///
-    /// Returns an immutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
+    /// Returns an immutable borrow if valid, otherwise [`EINVAL`](https://man7.org/linux/man-pages/man3/errno.3.html).
     ///
     /// [the ptr module documentation]: core::ptr#safety
     #[inline]
@@ -56,7 +56,7 @@ impl Platform for UserMemScope {
     /// * not borrowed already
     /// and registers the memory as borrowed mutably.
     ///
-    /// Returns a mutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
+    /// Returns a mutable borrow if valid, otherwise [`EINVAL`](https://man7.org/linux/man-pages/man3/errno.3.html).
     ///
     /// [the ptr module documentation]: core::ptr#safety
     #[inline]
@@ -80,7 +80,7 @@ impl Platform for UserMemScope {
     /// * not borrowed already
     /// and registers the memory as borrowed.
     ///
-    /// Returns an immutable borrow if valid, otherwise [`EINVAL`](libc::EINVAL).
+    /// Returns an immutable borrow if valid, otherwise [`EINVAL`](https://man7.org/linux/man-pages/man3/errno.3.html).
     ///
     /// [the ptr module documentation]: core::ptr#safety
     #[inline]

--- a/internal/shim-sgx/src/lib.rs
+++ b/internal/shim-sgx/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(generic_const_exprs)]
 #![feature(naked_functions)]
 #![feature(const_mut_refs)]
+#![feature(c_size_t, core_ffi_c)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
As a step towards porting the shims to x84_64-unknown-none, remove the libc dependency in favor of the vendored libc definitions exported by sallyport.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
