### PR TITLE
chore: put paths back for bindeps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,9 +566,9 @@ dependencies = [
  "colorful",
  "const-default",
  "dirs",
- "enarx-exec-wasmtime 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "enarx-shim-kvm 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "enarx-shim-sgx 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enarx-exec-wasmtime",
+ "enarx-shim-kvm",
+ "enarx-shim-sgx",
  "env_logger",
  "gdbstub",
  "goblin 0.5.1",
@@ -641,42 +641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enarx-exec-wasmtime"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f78eb91d95ae3c6e2a2f269fe6573efad4f24d08a408b415c4255d912845720"
-dependencies = [
- "anyhow",
- "cap-std",
- "clap",
- "const-oid",
- "env_logger",
- "io-lifetimes 0.6.1",
- "libc",
- "log",
- "pkcs8",
- "ring",
- "rustix 0.34.2",
- "rustls",
- "rustls-pemfile",
- "sec1",
- "serde",
- "sha2",
- "system-interface",
- "toml",
- "ureq",
- "url",
- "wasi-common",
- "wasmparser 0.84.0",
- "wasmtime",
- "wasmtime-wasi",
- "webpki-roots",
- "wiggle",
- "x509-cert",
- "zeroize",
-]
-
-[[package]]
 name = "enarx-shim-kvm"
 version = "0.4.0"
 dependencies = [
@@ -704,32 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enarx-shim-kvm"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ce1a9c84135127cfd1c529218ae897fd186c0b5f150d05e48c13e4504dc2eb"
-dependencies = [
- "aes-gcm",
- "array-const-fn-init",
- "bit_field",
- "bitflags",
- "const-default",
- "crt0stack",
- "goblin 0.5.1",
- "linked_list_allocator",
- "lock_api",
- "lset",
- "nbytes",
- "noted",
- "primordial",
- "rcrt1",
- "sallyport",
- "spinning",
- "x86_64",
- "xsave",
-]
-
-[[package]]
 name = "enarx-shim-sgx"
 version = "0.4.0"
 dependencies = [
@@ -740,27 +678,6 @@ dependencies = [
  "goblin 0.5.1",
  "lset",
  "memoffset",
- "mmledger",
- "noted",
- "primordial",
- "rcrt1",
- "sallyport",
- "sgx",
- "spinning",
- "x86_64",
- "xsave",
-]
-
-[[package]]
-name = "enarx-shim-sgx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a639cb028469847f85fee3d8dc98a57050601ddb78b11795e62ea4d7fb5aa486"
-dependencies = [
- "const-default",
- "crt0stack",
- "goblin 0.5.1",
- "lset",
  "mmledger",
  "noted",
  "primordial",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ atty = "0.2"
 dirs = "4.0"
 
 # binary dependencies
-enarx-shim-kvm = { version = "0.4.0", artifact = "bin", target = "x86_64-unknown-none" }
-enarx-shim-sgx = { version = "0.4.0", artifact = "bin", target = "x86_64-unknown-none" }
-enarx-exec-wasmtime = { version = "0.4.0", artifact = "bin", target = "x86_64-unknown-linux-musl" }
+enarx-shim-kvm = { version = "0.4.0", path = "src/bin/shim-kvm", artifact = "bin", target = "x86_64-unknown-none" }
+enarx-shim-sgx = { version = "0.4.0", path = "src/bin/shim-sgx", artifact = "bin", target = "x86_64-unknown-none" }
+enarx-exec-wasmtime = { version = "0.4.0", path = "src/bin/exec-wasmtime", artifact = "bin", target = "x86_64-unknown-linux-musl" }
 
 # h2 is an indirect dependency, to be specified when checking with `-Z minimal-versions`
 # h2 is a dependency of hyper, which is a dep of reqwest


### PR DESCRIPTION
We removed these paths for the 0.4 release as an extremely conservative measure, due to being wary of potential bugs in Cargo's unstable bindeps support. Since no bugs were revealed during the publish, this adds those paths back. We don't need to worry about doing this again in future releases.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
