### PR TITLE
refactor: switch from openssl to rcrypto

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@
 
 ### Fedora
 
-    $ sudo dnf install git curl gcc pkg-config openssl-devel musl-gcc
+    $ sudo dnf install git curl gcc musl-gcc
 
 ### Disclaimer
 
@@ -29,7 +29,7 @@ Failure to do so might result in weird failures at runtime.
 ### CentOS 8 / Stream
 
     $ sudo dnf copr enable ngompa/musl-libc
-    $ sudo dnf install git curl gcc-toolset-9 openssl-devel musl-gcc
+    $ sudo dnf install git curl gcc-toolset-9 musl-gcc
     $ source "/opt/rh/gcc-toolset-9/enable"
 
 Note: you may want to add that final `source` command to a `~/.profile`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cap-fs-ext"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +331,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
+name = "const-oid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
@@ -452,6 +464,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9274b445ee572d50bdeb17a1101be829becc565b5c12b21a697af4d360b48e8d"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,11 +494,22 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid 0.7.1",
+ "crypto-bigint",
+ "pem-rfc7468",
+]
+
+[[package]]
+name = "der"
 version = "0.6.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3ed717eef39a802bcfbfefed277ffe0639c53ad7720753646d21d2bd6074fe1"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.0",
  "der_derive",
  "flagset",
 ]
@@ -606,10 +639,10 @@ dependencies = [
  "anyhow",
  "cap-std",
  "clap",
- "const-oid",
+ "const-oid 0.9.0",
  "env_logger",
  "libc",
- "pkcs8",
+ "pkcs8 0.9.0-pre.1",
  "ring",
  "rustix 0.34.4",
  "rustls",
@@ -723,21 +756,6 @@ name = "flagset"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1029,6 +1047,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128"
@@ -1041,6 +1062,12 @@ name = "libc"
 version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+
+[[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked_list_allocator"
@@ -1169,12 +1196,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9ed3de88cf5f12b1b461eb59a5b85f60d84216207bda41bf0f0eb2d7d51d397"
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1208,33 +1274,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_str_bytes"
@@ -1274,6 +1313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,20 +1334,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
+name = "pkcs1"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+dependencies = [
+ "der 0.5.1",
+ "pkcs8 0.8.0",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der 0.5.1",
+ "spki 0.5.4",
+ "zeroize",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f39eca6cd63c3c92cf3d7bec60872b6e7a7542dbd03c9a164559e13e22c2a708"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.0-pre.3",
+ "spki 0.6.0-pre.2",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plain"
@@ -1538,6 +1602,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+dependencies = [
+ "byteorder",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.8.0",
+ "rand_core",
+ "smallvec",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rust_exec_tests"
 version = "0.1.0"
 dependencies = [
@@ -1686,7 +1770,7 @@ version = "0.3.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2a39b189e5764ec7067feb68646cced103360538af8a006616e387eb0d6e05"
 dependencies = [
- "der",
+ "der 0.6.0-pre.3",
  "generic-array",
 ]
 
@@ -1766,7 +1850,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1f19d6fdd241e6d507c924f95f9b86a90f13b52d84f7676f55114dba8175179"
 dependencies = [
  "bitflags",
- "openssl",
+ "num-integer",
+ "num-traits",
+ "rand",
+ "rsa",
+ "sha2",
  "x86_64",
  "xsave",
 ]
@@ -1814,12 +1902,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der 0.5.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.6.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093b274198792f2e7026c661f658c74fc4ab023212474878dff187eb98736db1"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.0-pre.3",
 ]
 
 [[package]]
@@ -2056,12 +2154,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdso"
@@ -2564,10 +2656,10 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08fda23a1ea0b7f7d229f49b99b6635f3106b3630b8920e815a0009e6fc384e"
 dependencies = [
- "const-oid",
- "der",
+ "const-oid 0.9.0",
+ "der 0.6.0-pre.3",
  "flagset",
- "spki",
+ "spki 0.6.0-pre.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "array-const-fn-init"
@@ -100,16 +100,16 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.28.3",
  "rustc-demangle",
 ]
 
@@ -186,7 +186,7 @@ dependencies = [
  "io-lifetimes 0.5.3",
  "ipnet",
  "maybe-owned",
- "rustix 0.33.6",
+ "rustix 0.33.7",
  "winapi",
  "winapi-util",
  "winx",
@@ -212,7 +212,7 @@ dependencies = [
  "io-extras",
  "io-lifetimes 0.5.3",
  "ipnet",
- "rustix 0.33.6",
+ "rustix 0.33.7",
 ]
 
 [[package]]
@@ -223,7 +223,7 @@ checksum = "b9ee4390904645f384bd4e03125a4ed4d1167e9f195931c41323bacc8a2328ce"
 dependencies = [
  "cap-primitives",
  "once_cell",
- "rustix 0.33.6",
+ "rustix 0.33.7",
  "winx",
 ]
 
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.10"
+version = "3.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3124f3f75ce09e22d1410043e1e24f2ecc44fad3afe4f08408f1f7663d68da2b"
+checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -756,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df62ee66ee2d532ea8d567b5a3f0d03ecd64636b98bad5be1e93dcc918b92aa"
 dependencies = [
  "io-lifetimes 0.5.3",
- "rustix 0.33.6",
+ "rustix 0.33.7",
  "winapi",
 ]
 
@@ -964,9 +964,9 @@ checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
 
 [[package]]
 name = "ipnet"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "is-terminal"
@@ -976,7 +976,7 @@ checksum = "7c89a757e762896bdbdfadf2860d0f8b0cea5e363d8cf3e7bdfeb63d1d976352"
 dependencies = [
  "hermit-abi 0.2.0",
  "io-lifetimes 0.5.3",
- "rustix 0.33.6",
+ "rustix 0.33.7",
  "winapi",
 ]
 
@@ -1123,12 +1123,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -1186,6 +1185,15 @@ checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "crc32fast",
  "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+dependencies = [
  "memchr",
 ]
 
@@ -1559,9 +1567,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.33.6"
+version = "0.33.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac32d9fc97153ca55305284cb6c2dcbb84e1fc6d7ac13392cea02222f2d8741"
+checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
 dependencies = [
  "bitflags",
  "errno",
@@ -1753,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "sgx"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36edd35c08990a7890efa046107de032a321c07b61e1a1b0ebbcbae673cdf08"
+checksum = "e1f19d6fdd241e6d507c924f95f9b86a90f13b52d84f7676f55114dba8175179"
 dependencies = [
  "bitflags",
  "openssl",
@@ -1854,7 +1862,7 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "io-lifetimes 0.5.3",
- "rustix 0.33.6",
+ "rustix 0.33.7",
  "winapi",
  "winx",
 ]
@@ -1937,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -1961,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfce9f3241b150f36e8e54bb561a742d5daa1a47b5dd9a5ce369fd4a4db2210"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
 ]
@@ -2110,7 +2118,7 @@ dependencies = [
  "io-lifetimes 0.5.3",
  "is-terminal",
  "lazy_static",
- "rustix 0.33.6",
+ "rustix 0.33.7",
  "system-interface",
  "tracing",
  "wasi-common",
@@ -2127,7 +2135,7 @@ dependencies = [
  "bitflags",
  "cap-rand",
  "cap-std",
- "rustix 0.33.6",
+ "rustix 0.33.7",
  "thiserror",
  "tracing",
  "wiggle",
@@ -2212,7 +2220,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "object",
+ "object 0.27.1",
  "once_cell",
  "paste",
  "psm",
@@ -2242,7 +2250,7 @@ dependencies = [
  "gimli",
  "log",
  "more-asserts",
- "object",
+ "object 0.27.1",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -2261,7 +2269,7 @@ dependencies = [
  "indexmap",
  "log",
  "more-asserts",
- "object",
+ "object 0.27.1",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -2282,10 +2290,10 @@ dependencies = [
  "cpp_demangle",
  "gimli",
  "log",
- "object",
+ "object 0.27.1",
  "region",
  "rustc-demangle",
- "rustix 0.33.6",
+ "rustix 0.33.7",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -2321,7 +2329,7 @@ dependencies = [
  "more-asserts",
  "rand",
  "region",
- "rustix 0.33.6",
+ "rustix 0.33.7",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-jit-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ vdso = { version = "0.2", default-features = false }
 gdbstub = { version = "0.5.0", optional = true, features = ["std"], default-features = false }
 kvm-bindings = { version = "0.5", optional = true, default-features = false }
 kvm-ioctls = { version = "0.11", optional = true, default-features = false }
-sgx = { version = "0.4.0", optional = true, features = ["openssl"], default-features = false }
+sgx = { version = "0.4.1", optional = true, features = ["rcrypto"], default-features = false }
 ureq = { version = "2.4.0", optional = true, default-features = false }
 x86_64 = { version = "0.14.9", optional = true, default-features = false }
 
@@ -88,6 +88,9 @@ opt-level = "s"
 strip = true
 
 [profile.dev.package.rcrt1]
+opt-level = 3
+
+[profile.dev.package.num-bigint-dig]
 opt-level = 3
 
 [workspace]

--- a/flake.nix
+++ b/flake.nix
@@ -24,14 +24,9 @@
         devShell = pkgs.mkShell.override { stdenv = pkgs.stdenvNoCC; } {
           buildInputs = (with pkgs; [
             gcc11
-            openssl
             musl
           ]) ++ [
             rust
-          ];
-
-          nativeBuildInputs = with pkgs; [
-            pkg-config
           ];
 
           shellHook = ''
@@ -79,9 +74,6 @@
             ENARX_PREBUILT_exec-wasmtime = "${execWasmtime}/bin/exec-wasmtime";
 
             CARGO_BUILD_TARGET = "x86_64-unknown-linux-gnu";
-
-            nativeBuildInputs = [ pkgs.pkg-config ];
-            buildInputs = [ pkgs.openssl ];
 
             doCheck = true;
             preCheck = ''

--- a/src/backend/sgx/builder.rs
+++ b/src/backend/sgx/builder.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::{Context, Error, Result};
 use mmarinus::{perms, Kind, Map};
 use primordial::Page;
-use sgx::crypto::{openssl::*, *};
+use sgx::crypto::{rcrypto::*, *};
 use sgx::page::{Class, Flags, SecInfo};
 use sgx::signature::{Author, Hasher, Signature};
 

--- a/src/backend/sgx/hasher.rs
+++ b/src/backend/sgx/hasher.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use anyhow::{Error, Result};
 use sgx::page::SecInfo;
 
-pub struct Hasher(sgx::signature::Hasher<sgx::crypto::openssl::S256Digest>);
+pub struct Hasher(sgx::signature::Hasher<sgx::crypto::rcrypto::S256Digest>);
 
 impl TryFrom<super::config::Config> for Hasher {
     type Error = Error;


### PR DESCRIPTION
This makes enarx easier to build. It also means we can hopefully provide
a binary that doesn't depend on system libraries besides libc. This is a
step towards an official release binary.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>