### PR TITLE
fix: corrections for wasm tls

### DIFF
--- a/src/bin/wasmldr/src/loader/requested.rs
+++ b/src/bin/wasmldr/src/loader/requested.rs
@@ -21,6 +21,7 @@ use const_oid::db::rfc5280::{
     ID_CE_BASIC_CONSTRAINTS, ID_CE_EXT_KEY_USAGE, ID_CE_KEY_USAGE, ID_KP_CLIENT_AUTH,
     ID_KP_SERVER_AUTH,
 };
+use rustix::rand;
 
 impl Loader<Requested> {
     fn steward(&self, url: &Url) -> Result<Vec<Vec<u8>>> {
@@ -57,10 +58,13 @@ impl Loader<Requested> {
         }
         .to_vec()?;
 
+        let mut serial: [u8; 32] = [0u8; 32];
+        rand::getrandom(&mut serial, rand::GetRandomFlags::RANDOM)?;
+
         // Create the certificate body.
         let tbs = TbsCertificate {
             version: x509::Version::V3,
-            serial_number: UIntBytes::new(&[0u8])?,
+            serial_number: UIntBytes::new(&serial)?,
             signature: pki.signs_with()?,
             issuer: RdnSequence::from_der(&rdns)?,
             validity: Validity::from_now(Duration::from_secs(60 * 60 * 24 * 365))?,


### PR DESCRIPTION
How to test:

```
$ git clone https://github.com/haraldh/mini_http
$ cd mini_http
$ cargo +nightly build --target wasm32-wasi --example hello_enarx
$ <PATH_TO_THIS_PRS_ENARX_BIN> run \
  --wasmcfgfile examples/Enarx.toml \
  target/wasm32-wasi/debug/examples/hello_enarx.wasm
```

Then point your browser to [`https://127.0.0.1:3000`](https://127.0.0.1:3000)