### PR TITLE
fix(ci): correct workflow which generates SBOM

### DIFF
--- a/.github/workflows/sbom_manifest_check.yml
+++ b/.github/workflows/sbom_manifest_check.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   Regenerate-BOM:
-    uses: ./.github/workflows/sbom_manifest_action.yml@main
+    uses: ./.github/workflows/sbom_manifest_action.yml
 


### PR DESCRIPTION
Resolves bug/issue #1594 by removing `@main` (local GitHub actions cannot use version/branch tags)