### PR TITLE
build(sgx): `force-backend` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ backend-kvm = ["x86_64", "kvm-bindings", "kvm-ioctls"]
 backend-sgx = ["x86_64", "sgx", "ureq"]
 gdb = ["gdbstub"]
 dbg = []
+force-backend = []
 
 [dependencies]
 x86_64 = { version = "^0.14.8", default-features = false, optional = true }

--- a/build.rs
+++ b/build.rs
@@ -282,4 +282,7 @@ fn main() {
             println!("cargo:rustc-cfg=host_can_test_attestation");
         }
     }
+
+    #[cfg(feature = "force-backend")]
+    println!("cargo:rustc-cfg=force_backend");
 }

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -107,9 +107,13 @@ fn sgx_enarxcall<'a>(enarxcall: &'a mut Payload, data: &'a mut [u8]) -> Result<O
                     .context("sgx_enarxcall deref")?
             };
 
-            let akid = get_attestation_key_id().context("error obtaining attestation key id")?;
-            let pkeysize = get_key_size(akid.clone()).context("error obtaining key size")?;
-            *ret = get_target_info(akid, pkeysize, out_buf).context("error getting target info")?;
+            if !cfg!(force_backend) {
+                let akid =
+                    get_attestation_key_id().context("error obtaining attestation key id")?;
+                let pkeysize = get_key_size(akid.clone()).context("error obtaining key size")?;
+                *ret = get_target_info(akid, pkeysize, out_buf)
+                    .context("error getting target info")?;
+            }
 
             Ok(None)
         }
@@ -137,8 +141,11 @@ fn sgx_enarxcall<'a>(enarxcall: &'a mut Payload, data: &'a mut [u8]) -> Result<O
                     .context("sgx_enarxcall deref")?
             };
 
-            let akid = get_attestation_key_id().context("error obtaining attestation key id")?;
-            *ret = get_quote(report_buf, akid, quote_buf).context("error getting quote")?;
+            if !cfg!(force_backend) {
+                let akid =
+                    get_attestation_key_id().context("error obtaining attestation key id")?;
+                *ret = get_quote(report_buf, akid, quote_buf).context("error getting quote")?;
+            }
 
             Ok(None)
         }
@@ -148,8 +155,11 @@ fn sgx_enarxcall<'a>(enarxcall: &'a mut Payload, data: &'a mut [u8]) -> Result<O
             ret,
             ..
         } => {
-            let akid = get_attestation_key_id().context("error obtaining attestation key id")?;
-            *ret = get_quote_size(akid).context("error getting quote size")?;
+            if !cfg!(force_backend) {
+                let akid =
+                    get_attestation_key_id().context("error obtaining attestation key id")?;
+                *ret = get_quote_size(akid).context("error getting quote size")?;
+            }
 
             Ok(None)
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -51,7 +51,7 @@ impl BackendOptions {
             BACKENDS
                 .deref()
                 .iter()
-                .find(|b| b.have() && b.name() == name)
+                .find(|b| (b.name() == name && cfg!(force_backend) || b.have()))
                 .ok_or_else(|| anyhow!("Keep backend {:?} is unsupported.", name))
         } else {
             BACKENDS.deref().iter().find(|b| b.have()).ok_or_else(|| {


### PR DESCRIPTION
Enables a clean `cargo test` run for developer without full attestation
stack setup.

Closes: #1621
Closes: #1618
Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
