### PR TITLE
fix: don't include the shim-kvm twice

### DIFF
--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -82,7 +82,7 @@ impl super::Backend for Backend {
 
     #[inline]
     fn shim(&self) -> &'static [u8] {
-        include_bytes!(env!("CARGO_BIN_FILE_ENARX_SHIM_KVM"))
+        super::kvm::Backend.shim()
     }
 
     #[inline]


### PR DESCRIPTION
before:

```
51309672 13. Apr 11:29 target/debug/enarx
```

after:

```
49908840 13. Apr 11:31 target/debug/enarx
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
