### PR TITLE
build: update Rust toolchain to 2022-03-23

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           components: rustfmt
-          toolchain: nightly-2022-03-14
+          toolchain: nightly-2022-03-23
           profile: minimal
           override: true
       - uses: actions-rs/cargo@v1
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
-          toolchain: nightly-2022-03-14
+          toolchain: nightly-2022-03-23
           profile: minimal
           target: x86_64-unknown-linux-musl
           override: true
@@ -74,7 +74,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
-          toolchain: nightly-2022-03-14
+          toolchain: nightly-2022-03-23
           profile: minimal
           target: x86_64-unknown-linux-musl
           override: true
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-14
+          toolchain: nightly-2022-03-23
           profile: minimal
           override: true
       - run: cargo install cargo-readme

--- a/.github/workflows/sbom_manifest_action.yml
+++ b/.github/workflows/sbom_manifest_action.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-musl
-          toolchain: nightly-2022-03-14
+          toolchain: nightly-2022-03-23
           override: true
 
       - name: Install cargo-cyclonedx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-musl
-          toolchain: nightly-2022-03-14
+          toolchain: nightly-2022-03-23
           override: true
+          components: rust-src
       - run: rustup target add wasm32-wasi
       - uses: actions-rs/cargo@v1
         with:
@@ -50,8 +51,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-musl
-          toolchain: nightly-2022-03-14
+          toolchain: nightly-2022-03-23
           override: true
+          components: rust-src
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -74,7 +76,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-03-14
+          toolchain: nightly-2022-03-23
           override: true
       - run: cargo test ${{ matrix.profile.flag }} --target x86_64-unknown-linux-gnu
         working-directory: internal/${{ matrix.crate }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-03-14"
+channel = "nightly-2022-03-23"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "wasm32-wasi"]
 profile = "minimal"
 components = ["rust-src"]


### PR DESCRIPTION
This is required to address a bug in artifact dependencies.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
