### PR TITLE
ci(actions): assorted GH workflow related fixes

### DIFF
--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -1,6 +1,5 @@
 on:
   workflow_dispatch:
-    branches: [ main ]
   schedule:
     - cron: '15 3 * * 4'
 concurrency:

--- a/.github/workflows/rust-toolchain-update.yml
+++ b/.github/workflows/rust-toolchain-update.yml
@@ -1,6 +1,5 @@
 on:
   workflow_dispatch:
-    branches: [ main ]
   schedule:
     - cron: '15 4 * * 4'
 concurrency:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -2,7 +2,6 @@ name: test-docs
 
 on:
   workflow_dispatch:
-    branches: [ main ]
   schedule:
     - cron: '5 1 * * *'
 

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -38,7 +38,7 @@ jobs:
           - name: centos7
           - name: centos8
         context:
-          - name: "git,helloworld"
+          - name: "git,helloworld,helloworld-git"
           - name: "crates,helloworld"
         document:
           - name: "docs/Install.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,4 +97,4 @@ opt-level = 3
 opt-level = 3
 
 [workspace]
-members = ["crates/*"]
+members = ["crates/*", "examples/*"]

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -236,7 +236,7 @@ $ cargo +nightly build --release --target=wasm32-wasi
 
 Assuming you did install the `enarx` binary and have it in your `$PATH`, you can
 now run the WebAssembly program in an Enarx keep.
-```sh:kvm-helloworld;
+```sh:helloworld-git;
 $ enarx run target/wasm32-wasi/release/hello-world.wasm
 ```
 ```console
@@ -250,7 +250,7 @@ If you want to suppress the debug output, add `2>/dev/null`.
 `enarx` will probe the machine it is running on in an attempt to deduce an
 appropriate deployment backend. To see what backends are supported on your
 system, run:
-```sh:kvm-backend,sgx-backend,snp-backend;
+```sh:git;
 $ enarx info
 ```
 You can manually select a backend with the `--backend` option, or by


### PR DESCRIPTION
- Fix `workflow_dispatch` to enable on-demand workflow execution
- Address bug caused by `examples/tcp_server` not excluded from workspace
- Enable tests for executing `enarx` using `nil` backend on workflows