### PR TITLE
docs(release): update docs prior to 0.5 Release

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -38,7 +38,7 @@ jobs:
           - name: centos7
           - name: centos8
         context:
-          - name: "git,helloworld,helloworld-git"
+          - name: "git,helloworld"
           - name: "crates,helloworld"
         document:
           - name: "docs/Install.md"

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -236,7 +236,7 @@ $ cargo +nightly build --release --target=wasm32-wasi
 
 Assuming you did install the `enarx` binary and have it in your `$PATH`, you can
 now run the WebAssembly program in an Enarx keep.
-```sh:helloworld-git;
+```sh:helloworld;
 $ enarx run target/wasm32-wasi/release/hello-world.wasm
 ```
 ```console


### PR DESCRIPTION
Please merge on the day of release.

With the 0.5 containing the nil backend, we no longer need to filter runtime tests depending on git or crate origin.
Signed-off-by: Paul Pietkiewicz <paul@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
