### PR TITLE
feat: no more `arch_prctl` syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "const-oid",
  "env_logger",
  "io-lifetimes 0.6.1",
+ "libc",
  "log",
  "pkcs8",
  "ring",
@@ -1584,6 +1585,9 @@ dependencies = [
 [[package]]
 name = "rust_exec_tests"
 version = "0.1.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/src/bin/shim-sgx/src/handler/mod.rs
+++ b/src/bin/shim-sgx/src/handler/mod.rs
@@ -44,7 +44,6 @@ use sallyport::guest::Handler as _;
 use sallyport::guest::{self, Platform, ThreadLocalStorage};
 use sallyport::item::enarxcall::sgx::{Report, ReportData, TargetInfo, TECH};
 use sallyport::item::enarxcall::SYS_GETATT;
-use sallyport::item::syscall::{ARCH_GET_FS, ARCH_GET_GS, ARCH_SET_FS, ARCH_SET_GS};
 use sallyport::libc::{
     off_t, EINVAL, EMSGSIZE, ENOMEM, ENOSYS, ENOTSUP, MAP_ANONYMOUS, MAP_PRIVATE, PROT_EXEC,
     PROT_READ, PROT_WRITE, STDERR_FILENO,
@@ -142,19 +141,11 @@ impl guest::Handler for Handler<'_> {
     fn arch_prctl(
         &mut self,
         _platform: &impl Platform,
-        code: c_int,
-        addr: c_ulong,
+        _code: c_int,
+        _addr: c_ulong,
     ) -> sallyport::Result<()> {
-        // TODO: Check that addr in %rdx does not point to an unmapped address
-        // and is not outside of the process address space.
-        match code {
-            ARCH_SET_FS => self.ssa.gpr.fsbase = addr,
-            ARCH_SET_GS => self.ssa.gpr.gsbase = addr,
-            ARCH_GET_FS => return Err(ENOSYS),
-            ARCH_GET_GS => return Err(ENOSYS),
-            _ => return Err(EINVAL),
-        }
-        Ok(())
+        debugln!(self, "arch_prctl should have never been called");
+        Err(ENOSYS)
     }
 
     fn brk(

--- a/src/bin/wasmldr/Cargo.toml
+++ b/src/bin/wasmldr/Cargo.toml
@@ -39,6 +39,7 @@ clap = { version = "3.1.6", default-features = false, features = ["derive", "std
 rustix = "0.34.1"
 url = { version = "2.2.2", features = ["serde"] }
 sha2 = "^0.10.2"
+libc = "0.2.102"
 
 [dev-dependencies]
 wat = "1.0"

--- a/src/bin/wasmldr/src/main.rs
+++ b/src/bin/wasmldr/src/main.rs
@@ -46,6 +46,7 @@
 #![deny(missing_docs)]
 #![deny(clippy::all)]
 #![warn(rust_2018_idioms)]
+#![feature(core_ffi_c)]
 
 mod config;
 mod loader;
@@ -68,8 +69,33 @@ use std::os::unix::prelude::AsRawFd;
 //
 
 use clap::Parser;
-
 use std::path::PathBuf;
+
+/// Set FSBASE
+///
+/// Overwrite the only location in musl, which uses the `arch_prctl` syscall
+#[no_mangle]
+pub extern "C" fn __set_thread_area(p: *mut std::ffi::c_void) -> std::ffi::c_int {
+    let mut rax: usize = 0;
+    if unsafe { core::arch::x86_64::__cpuid(7).ebx } & 1 == 1 {
+        unsafe {
+            std::arch::asm!("wrfsbase {}", in(reg) p);
+        }
+    } else {
+        const ARCH_SET_FS: std::ffi::c_int = 0x1002;
+        unsafe {
+            std::arch::asm!(
+            "syscall",
+            inlateout("rax")  libc::SYS_arch_prctl => rax,
+            in("rdi") ARCH_SET_FS,
+            in("rsi") p,
+            lateout("rcx") _, // clobbered
+            lateout("r11") _, // clobbered
+            );
+        }
+    }
+    rax as _
+}
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/tests/rust_exec_tests/Cargo.toml
+++ b/tests/rust_exec_tests/Cargo.toml
@@ -27,3 +27,4 @@ name="cpuid"
 path= "src/cpuid.rs"
 
 [dependencies]
+libc = "0.2.102"

--- a/tests/rust_exec_tests/src/cpuid.rs
+++ b/tests/rust_exec_tests/src/cpuid.rs
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#![feature(core_ffi_c)]
+
+use rust_exec_tests::musl_fsbase_fix;
+
+musl_fsbase_fix!();
+
 fn main() {
     let cpuid_result = unsafe { core::arch::x86_64::__cpuid_count(1, 0) };
 

--- a/tests/rust_exec_tests/src/echo.rs
+++ b/tests/rust_exec_tests/src/echo.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#![feature(core_ffi_c)]
+
+use rust_exec_tests::musl_fsbase_fix;
 use std::io::{self, Read, Write};
+
+musl_fsbase_fix!();
 
 fn main() -> io::Result<()> {
     let mut buffer = Vec::new();

--- a/tests/rust_exec_tests/src/lib.rs
+++ b/tests/rust_exec_tests/src/lib.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! musl_fsbase_fix
+
+#[macro_export]
+macro_rules! musl_fsbase_fix {
+    () => {
+        /// Set FSBASE
+        ///
+        /// Overwrite the only location in musl, which uses the `arch_prctl` syscall
+        #[no_mangle]
+        #[inline(never)]
+        pub extern "C" fn __set_thread_area(p: *mut std::ffi::c_void) -> std::ffi::c_int {
+            let mut rax: usize = 0;
+            if unsafe { core::arch::x86_64::__cpuid(7).ebx } & 1 == 1 {
+                unsafe {
+                    std::arch::asm!("wrfsbase {}", in(reg) p);
+                }
+            } else {
+                const ARCH_SET_FS: std::ffi::c_int = 0x1002;
+                unsafe {
+                    std::arch::asm!(
+                    "syscall",
+                    inlateout("rax")  libc::SYS_arch_prctl => rax,
+                    in("rdi") ARCH_SET_FS,
+                    in("rsi") p,
+                    lateout("rcx") _, // clobbered
+                    lateout("r11") _, // clobbered
+                    );
+                }
+            }
+            rax as _
+        }
+    }
+}

--- a/tests/rust_exec_tests/src/memory_stress_test.rs
+++ b/tests/rust_exec_tests/src/memory_stress_test.rs
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#![feature(core_ffi_c)]
+use rust_exec_tests::musl_fsbase_fix;
+
+musl_fsbase_fix!();
+
 const SIZE_32M: usize = 1024 * 1024 * 32;
 
 fn main() {

--- a/tests/rust_exec_tests/src/memspike.rs
+++ b/tests/rust_exec_tests/src/memspike.rs
@@ -4,7 +4,12 @@
 //! VM-based keeps. This will help test the ballooning itself as well
 //! as memory pinning for SEV.
 
+#![feature(core_ffi_c)]
+
+use rust_exec_tests::musl_fsbase_fix;
 use std::collections::TryReserveError;
+
+musl_fsbase_fix!();
 
 fn main() -> Result<(), TryReserveError> {
     let mut alloc: Vec<u8> = Vec::new();

--- a/tests/rust_exec_tests/src/unix_echo.rs
+++ b/tests/rust_exec_tests/src/unix_echo.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#![feature(core_ffi_c)]
+
+use rust_exec_tests::musl_fsbase_fix;
 use std::io::{self, stdin, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
+
+musl_fsbase_fix!();
 
 fn main() -> io::Result<()> {
     let mut dir_name = String::new();


### PR DESCRIPTION
Setting fsbase now even works in SGX.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
