### PR TITLE
refactor(exec): a few minor improvements

### DIFF
--- a/crates/exec-wasmtime/src/config.rs
+++ b/crates/exec-wasmtime/src/config.rs
@@ -11,21 +11,21 @@ fn default_port() -> u16 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Name(String);
+pub struct FileName(String);
 
-impl From<String> for Name {
+impl From<String> for FileName {
     fn from(value: String) -> Self {
         Self(value)
     }
 }
 
-impl From<&str> for Name {
+impl From<&str> for FileName {
     fn from(value: &str) -> Self {
         Self(value.into())
     }
 }
 
-impl Deref for Name {
+impl Deref for FileName {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -33,7 +33,7 @@ impl Deref for Name {
     }
 }
 
-impl<'de> Deserialize<'de> for Name {
+impl<'de> Deserialize<'de> for FileName {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -84,20 +84,20 @@ impl Default for Config {
 #[serde(tag = "kind")]
 pub enum File {
     #[serde(rename = "null")]
-    Null { name: Option<Name> },
+    Null { name: Option<FileName> },
 
     #[serde(rename = "stdin")]
-    Stdin { name: Option<Name> },
+    Stdin { name: Option<FileName> },
 
     #[serde(rename = "stdout")]
-    Stdout { name: Option<Name> },
+    Stdout { name: Option<FileName> },
 
     #[serde(rename = "stderr")]
-    Stderr { name: Option<Name> },
+    Stderr { name: Option<FileName> },
 
     #[serde(rename = "listen")]
     Listen {
-        name: Name,
+        name: FileName,
 
         #[serde(default = "default_port")]
         port: u16,
@@ -108,7 +108,7 @@ pub enum File {
 
     #[serde(rename = "connect")]
     Connect {
-        name: Option<Name>,
+        name: Option<FileName>,
 
         #[serde(default = "default_port")]
         port: u16,

--- a/crates/exec-wasmtime/src/loader/compiled/tls.rs
+++ b/crates/exec-wasmtime/src/loader/compiled/tls.rs
@@ -281,7 +281,7 @@ impl WasiFile for Listener {
     }
 
     async fn write_vectored<'a>(&mut self, bufs: &[std::io::IoSlice<'a>]) -> Result<u64, Error> {
-        Ok(bufs.iter().map(|b| b.len()).sum::<usize>() as _)
+        Ok(bufs.iter().map(|b| b.len() as u64).sum())
     }
 
     async fn write_vectored_at<'a>(
@@ -289,7 +289,7 @@ impl WasiFile for Listener {
         bufs: &[std::io::IoSlice<'a>],
         _offset: u64,
     ) -> Result<u64, Error> {
-        Ok(bufs.iter().map(|b| b.len()).fold(0, |a, x| a + x as u64))
+        Ok(bufs.iter().map(|b| b.len() as u64).sum())
     }
 
     async fn peek(&mut self, _buf: &mut [u8]) -> Result<u64, Error> {


### PR DESCRIPTION
- Use `sum()` method for clarity and consistency (see L284)
- Rename `Name` to `FileName` to differentiate from other "names"