### PR TITLE
fix(exec-wasmtime): use ureq with tls feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -2139,7 +2140,10 @@ dependencies = [
  "chunked_transfer",
  "log",
  "once_cell",
+ "rustls",
  "url",
+ "webpki",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/crates/exec-wasmtime/Cargo.toml
+++ b/crates/exec-wasmtime/Cargo.toml
@@ -26,7 +26,7 @@ sec1 = { version = "0.3.0-pre.1", features = ["der"], default-features = false }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 sha2 = { version = "0.10.2", default-features = false }
 toml = { version = "0.5.9", default-features = false }
-ureq = { version = "2.4.0", default-features = false }
+ureq = { version = "2.4.0", features = ["tls"], default-features = false }
 url = { version = "2.2.2", features = ["serde"], default-features = false }
 wasi-common = { version = "0.35.2", default-features = false }
 wasmtime = { version = "0.35.2", features = ["cranelift", "pooling-allocator"], default-features = false }


### PR DESCRIPTION
Otherwise the steward cannot be connected via `https`.

Fixup of commit 5639b589079563299211d23b919554e69a5becf6, which removed
all default features.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
