### PR TITLE
refactor(shim-kvm): port `shim-kvm` to `x86_64-unknown-none` EXTENDED

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          components: clippy
+          components: clippy, rust-src
           toolchain: nightly-2022-03-14
           profile: minimal
           target: x86_64-unknown-linux-musl
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          components: clippy
+          components: clippy, rust-src
           toolchain: nightly-2022-03-14
           profile: minimal
           target: x86_64-unknown-linux-musl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
+          components: rust-src
           target: x86_64-unknown-linux-musl
           toolchain: nightly-2022-03-14
           override: true
@@ -49,6 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
+          components: rust-src
           target: x86_64-unknown-linux-musl
           toolchain: nightly-2022-03-14
           override: true

--- a/internal/shim-kvm/.cargo/config
+++ b/internal/shim-kvm/.cargo/config
@@ -1,9 +1,0 @@
-[build]
-# FIXME: "x86_64-unknown-none" is not yet a tier 2 target, so setting this as
-#        the default target breaks rust-analyzer.
-# target = "x86_64-unknown-none"
-
-[target.x86_64-unknown-none]
-rustflags = [
-    "-C", "target-feature=-soft-float,+sse,+sse2",
-]

--- a/internal/shim-kvm/.cargo/config
+++ b/internal/shim-kvm/.cargo/config
@@ -5,8 +5,5 @@
 
 [target.x86_64-unknown-none]
 rustflags = [
-    "-C", "relocation-model=pic",
-    "-C", "linker=gcc",
-    "-C", "link-args=-Wl,--sort-section=alignment,-Tlayout.ld -nostartfiles",
     "-C", "target-feature=-soft-float,+sse,+sse2",
 ]

--- a/internal/shim-kvm/.cargo/config
+++ b/internal/shim-kvm/.cargo/config
@@ -1,10 +1,12 @@
 [build]
-target = "x86_64-unknown-linux-musl"
+# FIXME: "x86_64-unknown-none" is not yet a tier 2 target, so setting this as
+#        the default target breaks rust-analyzer.
+# target = "x86_64-unknown-none"
 
-[target.x86_64-unknown-linux-musl]
+[target.x86_64-unknown-none]
 rustflags = [
     "-C", "relocation-model=pic",
+    "-C", "linker=gcc",
     "-C", "link-args=-Wl,--sort-section=alignment,-Tlayout.ld -nostartfiles",
-    "-C", "link-self-contained=no",
-    "-C", "force-frame-pointers=yes",
+    "-C", "target-feature=-soft-float,+sse,+sse2",
 ]

--- a/internal/shim-kvm/Cargo.lock
+++ b/internal/shim-kvm/Cargo.lock
@@ -83,12 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compiler_builtins"
-version = "0.1.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80873f979f0a344a4ade87c2f70d9ccf5720b83b10c97ec7cd745895d021e85a"
-
-[[package]]
 name = "const-default"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,7 +377,6 @@ dependencies = [
  "array-const-fn-init",
  "bit_field",
  "bitflags",
- "compiler_builtins",
  "const-default",
  "crt0stack",
  "gdbstub",

--- a/internal/shim-kvm/Cargo.toml
+++ b/internal/shim-kvm/Cargo.toml
@@ -32,7 +32,7 @@ linked_list_allocator = { version = "0.9.1", default-features = false }
 bit_field = "0.10"
 bitflags = "1.3"
 lock_api = "0.4"
-aes-gcm = { version = "0.9", features = ["aes"], default-features = false  }
+aes-gcm = { version = "0.9", features = ["aes", "force-soft" ], default-features = false  }
 const-default = { version = "1.0", features = [ "derive" ] }
 
 [dev-dependencies]

--- a/internal/shim-kvm/Cargo.toml
+++ b/internal/shim-kvm/Cargo.toml
@@ -14,7 +14,6 @@ gdb = [ "gdbstub", "gdbstub_arch", "dbg" ]
 dbg = []
 
 [dependencies]
-compiler_builtins = { version = "0.1.68", default-features = false, features = [ "mem" ] }
 x86_64 = { version = "0.14.8", default-features = false, features = ["instructions", "inline_asm"] }
 gdbstub_arch = { version = "0.1.1" , default-features = false, optional = true }
 gdbstub = { version = "0.5.0" , default-features = false, optional = true }

--- a/internal/shim-kvm/build.rs
+++ b/internal/shim-kvm/build.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() {
+    println!("cargo:rustc-link-arg-bin=shim-kvm=-Tlayout.ld");
+    println!("cargo:rustc-link-arg-bin=shim-kvm=--sort-section=alignment");
     println!("cargo:rerun-if-changed=layout.ld");
 }

--- a/internal/shim-kvm/layout.ld
+++ b/internal/shim-kvm/layout.ld
@@ -26,23 +26,23 @@ PHDRS {
 }
 
 _ENARX_SHIM_START = 0xFFFFF000;
-_ENARX_MEM_START = 0xFFE00000;
+_ENARX_START = ABSOLUTE(0xFFE00000);
 _ENARX_EXEC_LEN = 128M;
 
 /*
  * These 3 sections need to be fixed for the startup asm block to work
  */
-_ENARX_PML3  = ABSOLUTE(_ENARX_MEM_START + 0 * CONSTANT(COMMONPAGESIZE));
-_ENARX_PML4  = ABSOLUTE(_ENARX_MEM_START + 1 * CONSTANT(COMMONPAGESIZE));
-_ENARX_CPUID = ABSOLUTE(_ENARX_MEM_START + 2 * CONSTANT(COMMONPAGESIZE));
+_ENARX_PML3  = ABSOLUTE(_ENARX_START + 0 * CONSTANT(COMMONPAGESIZE));
+_ENARX_PML4  = ABSOLUTE(_ENARX_START + 1 * CONSTANT(COMMONPAGESIZE));
+_ENARX_CPUID = ABSOLUTE(_ENARX_START + 2 * CONSTANT(COMMONPAGESIZE));
 
 ASSERT((_ENARX_SHIM_START >= (3 * 0x40000000)), "SHIM_START is too low for current initial identity page table")
 ASSERT((_ENARX_EXEC_START < (6 * 0x40000000)), "SHIM is too large for current initial identity page table")
 
 SECTIONS {
-    . = _ENARX_MEM_START;
-
     . = _ENARX_PML3;
+    _ENARX_MEM_START = .;
+
     .pml3 : ALIGN(CONSTANT(COMMONPAGESIZE)) {
         QUAD(0);
         QUAD(0);
@@ -51,14 +51,14 @@ SECTIONS {
         QUAD(4 * 0x40000000 + 0x83); /* Flags::HUGE_PAGE | Flags::WRITABLE | Flags::PRESENT */
         QUAD(5 * 0x40000000 + 0x83); /* Flags::HUGE_PAGE | Flags::WRITABLE | Flags::PRESENT */
         FILL(0);
-        . = CONSTANT(COMMONPAGESIZE);
+        . = ALIGN(CONSTANT(COMMONPAGESIZE));
     } :pagetables
 
     . = _ENARX_PML4;
     .pml4 : ALIGN(CONSTANT(COMMONPAGESIZE)) {
         QUAD(_ENARX_PML3 + 0x3); /* Flags::WRITABLE | Flags::PRESENT */
         FILL(0);
-        . = CONSTANT(COMMONPAGESIZE);
+        . = ALIGN(CONSTANT(COMMONPAGESIZE));
     } :pagetables
 
     . = _ENARX_CPUID;
@@ -106,7 +106,7 @@ SECTIONS {
     .bss                : { *(.bss .bss.*) } :data
 
     .code : ALIGN(CONSTANT(COMMONPAGESIZE)) {
-        _ENARX_EXEC_START = ABSOLUTE(.);
+        _ENARX_EXEC_START = .;
         FILL(0);
         . += _ENARX_EXEC_LEN;
     } :exec

--- a/internal/shim-kvm/src/main.rs
+++ b/internal/shim-kvm/src/main.rs
@@ -13,8 +13,6 @@
 #![feature(asm_const, asm_sym, naked_functions)]
 
 #[allow(unused_extern_crates)]
-extern crate compiler_builtins;
-#[allow(unused_extern_crates)]
 extern crate rcrt1;
 
 use shim_kvm::addr::SHIM_VIRT_OFFSET;
@@ -41,12 +39,6 @@ noted! {
     static NOTE_ENARX_SALLYPORT<note::NAME, note::REQUIRES, [u8; REQUIRES.len()]> = REQUIRES;
 
     static NOTE_BLOCK_SIZE<note::NAME, note::BLOCK_SIZE, u64> = BLOCK_SIZE as u64;
-}
-
-#[cfg(not(target_feature = "crt-static"))]
-#[allow(missing_docs)]
-fn __check_for_static_linking() {
-    compile_error!("shim is not statically linked");
 }
 
 #[cfg(not(debug_assertions))]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
 channel = "nightly-2022-03-14"
-targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "wasm32-wasi"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-unknown-none", "wasm32-wasi"]
 profile = "minimal"
+components = [ "rust-src" ]


### PR DESCRIPTION
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
