### PR TITLE
fix: rebuild enarx bin when binary dependencies change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -206,6 +206,9 @@ fn main() {
     println!("cargo:rerun-if-env-changed=OUT_DIR");
     println!("cargo:rerun-if-env-changed=PROFILE");
 
+    // FIXME: this exists to work around https://github.com/rust-lang/cargo/issues/10527
+    println!("cargo:rerun-if-changed=src/bin");
+
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let out_dir_proto = out_dir.join("protos");
     create(&out_dir_proto);


### PR DESCRIPTION
This works around the Cargo bug reported at https://github.com/rust-lang/cargo/issues/10527 .

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
