### PR TITLE
refactor(enarx): upgrade from StructOpt to Clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,18 +90,33 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
- "term_size",
+ "termcolor",
+ "terminal_size",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -183,6 +189,7 @@ dependencies = [
  "atty",
  "bitflags",
  "cc",
+ "clap",
  "colorful",
  "const-default",
  "dirs",
@@ -211,7 +218,6 @@ dependencies = [
  "sgx",
  "spinning",
  "static_assertions",
- "structopt",
  "tempfile",
  "ureq",
  "vdso",
@@ -324,13 +330,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -356,6 +365,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -574,6 +593,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1007,33 +1035,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1069,16 +1073,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,13 +1082,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "terminal_size"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
- "term_size",
- "unicode-width",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]
@@ -1155,12 +1158,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -1224,12 +1221,6 @@ dependencies = [
  "crt0stack",
  "goblin",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ kvm-bindings = { version = "0.5", optional = true }
 kvm-ioctls = { version = "0.11", optional = true }
 gdbstub = { version = "0.5.0", optional = true }
 protobuf = "2.22"
-structopt = { version = "0.3.26", features = ["wrap_help"] }
+clap = { version = "3.0", features = ["env", "derive", "wrap_help"] }
 openssl = "0.10"
 bitflags = "1.2"
 iocuddle = "0.1.1"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli::{BackendOptions, StructOpt};
+use crate::cli::BackendOptions;
 
 use std::path::PathBuf;
+
+use clap::Args;
 
 /// Execute a (static, PIE) binary inside an Enarx Keep.
 ///
@@ -14,17 +16,17 @@ use std::path::PathBuf;
 /// This subcommand is hidden from the main help because it's unlikely to be
 /// useful because of the restrictions above. It's mainly used for
 /// development and integration tests.
-#[derive(StructOpt, Debug)]
+#[derive(Args, Debug)]
 pub struct Options {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub backend: BackendOptions,
 
     /// Binary to load and run inside the keep
-    #[structopt(value_name = "BINARY")]
+    #[clap(value_name = "BINARY")]
     pub binpath: PathBuf,
 
     /// gdb options
     #[cfg(feature = "gdb")]
-    #[structopt(long, default_value = "localhost:23456")]
+    #[clap(long, default_value = "localhost:23456")]
     pub gdblisten: String,
 }

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::backend::BACKENDS;
-use crate::cli::{Result, StructOpt};
+use crate::cli::Result;
 use crate::Backend;
-use core::fmt::Formatter;
-use serde::Serialize;
-use std::fmt;
+
+use std::fmt::{self, Formatter};
 use std::ops::Deref;
+
+use clap::Args;
+use serde::Serialize;
+
 /// Show details about backend support on this system
-#[derive(StructOpt, Debug)]
+#[derive(Args, Debug)]
 pub struct Options {
-    #[structopt(short, long)]
+    #[clap(short, long)]
     /// Emit JSON rather than human-readable output
     json: bool,
 }

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -3,27 +3,27 @@
 use std::str::FromStr;
 
 use anyhow::{anyhow, Result};
-use structopt::StructOpt;
+use clap::Args;
 
 /// Common logging / output options
-#[derive(StructOpt, Debug)]
+#[derive(Args, Debug)]
 pub struct LogOptions {
     /// Increase log verbosity. Pass multiple times for more log output.
     ///
     /// By default we only show error messages. Passing `-v` will show warnings,
     /// `-vv` adds info, `-vvv` for debug, and `-vvvv` for trace.
-    #[structopt(long = "verbose", short = "v", parse(from_occurrences))]
+    #[clap(long = "verbose", short = 'v', parse(from_occurrences))]
     verbosity: u8,
 
     /// Set fancier logging filters.
     ///
     /// This is equivalent to the `RUST_LOG` environment variable.
     /// For more info, see the `env_logger` crate documentation.
-    #[structopt(long = "log-filter", env = "ENARX_LOG")]
+    #[clap(long = "log-filter", env = "ENARX_LOG")]
     log_filter: Option<String>,
 
     /// Set log output target ("stderr", "stdout")
-    #[structopt(long, default_value = "stderr")]
+    #[clap(long, default_value = "stderr")]
     log_target: LogTarget,
 }
 
@@ -37,7 +37,7 @@ enum LogTarget {
     // FUTURE: file path, syslog/journal, ...
 }
 
-/// Convert a str to a LogTarget. This is how StructOpt parses CLI args.
+/// Convert a str to a LogTarget. This is how Clap parses CLI args.
 impl FromStr for LogTarget {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,21 +10,23 @@ pub mod sgx;
 pub mod snp;
 
 use anyhow::{anyhow, Result};
+use clap::{Args, Subcommand};
 use std::ops::Deref;
-use structopt::{clap::AppSettings, StructOpt};
 
 pub use self::log::LogOptions;
 
 /// `enarx` subcommands and their options/arguments.
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum Command {
     Info(info::Options),
-    #[structopt(setting(AppSettings::Hidden))]
+    #[clap(hide = true)]
     Exec(exec::Options),
     Run(run::Options),
     #[cfg(feature = "backend-sev")]
+    #[clap(subcommand)]
     Snp(snp::Command),
     #[cfg(feature = "backend-sgx")]
+    #[clap(subcommand)]
     Sgx(sgx::Command),
 }
 
@@ -34,10 +36,10 @@ pub enum Command {
 
 use crate::backend::{Backend, BACKENDS};
 
-#[derive(StructOpt, Debug)]
+#[derive(Args, Debug)]
 pub struct BackendOptions {
     /// Set which backend to use
-    #[structopt(long, env = "ENARX_BACKEND")]
+    #[clap(long, env = "ENARX_BACKEND")]
     backend: Option<String>,
     // TODO: Path to an external shim binary?
     //shim: Option<PathBuf>,
@@ -67,9 +69,9 @@ impl BackendOptions {
 //
 use crate::workldr::{Workldr, WORKLDRS};
 
-#[derive(StructOpt, Debug)]
+#[derive(Args, Debug)]
 pub struct WorkldrOptions {
-    #[structopt(long, env = "ENARX_WASMCFGFILE")]
+    #[clap(long, env = "ENARX_WASMCFGFILE")]
     pub wasmcfgfile: Option<String>,
     // FUTURE: Path to an external workldr binary
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,24 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{BackendOptions, StructOpt, WorkldrOptions};
+use super::{BackendOptions, WorkldrOptions};
 
 use std::{fmt::Debug, path::PathBuf};
 
+use clap::Args;
+
 /// Run a WebAssembly module inside an Enarx Keep.
-#[derive(StructOpt, Debug)]
+#[derive(Args, Debug)]
 pub struct Options {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub backend: BackendOptions,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub workldr: WorkldrOptions,
 
     /// Path of the WebAssembly module to run
-    #[structopt(value_name = "MODULE", parse(from_os_str))]
+    #[clap(value_name = "MODULE", parse(from_os_str))]
     pub module: PathBuf,
 
     /// gdb options
     #[cfg(feature = "gdb")]
-    #[structopt(long, default_value = "localhost:23456")]
+    #[clap(long, default_value = "localhost:23456")]
     pub gdblisten: String,
 }

--- a/src/cli/sgx.rs
+++ b/src/cli/sgx.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Context, Result};
-use structopt::StructOpt;
+use clap::Subcommand;
 
 const EFI_UUID: &str = "304e0796-d515-4698-ac6e-e76cb1a71c28";
 const EFI_NAME: &str = "SgxRegistrationServerRequest";
@@ -9,7 +9,7 @@ const PATH: &str = "/sys/firmware/efi/efivars";
 const URL: &str = "https://api.trustedservices.intel.com/sgx/registration/v1/platform";
 
 /// SGX-specific functionality
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum Command {
     /// Register the platform with Intel
     Register,

--- a/src/cli/snp.rs
+++ b/src/cli/snp.rs
@@ -2,21 +2,23 @@
 
 use crate::backend::sev::Firmware;
 
-use anyhow::{anyhow, Context, Result};
 use std::fs::{self, remove_file};
 use std::io::{self, ErrorKind, Read, Seek};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
-use structopt::StructOpt;
+
+use anyhow::{anyhow, Context, Result};
+use clap::Subcommand;
 
 /// SNP-specific functionality
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum Command {
     /// SNP VCEK related commands
+    #[clap(subcommand)]
     Vcek(VcekCommand),
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum VcekCommand {
     /// Print the VCEK certificate for this platform to stdout in PEM format
     Show,

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,26 +86,23 @@ use std::fs::File;
 use std::os::unix::io::AsRawFd;
 
 use anyhow::Result;
+use clap::Parser;
 use log::info;
-use structopt::StructOpt;
 
 // This defines the toplevel `enarx` CLI
-#[derive(StructOpt, Debug)]
-#[structopt(
-    setting = structopt::clap::AppSettings::DeriveDisplayOrder,
-)]
+#[derive(Parser, Debug)]
 struct Options {
     /// Logging options
-    #[structopt(flatten)]
+    #[clap(flatten)]
     log: cli::LogOptions,
 
     /// Subcommands (with their own options)
-    #[structopt(flatten)]
+    #[clap(subcommand)]
     cmd: cli::Command,
 }
 
 fn main() -> Result<()> {
-    let opts = Options::from_args();
+    let opts = Options::parse();
     opts.log.init_logger();
 
     info!("logging initialized!");


### PR DESCRIPTION
In addition to being a desired upgrade, this is necessary in order to work around a bug in the forthcoming support for artifact dependencies.

Closes #1346.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
