### PR TITLE
fix(exec-wasmtime): rename `x509::` to `x509_cert::`

### DIFF
--- a/crates/exec-wasmtime/Cargo.toml
+++ b/crates/exec-wasmtime/Cargo.toml
@@ -32,7 +32,7 @@ wasmtime = { version = "0.36", features = ["cranelift", "pooling-allocator"], de
 wasmtime-wasi = { version = "0.36", features = ["sync"], default-features = false }
 wiggle = { version = "0.36", default-features = false }
 webpki-roots = { version = "0.22.2", default-features = false }
-x509 = { package = "x509-cert", version = "0.0.2", features = ["std"], default-features = false }
+x509-cert = { version = "0.0.2", features = ["std"], default-features = false }
 zeroize = { version = "1.5.4", features = ["alloc"], default-features = false }
 
 [dev-dependencies]

--- a/crates/exec-wasmtime/src/loader/configured/mod.rs
+++ b/crates/exec-wasmtime/src/loader/configured/mod.rs
@@ -14,9 +14,9 @@ use anyhow::Result;
 use const_oid::{db::rfc5912::SECP_256_R_1, db::rfc5912::SECP_384_R_1, AssociatedOid};
 use pkcs8::PrivateKeyInfo;
 use sha2::{Digest, Sha256, Sha384};
-use x509::der::{asn1::BitString, Any, Decodable, Encodable};
-use x509::request::{CertReq, CertReqInfo, ExtensionReq};
-use x509::{attr::Attribute, ext::Extension, name::RdnSequence};
+use x509_cert::der::{asn1::BitString, Any, Decodable, Encodable};
+use x509_cert::request::{CertReq, CertReqInfo, ExtensionReq};
+use x509_cert::{attr::Attribute, ext::Extension, name::RdnSequence};
 
 impl Loader<Configured> {
     pub fn make_csr(pki: &PrivateKeyInfo<'_>, exts: Vec<Extension<'_>>) -> Result<Vec<u8>> {
@@ -32,7 +32,7 @@ impl Loader<Configured> {
 
         // Create a certification request information structure.
         let cri = CertReqInfo {
-            version: x509::request::Version::V1,
+            version: x509_cert::request::Version::V1,
             attributes: vec![att].try_into()?,
             subject: RdnSequence::default(),
             public_key: pki.public_key()?,

--- a/crates/exec-wasmtime/src/loader/pki.rs
+++ b/crates/exec-wasmtime/src/loader/pki.rs
@@ -6,7 +6,7 @@ use pkcs8::{AlgorithmIdentifier, ObjectIdentifier, PrivateKeyInfo, SubjectPublic
 use zeroize::Zeroizing;
 
 use sec1::EcPrivateKey;
-use x509::der::{Decodable, Encodable};
+use x509_cert::der::{Decodable, Encodable};
 
 use const_oid::db::rfc5912::{
     ECDSA_WITH_SHA_256, ECDSA_WITH_SHA_384, ID_EC_PUBLIC_KEY as ECPK, SECP_256_R_1 as P256,

--- a/crates/exec-wasmtime/src/loader/requested.rs
+++ b/crates/exec-wasmtime/src/loader/requested.rs
@@ -10,12 +10,12 @@ use anyhow::{anyhow, Result};
 use pkcs8::PrivateKeyInfo;
 use rustls::{cipher_suite::*, kx_group::*, version::TLS13, *};
 use url::Url;
-use x509::der::asn1::{BitString, UIntBytes};
-use x509::der::{Decodable, Encodable};
-use x509::ext::pkix::{BasicConstraints, ExtendedKeyUsage, KeyUsage, KeyUsages};
-use x509::name::RdnSequence;
-use x509::time::Validity;
-use x509::{Certificate, PkiPath, TbsCertificate};
+use x509_cert::der::asn1::{BitString, UIntBytes};
+use x509_cert::der::{Decodable, Encodable};
+use x509_cert::ext::pkix::{BasicConstraints, ExtendedKeyUsage, KeyUsage, KeyUsages};
+use x509_cert::name::RdnSequence;
+use x509_cert::time::Validity;
+use x509_cert::{Certificate, PkiPath, TbsCertificate};
 
 use const_oid::db::rfc5280::{
     ID_CE_BASIC_CONSTRAINTS, ID_CE_EXT_KEY_USAGE, ID_CE_KEY_USAGE, ID_KP_CLIENT_AUTH,
@@ -63,7 +63,7 @@ impl Loader<Requested> {
 
         // Create the certificate body.
         let tbs = TbsCertificate {
-            version: x509::Version::V3,
+            version: x509_cert::Version::V3,
             serial_number: UIntBytes::new(&serial)?,
             signature: pki.signs_with()?,
             issuer: RdnSequence::from_der(&rdns)?,
@@ -73,17 +73,17 @@ impl Loader<Requested> {
             issuer_unique_id: None,
             subject_unique_id: None,
             extensions: Some(vec![
-                x509::ext::Extension {
+                x509_cert::ext::Extension {
                     extn_id: ID_CE_KEY_USAGE,
                     critical: true,
                     extn_value: &ku,
                 },
-                x509::ext::Extension {
+                x509_cert::ext::Extension {
                     extn_id: ID_CE_BASIC_CONSTRAINTS,
                     critical: true,
                     extn_value: &bc,
                 },
-                x509::ext::Extension {
+                x509_cert::ext::Extension {
                     extn_id: ID_CE_EXT_KEY_USAGE,
                     critical: false,
                     extn_value: &eu,


### PR DESCRIPTION
and remove the package renaming in `Cargo.toml`.

While mocking crate registries, this cause problems.

Let's just name the crate by its real name.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
