### PR TITLE
refactor: switch to `once_cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.83.0",
  "wasmtime-types",
 ]
 
@@ -518,6 +518,7 @@ dependencies = [
  "lset",
  "mmarinus",
  "nbytes",
+ "once_cell",
  "openssl",
  "primordial",
  "process_control",
@@ -532,7 +533,6 @@ dependencies = [
  "serial_test",
  "sev_attestation",
  "sgx",
- "spinning",
  "static_assertions",
  "tempfile",
  "ureq",
@@ -1640,15 +1640,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spinning"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spki"
 version = "0.6.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,7 +2092,7 @@ dependencies = [
  "ureq",
  "url",
  "wasi-common",
- "wasmparser",
+ "wasmparser 0.84.0",
  "wasmtime",
  "wasmtime-wasi",
  "wat",
@@ -2116,6 +2107,15 @@ name = "wasmparser"
 version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+
+[[package]]
+name = "wasmparser"
+version = "0.84.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "wasmtime"
@@ -2138,7 +2138,7 @@ dependencies = [
  "region",
  "serde",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.83.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-jit",
@@ -2164,7 +2164,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.83.0",
  "wasmtime-environ",
 ]
 
@@ -2184,7 +2184,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.83.0",
  "wasmtime-types",
 ]
 
@@ -2256,7 +2256,7 @@ dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.83.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ libc = "0.2"
 lset = "0.2"
 vdso = "0.2"
 log = "0.4"
-spinning = "0.1.0"
+once_cell = "1.10.0"
 env_logger = "0.9"
 ureq = { version = "2.4.0", optional = true }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use anyhow::{Error, Result};
 use libc::c_int;
 use mmarinus::{perms, Map};
+use once_cell::sync::Lazy;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
-use spinning::Lazy;
 
 trait Config: Sized {
     type Flags;

--- a/src/workldr/mod.rs
+++ b/src/workldr/mod.rs
@@ -23,7 +23,7 @@
 
 pub mod wasmldr;
 
-use spinning::Lazy;
+use once_cell::sync::Lazy;
 
 /// A trait for the "Workloader" - shortened to Workldr, also known as "exec"
 /// (as in Backend::keep(shim, exec) [q.v.]) and formerly known as the "code"


### PR DESCRIPTION
This pr replaces the uses of `spinning::Lazy` with `once_cell::sync::Lazy` in the main enarx binary. 

Closes #1517