### PR TITLE
feat(sgx): add feature disable-sgx-attestation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ backend-kvm = ["x86_64", "kvm-bindings", "kvm-ioctls"]
 backend-sgx = ["x86_64", "sgx", "ureq"]
 gdb = ["gdbstub"]
 dbg = []
+disable-sgx-attestation = []
 
 [dependencies]
 x86_64 = { version = "^0.14.8", default-features = false, optional = true }

--- a/build.rs
+++ b/build.rs
@@ -169,6 +169,9 @@ fn cargo_build_bin(
     #[cfg(feature = "dbg")]
     let cmd = cmd.arg("--features=dbg");
 
+    #[cfg(feature = "disable-sgx-attestation")]
+    let cmd = cmd.arg("--features=disable-sgx-attestation");
+
     let status = cmd.status()?;
 
     if !status.success() {
@@ -265,7 +268,8 @@ fn main() {
     {
         println!("cargo:rustc-cfg=host_can_test_sgx");
 
-        if std::path::Path::new(AESM_SOCKET).exists()
+        if (!cfg!(feature = "disable-sgx-attestation"))
+            && std::path::Path::new(AESM_SOCKET).exists()
             && fs::metadata(AESM_SOCKET).unwrap().file_type().is_socket()
         {
             println!("cargo:rustc-cfg=host_can_test_attestation");

--- a/internal/shim-kvm/Cargo.toml
+++ b/internal/shim-kvm/Cargo.toml
@@ -12,6 +12,7 @@ test = false
 [features]
 gdb = [ "gdbstub", "gdbstub_arch", "dbg" ]
 dbg = []
+disable-sgx-attestation = []
 
 [dependencies]
 x86_64 = { version = "0.14.8", default-features = false, features = ["instructions", "inline_asm"] }

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -12,6 +12,7 @@ test = false
 [features]
 gdb = [ "gdbstub", "gdbstub_arch", "dbg" ]
 dbg = []
+disable-sgx-attestation = []
 
 [dependencies]
 gdbstub_arch = { version = "0.1.1" , default-features = false, optional = true }

--- a/internal/shim-sgx/src/handler/mod.rs
+++ b/internal/shim-sgx/src/handler/mod.rs
@@ -255,6 +255,10 @@ impl<'a> Handler<'a> {
         buf: usize,
         buf_len: usize,
     ) -> Result<[usize; 2], c_int> {
+        if cfg!(feature = "disable-sgx-attestation") {
+            return Ok([0, 0]);
+        }
+
         let quote_size = self.get_sgx_quote_size()?;
 
         if buf == 0 {

--- a/src/backend/sgx/data.rs
+++ b/src/backend/sgx/data.rs
@@ -167,7 +167,7 @@ pub fn dev_sgx_enclave() -> Datum {
 pub fn aesm_socket() -> Datum {
     Datum {
         name: "AESM Daemon Socket".into(),
-        pass: Path::new(AESM_SOCKET).exists(),
+        pass: cfg!(feature = "disable-sgx-attestation") || Path::new(AESM_SOCKET).exists(),
         info: Some(AESM_SOCKET.into()),
         mesg: None,
     }


### PR DESCRIPTION
For sgx development, where the machine is offline or no proper aesmd/PCCS daemon setup is possible, the `disable-sgx-attestation` feature can be enabled.

The `get_attestation()` syscall will return (0, 0) in this case.

Closes: #1621
Closes: #1618

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
