### PR TITLE
fix(shim-kvm): correctly handle `brk()` unmap

### DIFF
--- a/internal/shim-kvm/src/exec.rs
+++ b/internal/shim-kvm/src/exec.rs
@@ -17,6 +17,7 @@ use crt0stack::{self, Builder, Entry};
 use goblin::elf::header::header64::Header;
 use goblin::elf::header::ELFMAG;
 use goblin::elf::program_header::program_header64::*;
+use lset::Line;
 use nbytes::bytes;
 use spinning::{Lazy, RwLock};
 use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
@@ -54,11 +55,9 @@ pub static EXEC_VIRT_ADDR: Lazy<RwLock<VirtAddr>> = Lazy::new(|| {
 });
 
 /// Actual brk virtual address the exec gets, when calling brk
-pub static NEXT_BRK_RWLOCK: Lazy<RwLock<VirtAddr>> = Lazy::new(|| {
-    RwLock::<VirtAddr>::const_new(
-        spinning::RawRwLock::const_new(),
-        EXEC_BRK_VIRT_ADDR_BASE + (random() & 0xFFFF_F000),
-    )
+pub static BRK_LINE: Lazy<RwLock<Line<VirtAddr>>> = Lazy::new(|| {
+    let start = EXEC_BRK_VIRT_ADDR_BASE + (random() & 0xFFFF_F000);
+    RwLock::<Line<VirtAddr>>::const_new(spinning::RawRwLock::const_new(), Line::new(start, start))
 });
 
 /// The global NextMMap RwLock


### PR DESCRIPTION
Previously unmapping of previously mapped brk pages was not handled.

This patch correctly unmaps anything mapped above the passed address.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
