### PR TITLE
feat: SNP attestation with VCEK key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,8 +842,7 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 [[package]]
 name = "sallyport"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f264dba3626016c14186361e82a499d3274d4580305c60e399fd07623af27404"
+source = "git+https://github.com/enarx/sallyport?rev=580480b19b1542bc3da2fdafef08f895f5bb3389#580480b19b1542bc3da2fdafef08f895f5bb3389"
 dependencies = [
  "goblin",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ x86_64 = { version = "^0.14.8", default-features = false, optional = true }
 sgx = { version = "0.3.0", features = ["openssl"], optional = true }
 const-default = { version = "1.0", features = [ "derive" ] }
 primordial = { version = "0.4", features = ["alloc"] }
-sallyport = { version = "0.3.0" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "580480b19b1542bc3da2fdafef08f895f5bb3389" }
 kvm-bindings = { version = "0.5", optional = true }
 kvm-ioctls = { version = "0.11", optional = true }
 gdbstub = { version = "0.5.0", optional = true }

--- a/internal/shim-kvm/Cargo.lock
+++ b/internal/shim-kvm/Cargo.lock
@@ -339,8 +339,7 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f264dba3626016c14186361e82a499d3274d4580305c60e399fd07623af27404"
+source = "git+https://github.com/enarx/sallyport?rev=580480b19b1542bc3da2fdafef08f895f5bb3389#580480b19b1542bc3da2fdafef08f895f5bb3389"
 dependencies = [
  "goblin 0.5.1",
 ]

--- a/internal/shim-kvm/Cargo.toml
+++ b/internal/shim-kvm/Cargo.toml
@@ -21,7 +21,7 @@ goblin = { version = "0.5", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
 spinning = { version = "0.1", default-features = false }
 primordial = "0.4"
-sallyport = { version = "0.3.0" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "580480b19b1542bc3da2fdafef08f895f5bb3389" }
 xsave = { version = "2.0.2" }
 noted = "1.0.0"
 nbytes = "0.1"

--- a/internal/shim-kvm/src/snp/attestation.rs
+++ b/internal/shim-kvm/src/snp/attestation.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! SNP attestation and ASN.1 helper functions
+
+/// Header of the SnpReport Response
+#[repr(C)]
+pub struct SnpReportResponseData {
+    /// 0 if valid
+    pub status: u32,
+    /// size
+    pub size: u32,
+    rsvd: [u8; 24],
+}
+
+/// writes a 6 byte header including a u32 length in big endian
+///
+/// helper function for ASN.1 encoding
+fn asn_len_header(header: &mut [u8], tag: u8, len: usize) -> Option<()> {
+    let len: u32 = len.try_into().ok()?;
+    header[0] = tag;
+    header[1] = 0x84; // 4 bytes of length
+    header[2..ASN_LEN_HEADER_SIZE].copy_from_slice(&len.to_be_bytes());
+    Some(())
+}
+
+const ASN_LEN_HEADER_SIZE: usize = 6;
+
+/// wraps a chunk with a header returning the total length
+///
+/// helper function for ASN.1 encoding
+fn asn_wrap(
+    chunks: &mut [u8],
+    header_len: usize,
+    header: impl Fn(&mut [u8], usize) -> Option<()>,
+    body: impl Fn(&mut [u8]) -> Option<usize>,
+) -> Option<usize> {
+    let (head_chunk, body_chunk) = chunks.split_at_mut(header_len);
+
+    let body_len = body(body_chunk)?;
+
+    header(head_chunk, body_len)?;
+
+    let len = header_len.checked_add(body_len)?;
+    Some(len)
+}
+
+const ASN_SECTION_CONSTRUCTED: u8 = 0x30;
+const ASN_OCTET_STRING: u8 = 0x04;
+
+/// Naive ASN.1 encoding for OID 1.3.6.1.4.1.58270.1.3
+pub fn asn1_encode_report_vcek(chunks: &mut [u8], report: &[u8], vcek: &[u8]) -> Option<usize> {
+    let section_header =
+        |header: &mut [u8], body_len| asn_len_header(header, ASN_SECTION_CONSTRUCTED, body_len);
+
+    let octet_header =
+        |header: &mut [u8], body_len| asn_len_header(header, ASN_OCTET_STRING, body_len);
+
+    let report_chunk = |chunks: &mut [u8]| {
+        // report data
+        chunks[..report.len()].copy_from_slice(report);
+        Some(report.len())
+    };
+
+    let vcek_report = |chunks: &mut [u8]| {
+        // vcek data
+        let (vcek_chunk, chunks) = chunks.split_at_mut(vcek.len());
+        vcek_chunk.copy_from_slice(vcek);
+        let report_chunk_len = asn_wrap(chunks, ASN_LEN_HEADER_SIZE, octet_header, report_chunk)?;
+        let len = report_chunk_len.checked_add(vcek.len())?;
+        Some(len)
+    };
+
+    asn_wrap(chunks, ASN_LEN_HEADER_SIZE, section_header, vcek_report)
+}

--- a/internal/shim-kvm/src/snp/mod.rs
+++ b/internal/shim-kvm/src/snp/mod.rs
@@ -11,6 +11,7 @@ pub use cpuid_page::{cpuid, cpuid_count, get_cpuid_max};
 
 use crate::snp::Error::{FailInput, FailSizeMismatch, Unknown};
 
+pub mod attestation;
 pub mod cpuid_page;
 pub mod ghcb;
 pub mod secrets_page;

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -224,8 +224,7 @@ dependencies = [
 [[package]]
 name = "sallyport"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f264dba3626016c14186361e82a499d3274d4580305c60e399fd07623af27404"
+source = "git+https://github.com/enarx/sallyport?rev=580480b19b1542bc3da2fdafef08f895f5bb3389#580480b19b1542bc3da2fdafef08f895f5bb3389"
 dependencies = [
  "goblin 0.5.1",
 ]

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -20,7 +20,7 @@ goblin = { version = "0.5", default-features = false, features = [ "elf64" ] }
 primordial = { version = "^0.4.0", features = ["const-default"] }
 x86_64 = { version = "^0.14.8", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
-sallyport = { version = "0.3.0" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "580480b19b1542bc3da2fdafef08f895f5bb3389" }
 spinning = { version = "0.1", default-features = false }
 const-default = "1.0"
 noted = "^1.0.0"

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -14,6 +14,8 @@ use kvm_bindings::bindings::kvm_userspace_memory_region;
 use kvm_ioctls::Kvm;
 use kvm_ioctls::{VcpuFd, VmFd};
 use mmarinus::{perms, Map};
+use sallyport::item::enarxcall::Payload;
+use sallyport::item::Item;
 use x86_64::VirtAddr;
 
 pub mod builder;
@@ -25,6 +27,14 @@ pub mod thread;
 pub trait KeepPersonality {
     fn map(_vm_fd: &mut VmFd, _region: &Region) -> std::io::Result<()> {
         Ok(())
+    }
+
+    fn enarxcall<'a>(
+        &mut self,
+        enarxcall: &'a mut Payload,
+        data: &'a mut [u8],
+    ) -> Result<Option<Item<'a>>> {
+        Ok(Some(Item::Enarxcall(enarxcall, data)))
     }
 }
 

--- a/src/backend/kvm/thread.rs
+++ b/src/backend/kvm/thread.rs
@@ -161,11 +161,16 @@ impl<P: KeepPersonality> super::super::Thread for Thread<P> {
                         }
 
                         Item::Enarxcall(enarxcall, data) => {
-                            sallyport::host::execute(
-                                self.kvm_enarxcall(enarxcall, data)?.into_iter(),
-                            )
-                            .map_err(io::Error::from_raw_os_error)
-                            .context("sallyport::host::execute")?;
+                            if let Some(Item::Enarxcall(enarxcall, data)) =
+                                self.kvm_enarxcall(enarxcall, data)?
+                            {
+                                let mut keep = self.keep.write().unwrap();
+                                sallyport::host::execute(
+                                    keep.personality.enarxcall(enarxcall, data)?.into_iter(),
+                                )
+                                .map_err(io::Error::from_raw_os_error)
+                                .context("sallyport::host::execute")?;
+                            }
                         }
 
                         // Catch exit and exit_group for a clean shutdown

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -6,7 +6,7 @@ use super::kvm::mem::Region;
 use super::kvm::{Keep, KeepPersonality};
 use super::probe::common::system_info;
 use super::Loader;
-use crate::cli::sev::get_vcek_reader;
+use crate::cli::snp::get_vcek_reader;
 use data::{
     dev_kvm, dev_sev, dev_sev_readable, dev_sev_writable, has_reasonable_memlock_rlimit,
     kvm_version, sev_enabled_in_kernel, CPUIDS,

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -6,17 +6,21 @@ use super::kvm::mem::Region;
 use super::kvm::{Keep, KeepPersonality};
 use super::probe::common::system_info;
 use super::Loader;
-
-use std::sync::Arc;
-
-use anyhow::Result;
+use crate::cli::sev::get_vcek_reader;
 use data::{
     dev_kvm, dev_sev, dev_sev_readable, dev_sev_writable, has_reasonable_memlock_rlimit,
     kvm_version, sev_enabled_in_kernel, CPUIDS,
 };
 
+use std::io;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
 use kvm_bindings::bindings::kvm_enc_region;
 use kvm_ioctls::VmFd;
+use sallyport::host::deref_slice;
+use sallyport::item::enarxcall::Payload;
+use sallyport::item::{self, Item};
 
 mod builder;
 mod cpuid_page;
@@ -36,6 +40,32 @@ impl KeepPersonality for SnpKeepPersonality {
         };
         vm_fd.register_enc_memory_region(&memory_region).unwrap();
         Ok(())
+    }
+    fn enarxcall<'a>(
+        &mut self,
+        enarxcall: &'a mut Payload,
+        data: &'a mut [u8],
+    ) -> Result<Option<Item<'a>>> {
+        match enarxcall {
+            item::Enarxcall {
+                num: item::enarxcall::Number::GetSnpVcek,
+                argv: [vcek_offset, vcek_len, ..],
+                ret,
+            } => {
+                let mut vcek_buf: &mut [u8] = unsafe {
+                    // Safety: `deref_slice` gives us a pointer to a byte slice, which does not have to be aligned.
+                    // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
+                    // is a subslice of.
+                    &mut *deref_slice::<u8>(data, *vcek_offset, *vcek_len)
+                        .map_err(io::Error::from_raw_os_error)
+                        .context("snp::enarxcall deref")?
+                };
+                let mut vcek_reader = get_vcek_reader()?;
+                *ret = std::io::copy(&mut vcek_reader, &mut vcek_buf)? as _;
+                Ok(None)
+            }
+            _ => return Ok(Some(Item::Enarxcall(enarxcall, data))),
+        }
     }
 }
 

--- a/tests/sev_attestation/Cargo.toml
+++ b/tests/sev_attestation/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sallyport = { version = "0.3.0" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "580480b19b1542bc3da2fdafef08f895f5bb3389" }
 
 [dev-dependencies]
 memoffset = "0.6.4"


### PR DESCRIPTION
Chain the SNP report with the vcek in ASN.1 format, in a format the steward can use right away.

For simplicity the length fields are all u32 encoded, regardless of the actual size.

See also `tests/sev_attestation/src/main.rs`.

Fixes: https://github.com/enarx/sallyport/issues/136

Signed-off-by: Harald Hoyer <harald@profian.com>