### PR TITLE
chore(deps): update code to use sgx 0.5 and mmledger 0.3 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sev_attestation",
- "sgx 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx",
  "static_assertions",
  "tempfile",
  "ureq",
@@ -694,7 +694,7 @@ dependencies = [
  "primordial",
  "rcrt1",
  "sallyport",
- "sgx 0.4.1 (git+https://github.com/enarx/sgx?rev=3530660)",
+ "sgx",
  "spinning",
  "x86_64",
  "xsave",
@@ -1180,8 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "mmledger"
-version = "0.2.0"
-source = "git+https://github.com/enarx/mmledger?rev=a19f609#a19f60996d3313a55d3b614579d92b279dbbd926"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e897144402a49ebd210db4b367029e69fdad0db6f38ad97289dc9d5af10023"
 dependencies = [
  "bitflags",
  "lset",
@@ -1811,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "sgx"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f19d6fdd241e6d507c924f95f9b86a90f13b52d84f7676f55114dba8175179"
+checksum = "536c96a764daacb2abe1e22834d5f48c9e285e7cf3683fb40e9d426ea0907437"
 dependencies = [
  "bitflags",
  "num-integer",
@@ -1821,16 +1822,6 @@ dependencies = [
  "rand",
  "rsa",
  "sha2",
- "x86_64",
- "xsave",
-]
-
-[[package]]
-name = "sgx"
-version = "0.4.1"
-source = "git+https://github.com/enarx/sgx?rev=3530660#3530660d45f50abd0dfd1a29bc8641762d0a532b"
-dependencies = [
- "bitflags",
  "x86_64",
  "xsave",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ protobuf = { version = "2.22", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, features = ["std", "std_rng"], default-features = false }
 sallyport = { version = "0.4.0", optional = true, path = "crates/sallyport", default-features = false }
 semver = { version = "1.0", optional = true, default-features = false }
-sgx = { version = "0.4.1", optional = true, features = ["rcrypto"], default-features = false }
+sgx = { version = "0.5.0", optional = true, features = ["rcrypto"], default-features = false }
 static_assertions = { version = "1.1.0", optional = true, default-features = false }
 ureq = { version = "2.4.0", optional = true, default-features = false }
 vdso = { version = "0.2", optional = true, default-features = false }

--- a/crates/shim-sgx/Cargo.toml
+++ b/crates/shim-sgx/Cargo.toml
@@ -16,12 +16,12 @@ disable-sgx-attestation = []
 const-default = { version = "1.0", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
 goblin = { version = "0.5", features = ["elf64"], default-features = false }
-mmledger = { git = "https://github.com/enarx/mmledger", rev = "a19f609", default-features = false }
+mmledger = { version = "0.3.0", default-features = false }
 noted = { version = "1.0.0", default-features = false }
 primordial = { version = "0.5.0", features = ["const-default"], default-features = false }
 rcrt1 = { version = "2.4.0", default-features = false }
 sallyport = { version = "0.4.0", path = "../sallyport", default-features = false }
-sgx = { git = "https://github.com/enarx/sgx", rev = "3530660", default-features = false }
+sgx = { version = "0.5.0", default-features = false }
 spinning = { version = "0.1", default-features = false }
 x86_64 = { version = "0.14.9", default-features = false }
 xsave = { version = "2.0.2", default-features = false }


### PR DESCRIPTION
Signed-off-by: Paul Pietkiewicz <paul@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
