### PR TITLE
ci: disable sgx testing, if host can't test

### DIFF
--- a/tests/c_integration_tests.rs
+++ b/tests/c_integration_tests.rs
@@ -151,7 +151,7 @@ fn get_att() {
 }
 
 #[cfg(feature = "backend-sgx")]
-#[cfg_attr(not(host_can_test_attestation), ignore)]
+#[cfg_attr(any(not(host_can_test_sgx), not(host_can_test_attestation)), ignore)]
 #[test]
 #[serial]
 fn sgx_get_att_quote() {
@@ -159,7 +159,7 @@ fn sgx_get_att_quote() {
 }
 
 #[cfg(feature = "backend-sgx")]
-#[cfg_attr(not(host_can_test_attestation), ignore)]
+#[cfg_attr(any(not(host_can_test_sgx), not(host_can_test_attestation)), ignore)]
 #[test]
 #[serial]
 fn sgx_get_att_quote_size() {


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
