### PR TITLE
feat(rust_syscall_tests): use the `rcrt1::x86_64_linux_startup!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "rcrt1"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bfa166b68f87b2625d5cdacb056ffe5a673d82742ba92c080d53d274e312e"
+checksum = "4f8a99a72ca3e4288ba1beac8418e6602a4d519efaecdc5844370b02cbd980e3"
 dependencies = [
  "goblin",
  "libc",

--- a/crates/shim-kvm/Cargo.toml
+++ b/crates/shim-kvm/Cargo.toml
@@ -22,7 +22,7 @@ lset = { version = "0.3", default-features = false }
 nbytes = { version = "0.1", default-features = false }
 noted = { version = "1.0.0", default-features = false }
 primordial = { version = "0.5", default-features = false }
-rcrt1 = { version = "2.2.0", default-features = false }
+rcrt1 = { version = "2.4.0", default-features = false }
 sallyport = { version = "0.4.0", path = "../sallyport", default-features = false }
 spinning = { version = "0.1", default-features = false }
 x86_64 = { version = "0.14.9", features = ["instructions", "inline_asm"], default-features = false }

--- a/crates/shim-sgx/Cargo.toml
+++ b/crates/shim-sgx/Cargo.toml
@@ -19,7 +19,7 @@ goblin = { version = "0.5", features = ["elf64"], default-features = false }
 mmledger = { git = "https://github.com/enarx/mmledger", rev = "a19f609", default-features = false }
 noted = { version = "1.0.0", default-features = false }
 primordial = { version = "0.5.0", features = ["const-default"], default-features = false }
-rcrt1 = { version = "2.2.0", default-features = false }
+rcrt1 = { version = "2.4.0", default-features = false }
 sallyport = { version = "0.4.0", path = "../sallyport", default-features = false }
 sgx = { git = "https://github.com/enarx/sgx", rev = "3530660", default-features = false }
 spinning = { version = "0.1", default-features = false }

--- a/tests/rust_syscall_tests/Cargo.toml
+++ b/tests/rust_syscall_tests/Cargo.toml
@@ -6,5 +6,5 @@ license = "Apache-2.0"
 
 [dependencies]
 goblin = { version = "0.5", features = ["elf64"], default-features = false }
-rcrt1 = { version = "2.2.0", default-features = false }
+rcrt1 = { version = "2.4.0", default-features = false }
 sallyport = { path = "../../crates/sallyport", default-features = false }

--- a/tests/rust_syscall_tests/src/io.rs
+++ b/tests/rust_syscall_tests/src/io.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Traits, helpers, and type definitions for core I/O functionality.
+
+use core::fmt;
+
+struct Stdio<const FD: i32>;
+
+impl<const FD: i32> fmt::Write for Stdio<FD> {
+    #[inline(always)]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        super::write(FD, s.as_ptr(), s.len()).map_err(|_| fmt::Error)?;
+        Ok(())
+    }
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _eprint(args: fmt::Arguments<'_>) {
+    use core::fmt::Write;
+    Stdio::<2>.write_fmt(args).unwrap();
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _print(args: fmt::Arguments<'_>) {
+    use core::fmt::Write;
+    Stdio::<1>.write_fmt(args).unwrap();
+}

--- a/tests/rust_syscall_tests/src/macros.rs
+++ b/tests/rust_syscall_tests/src/macros.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Standard library macros
+
+/// Prints to the standard error.
+#[macro_export]
+macro_rules! eprint {
+    ($($arg:tt)*) => {
+        $crate::io::_eprint(format_args!($($arg)*))
+    };
+}
+
+/// Prints to the standard error of the host, with a newline.
+#[macro_export]
+macro_rules! eprintln {
+    () => ($crate::eprint!("\n"));
+    ($fmt:expr) => ($crate::eprint!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::eprint!(concat!($fmt, "\n"), $($arg)*));
+}
+
+/// Prints to the standard output of the host.
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {
+      $crate::io::_print(format_args!($($arg)*));
+    };
+}
+
+/// Prints to the standard output of the host, with a newline.
+#[macro_export]
+macro_rules! println {
+    () => ($crate::print!("\n"));
+    ($fmt:expr) => ($crate::print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::print!(concat!($fmt, "\n"), $($arg)*));
+}
+
+/// Prints and returns the value of a given expression for quick and dirty
+/// debugging.
+#[macro_export]
+macro_rules! dbg {
+    () => {
+        $crate::eprintln!("[{}:{}]", file!(), line!());
+    };
+    ($val:expr $(,)?) => {
+        // Use of `match` here is intentional because it affects the lifetimes
+        // of temporaries - https://stackoverflow.com/a/48732525/1063961
+        match $val {
+            tmp => {
+                $crate::eprintln!("[{}:{}] {} = {:#?}",
+                    file!(), line!(), stringify!($val), &tmp);
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($($crate::dbg!($val)),+,)
+    };
+}


### PR DESCRIPTION
and convert `main` return value with the `Termination` trait to an
`exit()` value.

Also add some convenience io macros like `dbg!()`, `println!()` and
`eprintln()!`.

Also `eprintln!()` the `panic()` `PanicInfo`.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
