### PR TITLE
fix(exec-wasmtime): handle EPERM for get_att() syscall

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
             flags: --no-default-features --features=backend-kvm
           - name: exec-wasmtime
             path: ./crates/exec-wasmtime
-            host: ubuntu-20.04 # enarx syscall returns -EPERM on self-hosted (podman??)
+            host: [ self-hosted, linux ]
           - name: shim-kvm
             path: ./crates/shim-kvm
             host: [ self-hosted, linux ]

--- a/crates/exec-wasmtime/src/loader/configured/platform.rs
+++ b/crates/exec-wasmtime/src/loader/configured/platform.rs
@@ -36,7 +36,9 @@ impl Platform {
     const SYS_GETATT: usize = 0xEA01;
 
     fn get_att(nonce: Option<&[u8]>, mut buf: Option<&mut [u8]>) -> Result<Self> {
-        const ENOSYS: isize = -38;
+        const ENOSYS: isize = -(libc::ENOSYS as isize);
+        const EPERM: isize = -(libc::EPERM as isize);
+
         let mut rax;
         let mut rdx;
 
@@ -56,7 +58,7 @@ impl Platform {
         }
 
         match (rax, rdx) {
-            (ENOSYS, ..) => Ok(Self(Technology::Kvm, 0)),
+            (ENOSYS | EPERM, ..) => Ok(Self(Technology::Kvm, 0)),
             (n, ..) if n < 0 => Err(std::io::Error::from_raw_os_error(-n as i32)),
             (n, t) => match t {
                 0 => Ok(Self(Technology::Kvm, n as _)),


### PR DESCRIPTION
In the podman container the enarx syscall returns EPERM.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
