### PR TITLE
fix(shim-kvm): fail SNP attestation for vcek of length 0

### DIFF
--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -15,7 +15,7 @@ use data::{
 use std::io;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use kvm_bindings::bindings::kvm_enc_region;
 use kvm_ioctls::VmFd;
 use sallyport::host::deref_slice;
@@ -62,6 +62,9 @@ impl KeepPersonality for SnpKeepPersonality {
                 };
                 let mut vcek_reader = get_vcek_reader()?;
                 *ret = std::io::copy(&mut vcek_reader, &mut vcek_buf)? as _;
+                if *ret == 0 {
+                    bail!("Could not get SEV-SNP vcek! Run `enarx snp vcek update`")
+                }
                 Ok(None)
             }
             _ => return Ok(Some(Item::Enarxcall(enarxcall, data))),


### PR DESCRIPTION
In the case, where the vcek could not be downloaded, fail early and also
safe guard inside the shim.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
