### PR TITLE
fix: propagate features to bindeps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ backend-sev = ["backend-kvm", "ureq"]
 backend-sgx = ["sgx", "ureq", "x86_64"]
 
 # non-default features
-gdb = ["gdbstub"]
-dbg = []
-disable-sgx-attestation = []
+gdb = ["gdbstub", "enarx-shim-kvm/gdb", "enarx-shim-sgx/gdb"]
+dbg = [ "enarx-shim-kvm/dbg", "enarx-shim-sgx/dbg" ]
+disable-sgx-attestation = ["enarx-shim-sgx/disable-sgx-attestation"]
 
 [dependencies]
 anyhow = { version = "1.0.56", features = ["std"], default-features = false }

--- a/crates/exec-wasmtime/Cargo.toml
+++ b/crates/exec-wasmtime/Cargo.toml
@@ -7,10 +7,6 @@ authors = ["The Enarx Project Developers"]
 repository = "https://github.com/enarx/enarx"
 license = "Apache-2.0"
 
-[features]
-dbg = []
-gdb = []
-
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
 cap-std = { version = "0.24.2", default-features = false }

--- a/crates/shim-kvm/Cargo.toml
+++ b/crates/shim-kvm/Cargo.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 [features]
 gdb = ["gdbstub", "gdbstub_arch", "dbg"]
 dbg = []
-disable-sgx-attestation = []
 
 [dependencies]
 aes-gcm = { version = "0.9", features = ["force-soft"], default-features = false }


### PR DESCRIPTION
Fixup of commit 5639b589079563299211d23b919554e69a5becf6, which removed
all default features.

Fixes: #1780

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
