### PR TITLE
build: bump Rust toolchain to 2022-04-07

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-03-23"
+channel = "nightly-2022-04-07"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "wasm32-wasi"]
 profile = "minimal"
 components = ["rust-src", "rustfmt", "clippy"]


### PR DESCRIPTION
@haraldh mentioned that he observed some test failures while previously attempting to bump the toolchain. Since we're going to need to bump the toolchain to get Tier 2 x86_64-unknown-none support, and since Tier 2 support unblocks bindeps for the shims, and since bindepping the shims is desirable for the next release, and since the next release is very soon, this PR is to get a head start on diagnosing any test failures.

This PR doesn't necessarily need to get merged, as it mostly exists just to exercise the CI on the new toolchain. However, if you wanted to merge it (assuming the tests pass) then that wouldn't hurt anything.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
