### PR TITLE
fix(tests): correct C test signed compare

### DIFF
--- a/tests/c-tests/sgx_get_att_quote.c
+++ b/tests/c-tests/sgx_get_att_quote.c
@@ -30,7 +30,7 @@ int main(void) {
         return 0;
 
     /* Ooops, the test fails because of false assumptions */
-    if (size > sizeof(buf))
+    if (size > (ssize_t) sizeof(buf))
         return 1000;
 
     ssize_t quote_size = get_att(nonce, sizeof(nonce), buf, size, &technology);


### PR DESCRIPTION
```
  /runner/_work/enarx/enarx/tests/c-tests/sgx_get_att_quote.c: In function 'main':
  /runner/_work/enarx/enarx/tests/c-tests/sgx_get_att_quote.c:33:14: warning: comparison of integer expressions of different signedness: 'ssize_t' {aka 'long int'} and 'long unsigned int' [-Wsign-compare]
     33 |     if (size > sizeof(buf))
        |
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
