### PR TITLE
fix(shim-snp): encode ASN.1 lengths with minimum number of octets

### DIFF
--- a/internal/shim-kvm/src/snp/attestation.rs
+++ b/internal/shim-kvm/src/snp/attestation.rs
@@ -12,36 +12,90 @@ pub struct SnpReportResponseData {
     rsvd: [u8; 24],
 }
 
-/// writes a 6 byte header including a u32 length in big endian
-///
-/// helper function for ASN.1 encoding
-fn asn_len_header(header: &mut [u8], tag: u8, len: usize) -> Option<()> {
-    let len: u32 = len.try_into().ok()?;
-    header[0] = tag;
-    header[1] = 0x84; // 4 bytes of length
-    header[2..ASN_LEN_HEADER_SIZE].copy_from_slice(&len.to_be_bytes());
-    Some(())
-}
-
-const ASN_LEN_HEADER_SIZE: usize = 6;
-
 /// wraps a chunk with a header returning the total length
 ///
 /// helper function for ASN.1 encoding
 fn asn_wrap(
     chunks: &mut [u8],
-    header_len: usize,
-    header: impl Fn(&mut [u8], usize) -> Option<()>,
-    body: impl Fn(&mut [u8]) -> Option<usize>,
+    header_f: impl Fn(&mut [u8], usize) -> Option<usize>,
+    body_f: impl Fn(&mut [u8]) -> Option<usize>,
+    body_len_f: impl Fn() -> Option<usize>,
 ) -> Option<usize> {
+    let body_len = body_len_f()?;
+    let header_len = calc_asn_header_len(body_len)?;
+
     let (head_chunk, body_chunk) = chunks.split_at_mut(header_len);
 
-    let body_len = body(body_chunk)?;
+    let copied_body_len = body_f(body_chunk)?;
+    let copied_header_len = header_f(head_chunk, body_len)?;
 
-    header(head_chunk, body_len)?;
+    debug_assert_eq!(copied_body_len, body_len);
+    debug_assert_eq!(copied_header_len, header_len);
 
-    let len = header_len.checked_add(body_len)?;
+    let len = copied_header_len.checked_add(copied_body_len)?;
     Some(len)
+}
+
+/// writes a tag and the length encoded with a minimum number of octets
+///
+/// X.690 Section 10.1: DER lengths must be encoded with a minimum number of octets
+///
+/// helper function for ASN.1 encoding
+fn write_asn_header(header: &mut [u8], tag: u8, len: usize) -> Option<usize> {
+    let len: u32 = len.try_into().ok()?;
+
+    match len.to_be_bytes() {
+        [0, 0, 0, byte0] if byte0 < 0x80 => {
+            header[0] = tag;
+            header[1] = byte0;
+            Some(2)
+        }
+        [0, 0, 0, byte0] => {
+            header[0] = tag;
+            header[1] = 0x81;
+            header[2] = byte0;
+            Some(3)
+        }
+        [0, 0, byte1, byte0] => {
+            header[0] = tag;
+            header[1] = 0x82;
+            header[2] = byte1;
+            header[3] = byte0;
+            Some(4)
+        }
+        [0, byte2, byte1, byte0] => {
+            header[0] = tag;
+            header[1] = 0x83;
+            header[2] = byte2;
+            header[3] = byte1;
+            header[4] = byte0;
+            Some(5)
+        }
+        [byte3, byte2, byte1, byte0] => {
+            header[0] = tag;
+            header[1] = 0x84;
+            header[2] = byte3;
+            header[3] = byte2;
+            header[4] = byte1;
+            header[5] = byte0;
+            Some(6)
+        }
+    }
+}
+
+/// size of header for a tag and the length encoded with a minimum number of octets
+///
+/// helper function for ASN.1 encoding
+fn calc_asn_header_len(len: usize) -> Option<usize> {
+    let len: u32 = len.try_into().ok()?;
+
+    match len.to_be_bytes() {
+        [0, 0, 0, byte] if byte < 0x80 => Some(2),
+        [0, 0, 0, _] => Some(3),
+        [0, 0, _, _] => Some(4),
+        [0, _, _, _] => Some(5),
+        [_, _, _, _] => Some(6),
+    }
 }
 
 const ASN_SECTION_CONSTRUCTED: u8 = 0x30;
@@ -50,10 +104,10 @@ const ASN_OCTET_STRING: u8 = 0x04;
 /// Naive ASN.1 encoding for OID 1.3.6.1.4.1.58270.1.3
 pub fn asn1_encode_report_vcek(chunks: &mut [u8], report: &[u8], vcek: &[u8]) -> Option<usize> {
     let section_header =
-        |header: &mut [u8], body_len| asn_len_header(header, ASN_SECTION_CONSTRUCTED, body_len);
+        |header: &mut [u8], body_len| write_asn_header(header, ASN_SECTION_CONSTRUCTED, body_len);
 
     let octet_header =
-        |header: &mut [u8], body_len| asn_len_header(header, ASN_OCTET_STRING, body_len);
+        |header: &mut [u8], body_len| write_asn_header(header, ASN_OCTET_STRING, body_len);
 
     let report_chunk = |chunks: &mut [u8]| {
         // report data
@@ -61,14 +115,25 @@ pub fn asn1_encode_report_vcek(chunks: &mut [u8], report: &[u8], vcek: &[u8]) ->
         Some(report.len())
     };
 
+    let report_chunk_len_f = || Some(report.len());
+
     let vcek_report = |chunks: &mut [u8]| {
         // vcek data
         let (vcek_chunk, chunks) = chunks.split_at_mut(vcek.len());
         vcek_chunk.copy_from_slice(vcek);
-        let report_chunk_len = asn_wrap(chunks, ASN_LEN_HEADER_SIZE, octet_header, report_chunk)?;
+        let report_chunk_len = asn_wrap(chunks, octet_header, report_chunk, report_chunk_len_f)?;
         let len = report_chunk_len.checked_add(vcek.len())?;
         Some(len)
     };
 
-    asn_wrap(chunks, ASN_LEN_HEADER_SIZE, section_header, vcek_report)
+    let vcek_report_len_f = || {
+        let report_chunk_len = report_chunk_len_f()?;
+        let vcek_len = vcek.len();
+        let len = report_chunk_len
+            .checked_add(calc_asn_header_len(vcek_len)?)?
+            .checked_add(vcek_len)?;
+        Some(len)
+    };
+
+    asn_wrap(chunks, section_header, vcek_report, vcek_report_len_f)
 }


### PR DESCRIPTION
Encode the length with a minimum number of octets as required by some
decoders.

> X.690 Section 10.1: DER lengths must be encoded with a minimum number of octets

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
