### PR TITLE
ci: make it pass again

### DIFF
--- a/src/cli/snp.rs
+++ b/src/cli/snp.rs
@@ -279,7 +279,9 @@ mod tests {
             join_handles.push(thread::spawn(move || {
                 let (path, mut r) = get_or_write(
                     vec![
-                        PathBuf::from("/ENOENT DIRECTORY SHOULD NOT EXIST/"),
+                        PathBuf::from(
+                            "/proc/ENOENT DIRECTORY SHOULD NOT EXIST AND NOT BE ABLE TO CREATE/",
+                        ),
                         tmp_dir_path,
                         tmp_dir_path2,
                     ],
@@ -304,7 +306,9 @@ mod tests {
     #[test]
     fn test_empty_cache_path() -> Result<()> {
         let res = get_or_write(
-            vec![PathBuf::from("/ENOENT DIRECTORY SHOULD NOT EXIST/")],
+            vec![PathBuf::from(
+                "/proc/ENOENT DIRECTORY SHOULD NOT EXIST AND NOT BE ABLE TO CREATE/",
+            )],
             "test".to_string(),
             || Ok(Box::new(b"test test".as_slice())),
             UpdateMode::ReadOnly,

--- a/tests/c-tests/sgx_get_att_quote.c
+++ b/tests/c-tests/sgx_get_att_quote.c
@@ -30,7 +30,7 @@ int main(void) {
         return 0;
 
     /* Ooops, the test fails because of false assumptions */
-    if (size > sizeof(buf))
+    if (size > (ssize_t) sizeof(buf))
         return 1000;
 
     ssize_t quote_size = get_att(nonce, sizeof(nonce), buf, size, &technology);


### PR DESCRIPTION
### fix(backend::sev::snp::firmware::test): changed directory

In the github CI it seems the root directory is writable.

Change the test directory, which should not be able to be created to
`/proc/…`.

### fix(tests): correct C test signed compare

```
  /runner/_work/enarx/enarx/tests/c-tests/sgx_get_att_quote.c: In function 'main':
  /runner/_work/enarx/enarx/tests/c-tests/sgx_get_att_quote.c:33:14: warning: comparison of integer expressions of different signedness: 'ssize_t' {aka 'long int'} and 'long unsigned int' [-Wsign-compare]
     33 |     if (size > sizeof(buf))
        |
```
        