### PR TITLE
feat: add clock_getres syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 [[package]]
 name = "sallyport"
 version = "0.3.0"
-source = "git+https://github.com/enarx/sallyport?rev=0b290de72c57569d94de6c3ead4570981c187c6c#0b290de72c57569d94de6c3ead4570981c187c6c"
+source = "git+https://github.com/enarx/sallyport?rev=867b54c50ca43569719b75db22d94199d80268e9#867b54c50ca43569719b75db22d94199d80268e9"
 dependencies = [
  "goblin",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ x86_64 = { version = "^0.14.9", default-features = false, optional = true }
 sgx = { version = "0.3.0", features = ["openssl"], optional = true }
 const-default = { version = "1.0", features = [ "derive" ] }
 primordial = { version = "0.4", features = ["alloc"] }
-sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "0b290de72c57569d94de6c3ead4570981c187c6c" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "867b54c50ca43569719b75db22d94199d80268e9" }
 kvm-bindings = { version = "0.5", optional = true }
 kvm-ioctls = { version = "0.11", optional = true }
 gdbstub = { version = "0.5.0", optional = true }

--- a/internal/shim-kvm/Cargo.lock
+++ b/internal/shim-kvm/Cargo.lock
@@ -337,7 +337,7 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 [[package]]
 name = "sallyport"
 version = "0.3.0"
-source = "git+https://github.com/enarx/sallyport?rev=0b290de72c57569d94de6c3ead4570981c187c6c#0b290de72c57569d94de6c3ead4570981c187c6c"
+source = "git+https://github.com/enarx/sallyport?rev=867b54c50ca43569719b75db22d94199d80268e9#867b54c50ca43569719b75db22d94199d80268e9"
 dependencies = [
  "goblin 0.5.1",
 ]

--- a/internal/shim-kvm/Cargo.toml
+++ b/internal/shim-kvm/Cargo.toml
@@ -22,7 +22,7 @@ goblin = { version = "0.5", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
 spinning = { version = "0.1", default-features = false }
 primordial = "0.4"
-sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "0b290de72c57569d94de6c3ead4570981c187c6c" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "867b54c50ca43569719b75db22d94199d80268e9" }
 xsave = { version = "2.0.2" }
 noted = "1.0.0"
 nbytes = "0.1"

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 [[package]]
 name = "sallyport"
 version = "0.3.0"
-source = "git+https://github.com/enarx/sallyport?rev=0b290de72c57569d94de6c3ead4570981c187c6c#0b290de72c57569d94de6c3ead4570981c187c6c"
+source = "git+https://github.com/enarx/sallyport?rev=867b54c50ca43569719b75db22d94199d80268e9#867b54c50ca43569719b75db22d94199d80268e9"
 dependencies = [
  "goblin 0.5.1",
 ]

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -21,7 +21,7 @@ goblin = { version = "0.5", default-features = false, features = [ "elf64" ] }
 primordial = { git = "https://github.com/enarx/primordial", rev = "b606b9e472e2238384b003f12fdada077e04d2fe", features = ["const-default"] }
 x86_64 = { version = "^0.14.9", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
-sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "0b290de72c57569d94de6c3ead4570981c187c6c" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "867b54c50ca43569719b75db22d94199d80268e9" }
 spinning = { version = "0.1", default-features = false }
 const-default = "1.0"
 noted = "^1.0.0"

--- a/tests/sev_attestation/Cargo.toml
+++ b/tests/sev_attestation/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "0b290de72c57569d94de6c3ead4570981c187c6c" }
+sallyport = { version = "0.3.0", git = "https://github.com/enarx/sallyport", rev = "867b54c50ca43569719b75db22d94199d80268e9" }
 
 [dev-dependencies]
 testaso = "0.1.0"


### PR DESCRIPTION
via a sallyport update

Fixes: https://github.com/enarx/enarx/issues/1657

```
     Running `target/release/enarx run /home/harald/Downloads/wasm_file.wasm`
Hello, World!
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
