### PR TITLE
ci: enable fast-fail on coverage, lint, and test jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,6 @@ jobs:
       ENARX_BACKEND: ${{ matrix.crate.name }}
 
     strategy:
-      fail-fast: false
       matrix:
         crate:
           # If you change the number of elements here, also adjust /.codecov.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,6 @@ jobs:
           command: fmt
           args: --manifest-path=${{ matrix.crate.path }} -- --check
     strategy:
-      fail-fast: false
       matrix:
         crate:
           - {name: enarx, path: Cargo.toml}
@@ -42,7 +41,6 @@ jobs:
           command: clippy
           args: ${{ matrix.crate.target }} --all-features --manifest-path=${{ matrix.crate.path }} -- -D warnings
     strategy:
-      fail-fast: false
       matrix:
         crate:
           - {name: enarx, path: Cargo.toml}
@@ -77,7 +75,6 @@ jobs:
           command: clippy
           args: ${{ matrix.profile.flag }} --no-default-features --features=backend-${{ matrix.backend.name }} --examples -- -D warnings
     strategy:
-      fail-fast: false
       matrix:
         backend:
           - {name: sev, host: [self-hosted, linux, sev-snp]}
@@ -97,7 +94,6 @@ jobs:
         with:
           arguments: --workspace --manifest-path=${{ matrix.crate.path }}
     strategy:
-      fail-fast: false
       matrix:
         crate:
           - {name: enarx, path: ./Cargo.toml}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
           command: test
           args: ${{ matrix.profile.flag }} --no-default-features --features=backend-${{ matrix.backend.name }}
     strategy:
-      fail-fast: false
       matrix:
         backend:
           - {name: sev, host: [self-hosted, linux, sev-snp]}
@@ -58,7 +57,6 @@ jobs:
           command: build
           args: ${{ matrix.profile.flag }}
     strategy:
-      fail-fast: false
       matrix:
         profile:
           - name: default-features
@@ -76,7 +74,6 @@ jobs:
         run: rustup show
       - run: cargo test ${{ matrix.profile.flag }} --target x86_64-unknown-linux-gnu --manifest-path ${{ matrix.crate.path }}/Cargo.toml
     strategy:
-      fail-fast: false
       matrix:
         crate:
           - { name: exec-wasmtime, path: crates/exec-wasmtime }
@@ -110,7 +107,6 @@ jobs:
           command: miri
           args: test --manifest-path ${{ matrix.crate.path }}/Cargo.toml
     strategy:
-      fail-fast: false
       matrix:
         crate:
           - { name: sallyport, path: crates/sallyport }


### PR DESCRIPTION
Enable fast-fail (enabled by default) for coverage, lint, and test jobs.

Closes #1753

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
