### PR TITLE
fix(exec-wasmtime): mark registers clobbered

### DIFF
--- a/src/bin/exec-wasmtime/src/loader/configured/platform.rs
+++ b/src/bin/exec-wasmtime/src/loader/configured/platform.rs
@@ -50,6 +50,8 @@ impl Platform {
                 in("rsi") nonce.map(|x| x.len()).unwrap_or_default(),
                 in("rdx") buf.as_mut().map(|x| x.as_mut_ptr()).unwrap_or_else(null_mut),
                 in("r10") buf.map(|x| x.len()).unwrap_or_default(),
+                lateout("rcx") _, // clobbered
+                lateout("r11") _, // clobbered
             )
         }
 


### PR DESCRIPTION
Although we always mark `rcx` and `r11` clobbered
in all existing syscall asm blocks, they were missing here.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
