### PR TITLE
ci: remove stale toolchain overrides

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,10 @@ jobs:
           toolchain: nightly
           profile: minimal
       - name: Setup Rust toolchain
-        run: rustup show
-      - run: rustup target add wasm32-wasi
+        run: >
+            rustup override unset || :
+            && rustup target add wasm32-wasi
+            && rustup show
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.83.0",
  "wasmtime-types",
 ]
 
@@ -2101,7 +2101,7 @@ dependencies = [
  "ureq",
  "url",
  "wasi-common",
- "wasmparser",
+ "wasmparser 0.84.0",
  "wasmtime",
  "wasmtime-wasi",
  "wat",
@@ -2116,6 +2116,15 @@ name = "wasmparser"
 version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+
+[[package]]
+name = "wasmparser"
+version = "0.84.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "wasmtime"
@@ -2138,7 +2147,7 @@ dependencies = [
  "region",
  "serde",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.83.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-jit",
@@ -2164,7 +2173,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.83.0",
  "wasmtime-environ",
 ]
 
@@ -2184,7 +2193,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.83.0",
  "wasmtime-types",
 ]
 
@@ -2256,7 +2265,7 @@ dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.83.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Because there were some stale toolchain overrides from previous attempts, the cargo build failed with:
```
  --- stderr
  Unknown internal directory: shim-sgx
  ```

The culprit showed up as:
```
installed toolchains
--------------------

nightly-2022-03-23-x86_64-unknown-linux-gnu
nightly-2022-04-07-x86_64-unknown-linux-gnu
nightly-x86_64-unknown-linux-gnu (default)

installed targets for active toolchain
--------------------------------------

wasm32-wasi
x86_64-unknown-linux-gnu
x86_64-unknown-linux-musl

active toolchain
----------------

nightly-2022-04-07-x86_64-unknown-linux-gnu (directory override for '/runner/_work/enarx/enarx')
rustc 1.62.0-nightly (8f36334ca 2022-04-06)
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
