### PR TITLE
build(deps): remove sallyport version from internal tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
  "rand",
  "rust_exec_tests",
  "rust_syscall_tests",
- "sallyport 0.4.0",
+ "sallyport",
  "semver",
  "serde",
  "serde_json",
@@ -673,7 +673,7 @@ dependencies = [
  "noted",
  "primordial",
  "rcrt1",
- "sallyport 0.4.0",
+ "sallyport",
  "spinning",
  "testaso",
  "x86_64",
@@ -693,7 +693,7 @@ dependencies = [
  "noted",
  "primordial",
  "rcrt1",
- "sallyport 0.4.0",
+ "sallyport",
  "sgx 0.4.1 (git+https://github.com/enarx/sgx?rev=3530660)",
  "spinning",
  "x86_64",
@@ -1625,7 +1625,7 @@ version = "0.1.0"
 dependencies = [
  "goblin",
  "rcrt1",
- "sallyport 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sallyport",
 ]
 
 [[package]]
@@ -1689,15 +1689,6 @@ dependencies = [
  "libc",
  "serial_test",
  "testaso",
-]
-
-[[package]]
-name = "sallyport"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d32884a5700fb9298473bb829536f523437523f410793ff3d64531e17b3927"
-dependencies = [
- "goblin",
 ]
 
 [[package]]
@@ -1811,7 +1802,7 @@ dependencies = [
 name = "sev_attestation"
 version = "0.1.0"
 dependencies = [
- "sallyport 0.4.0",
+ "sallyport",
  "testaso",
 ]
 

--- a/tests/rust_syscall_tests/Cargo.toml
+++ b/tests/rust_syscall_tests/Cargo.toml
@@ -7,4 +7,4 @@ license = "Apache-2.0"
 [dependencies]
 goblin = { version = "0.5", features = ["elf64"], default-features = false }
 rcrt1 = { version = "2.2.0", default-features = false }
-sallyport = { version = "0.4.0", default-features = false }
+sallyport = { path = "../../crates/sallyport", default-features = false }

--- a/tests/sev_attestation/Cargo.toml
+++ b/tests/sev_attestation/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-sallyport = { version = "0.4.0", path = "../../crates/sallyport", default-features = false }
+sallyport = { path = "../../crates/sallyport", default-features = false }
 
 [dev-dependencies]
 testaso = { version = "0.1.0", default-features = false }


### PR DESCRIPTION
The tests are not published to crates.io and don't need a version.

By removing the version, we also remove the burden to update the
version.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
