### PR TITLE
build(nix): use `buildRustPackage` instead of `naersk`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,26 +53,6 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1639947939,
-        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1647125019,
@@ -94,7 +74,6 @@
         "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,8 @@
   inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.fenix.url = github:rvolosatovs/fenix?ref=fix/rustc-patch;
-  inputs.naersk.url = github:nix-community/naersk;
-  inputs.naersk.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, fenix, flake-utils, naersk, ... }:
+  outputs = { self, nixpkgs, fenix, flake-utils, ... }:
     # NOTE: musl is only supported on Linux.
     with flake-utils.lib; eachSystem [ system.x86_64-linux ] (system:
       let
@@ -44,25 +42,29 @@
           let
             src = nixpkgs.lib.cleanSource self;
 
+            pkgsCross = import nixpkgs {
+              inherit system;
+              crossSystem.config = "x86_64-unknown-linux-musl";
+            };
+
             # Common base derivation to build Enarx crates
-            buildEnarxPackage = { src, ... }@extraAttrs:
+            buildEnarxPackage = pkgs: extraAttrs:
               let
                 cargoToml = with builtins; fromTOML (readFile "${src}/Cargo.toml");
-                buildPackage = (naersk.lib.${system}.override {
+                buildPackage = (pkgs.makeRustPlatform {
                   cargo = rust;
                   rustc = rust;
-                }).buildPackage;
+                }).buildRustPackage;
               in
               buildPackage ({
-                inherit src;
                 inherit (cargoToml.package) name version;
+
+                cargoLock.lockFile = "${extraAttrs.src}/Cargo.lock";
               } // extraAttrs);
 
             # Enarx internal static dependencies
-            buildEnarxInternalPackage = src: buildEnarxPackage {
+            buildEnarxInternalPackage = src: buildEnarxPackage pkgsCross {
               inherit src;
-
-              CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
 
               stripAllFlags = [ "--strip-unneeded" ];
               stripAllList = [ "bin" ];
@@ -71,23 +73,23 @@
             shimSgx = buildEnarxInternalPackage ./internal/shim-sgx;
             wasmldr = buildEnarxInternalPackage ./internal/wasmldr;
           in
-          buildEnarxPackage {
+          buildEnarxPackage pkgs {
             inherit src;
+
+            postPatch = ''
+              patchShebangs ./helper
+            '';
 
             ENARX_PREBUILT_shim-kvm = "${shimKvm}/bin/shim-kvm";
             ENARX_PREBUILT_shim-sgx = "${shimSgx}/bin/shim-sgx";
             ENARX_PREBUILT_wasmldr = "${wasmldr}/bin/wasmldr";
-
-            CARGO_BUILD_TARGET = "x86_64-unknown-linux-gnu";
 
             nativeBuildInputs = [ pkgs.pkg-config ];
             buildInputs = [ pkgs.openssl ];
 
             doCheck = true;
             preCheck = ''
-              if [[ -e /dev/kvm ]]; then
-                export cargo_test_options="$cargo_test_options -- --skip check_listen_fd"
-              else
+              if [[ ! -e /dev/kvm ]]; then
                 header "No KVM support, running only unit tests"
                 export cargo_test_options="$cargo_test_options --bins"
               fi

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
 
         rust = fenix.packages."${system}".fromToolchainFile {
           file = "${self}/rust-toolchain.toml";
+          sha256 = "sha256-CSZsqsnfDEL4pfyKRvWU/opdMjvx6vnJwFnkJXL/oBI=";
         };
       in
       {


### PR DESCRIPTION
- Use native `nixpkgs` tooling to produce `x86_64-unknown-linux-musl` artifacts
- Remove `naersk`
- Re-add the toolchain hash to allow pure evaluation/building (aee24c73f79d12a9818d434af512d5087d868b78)
- Run all tests when building (`nix build`)