### PR TITLE
build(shim-sgx): set mmledger version to 0.2.0

### DIFF
--- a/src/bin/shim-sgx/Cargo.toml
+++ b/src/bin/shim-sgx/Cargo.toml
@@ -29,7 +29,7 @@ xsave = { version = "2.0.2" }
 rcrt1 = "1.0.0"
 lset = { git = "https://github.com/enarx/lset", rev = "5c2feed24d85442725f55d812315854e1b29595d"  }
 sgx = { git = "https://github.com/enarx/sgx", rev = "f6de78316cdd74abf825dc3f6794f6f43f744e85" }
-mmledger = { git = "https://github.com/enarx/mmledger", rev = "843bd70e5266bcff912d651af0a9c07a413b5626" }
+mmledger = "0.2.0"
 
 [dev-dependencies]
 memoffset = "0.6.1"


### PR DESCRIPTION
Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
