### PR TITLE
fix(shim-kvm): correct ASN.1 encoding for SNP attestation

### DIFF
--- a/internal/shim-kvm/src/snp/attestation.rs
+++ b/internal/shim-kvm/src/snp/attestation.rs
@@ -130,7 +130,7 @@ pub fn asn1_encode_report_vcek(chunks: &mut [u8], report: &[u8], vcek: &[u8]) ->
         let report_chunk_len = report_chunk_len_f()?;
         let vcek_len = vcek.len();
         let len = report_chunk_len
-            .checked_add(calc_asn_header_len(vcek_len)?)?
+            .checked_add(calc_asn_header_len(report_chunk_len)?)?
             .checked_add(vcek_len)?;
         Some(len)
     };


### PR DESCRIPTION
The wrong sub-chunk length was used to calculate size of the combined
report + vcek chunk length.

This manifested in the rare case, where the vcek download failed and was
of size 0. This will be fixed in another PR.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
