### PR TITLE
refactor(shim-sgx): put heap to a lazy container

### DIFF
--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "mmledger"
 version = "0.1.13"
-source = "git+https://github.com/jarkkojs/mmledger?rev=2b3e55024cc13c8c14b76efa2f61bbae0905f6eb#2b3e55024cc13c8c14b76efa2f61bbae0905f6eb"
+source = "git+https://github.com/enarx/mmledger?rev=843bd70e5266bcff912d651af0a9c07a413b5626#843bd70e5266bcff912d651af0a9c07a413b5626"
 dependencies = [
  "bitflags",
  "lset",

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -28,7 +28,7 @@ xsave = { version = "2.0.2" }
 rcrt1 = "1.0.0"
 lset = { git = "https://github.com/enarx/lset", rev = "5c2feed24d85442725f55d812315854e1b29595d"  }
 sgx = "0.3"
-mmledger = { git = "https://github.com/jarkkojs/mmledger", rev = "2b3e55024cc13c8c14b76efa2f61bbae0905f6eb" }
+mmledger = { git = "https://github.com/enarx/mmledger", rev = "843bd70e5266bcff912d651af0a9c07a413b5626" }
 
 [dev-dependencies]
 memoffset = "0.6.1"

--- a/internal/shim-sgx/src/heap.rs
+++ b/internal/shim-sgx/src/heap.rs
@@ -13,16 +13,15 @@ use primordial::{Address, Offset, Page};
 use sallyport::libc::{
     off_t, EINVAL, ENOMEM, MAP_ANONYMOUS, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE,
 };
+use spinning::{Lazy, RwLock};
 
 /// This section MUST be marked as RWX in the linker script
 #[link_section = ".enarx.heap"]
 static mut BLOCK: Block<32768> = Block::new();
 
 /// The keep heap
-pub static HEAP: spinning::RwLock<Heap<'_>> =
-    spinning::RwLock::const_new(spinning::RawRwLock::const_new(), unsafe {
-        Heap::new(&mut BLOCK.0)
-    });
+pub static HEAP: Lazy<RwLock<Heap<'_>>> =
+    Lazy::new(|| RwLock::new(unsafe { Heap::new(&mut BLOCK.0) }));
 
 /// An allocated block of memory
 #[repr(C, align(4096))]


### PR DESCRIPTION
This will allow to replace it in `main()`. In addition, switch from
`jarkkojs/mmledger` to `enarx/mmledger`.

Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
