### PR TITLE
fix: use `core::ffi` for `std::ffi::c_*`

### DIFF
--- a/crates/exec-wasmtime-bin/src/main.rs
+++ b/crates/exec-wasmtime-bin/src/main.rs
@@ -13,14 +13,14 @@ use enarx_exec_wasmtime::{execute, Args};
 ///
 /// Overwrite the only location in musl, which uses the `arch_prctl` syscall
 #[no_mangle]
-pub extern "C" fn __set_thread_area(p: *mut std::ffi::c_void) -> std::ffi::c_int {
+pub extern "C" fn __set_thread_area(p: *mut core::ffi::c_void) -> core::ffi::c_int {
     let mut rax: usize = 0;
     if unsafe { core::arch::x86_64::__cpuid(7).ebx } & 1 == 1 {
         unsafe {
             std::arch::asm!("wrfsbase {}", in(reg) p);
         }
     } else {
-        const ARCH_SET_FS: std::ffi::c_int = 0x1002;
+        const ARCH_SET_FS: core::ffi::c_int = 0x1002;
         unsafe {
             std::arch::asm!(
             "syscall",

--- a/tests/sev_attestation/src/main.rs
+++ b/tests/sev_attestation/src/main.rs
@@ -109,7 +109,7 @@ impl TryFrom<u64> for TeeTech {
 ///
 /// Overwrite the only location in musl, which uses the `arch_prctl` syscall
 #[no_mangle]
-pub extern "C" fn __set_thread_area(p: *mut std::ffi::c_void) -> std::ffi::c_int {
+pub extern "C" fn __set_thread_area(p: *mut core::ffi::c_void) -> core::ffi::c_int {
     let mut rax: usize = 0;
     if unsafe { core::arch::x86_64::__cpuid(7).ebx } & 1 == 1 {
         unsafe {


### PR DESCRIPTION
For `nightly-2022-05-03`:

```
 19 | use std::ffi::{c_char, c_int, CString};
   |                ^^^^^^  ^^^^^ no `c_int` in `ffi`
   |                |
   |                no `c_char` in `ffi`
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
