### PR TITLE
fix: use `core::ffi` for `std::ffi::c_*`

### DIFF
--- a/crates/sallyport/tests/integration_tests/syscall.rs
+++ b/crates/sallyport/tests/integration_tests/syscall.rs
@@ -3,6 +3,7 @@
 use super::{run_test, write_tcp};
 use crate::integration_tests::recv_udp;
 
+use core::ffi::{c_char, c_int};
 use libc::{
     self, in_addr, iovec, pollfd, sockaddr, sockaddr_in, timespec, timeval, utsname, SYS_accept,
     SYS_accept4, SYS_bind, SYS_clock_getres, SYS_clock_gettime, SYS_close, SYS_fcntl, SYS_fstat,
@@ -16,7 +17,7 @@ use libc::{
     SOL_SOCKET, SO_RCVTIMEO, SO_REUSEADDR, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
 };
 use std::env::temp_dir;
-use std::ffi::{c_char, c_int, CString};
+use std::ffi::CString;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, Write};
 use std::mem::{size_of, transmute};

--- a/tests/rust_exec_tests/src/lib.rs
+++ b/tests/rust_exec_tests/src/lib.rs
@@ -10,16 +10,16 @@ macro_rules! musl_fsbase_fix {
         /// Overwrite the only location in musl, which uses the `arch_prctl` syscall
         #[no_mangle]
         #[inline(never)]
-        pub extern "C" fn __set_thread_area(p: *mut std::ffi::c_void) -> std::ffi::c_int {
+        pub extern "C" fn __set_thread_area(p: *mut core::ffi::c_void) -> core::ffi::c_int {
             let mut rax: usize = 0;
             if unsafe { core::arch::x86_64::__cpuid(7).ebx } & 1 == 1 {
                 unsafe {
-                    std::arch::asm!("wrfsbase {}", in(reg) p);
+                    core::arch::asm!("wrfsbase {}", in(reg) p);
                 }
             } else {
-                const ARCH_SET_FS: std::ffi::c_int = 0x1002;
+                const ARCH_SET_FS: core::ffi::c_int = 0x1002;
                 unsafe {
-                    std::arch::asm!(
+                    core::arch::asm!(
                     "syscall",
                     inlateout("rax")  libc::SYS_arch_prctl => rax,
                     in("rdi") ARCH_SET_FS,


### PR DESCRIPTION
For [`nightly-2022-05-03`](https://github.com/enarx/enarx/actions/runs/2262784577):

```
 19 | use std::ffi::{c_char, c_int, CString};
   |                ^^^^^^  ^^^^^ no `c_int` in `ffi`
   |                |
   |                no `c_char` in `ffi`
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
