### PR TITLE
test: enforce maximum shim size in release tests

### DIFF
--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -108,3 +108,22 @@ impl crate::backend::Backend for Backend {
         Ok(Vec::new())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg_attr(debug_assertions, ignore)]
+    fn shim_kvm_binary_size() {
+        use crate::backend::Backend;
+
+        let max_shim_size = 500_000;
+        let shim = super::Backend.shim();
+        if shim.len() > max_shim_size {
+            panic!(
+                "shim size should be less than {} bytes, but is {} bytes",
+                max_shim_size,
+                shim.len()
+            );
+        }
+    }
+}

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -68,3 +68,22 @@ impl crate::backend::Backend for Backend {
         hasher::Hasher::load(shim, exec)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg_attr(debug_assertions, ignore)]
+    fn shim_sgx_binary_size() {
+        use crate::backend::Backend;
+
+        let max_shim_size = 500_000;
+        let shim = super::Backend.shim();
+        if shim.len() > max_shim_size {
+            panic!(
+                "shim size should be less than {} bytes, but is {} bytes",
+                max_shim_size,
+                shim.len()
+            );
+        }
+    }
+}

--- a/src/exec/exec_wasmtime/mod.rs
+++ b/src/exec/exec_wasmtime/mod.rs
@@ -19,19 +19,3 @@ impl crate::exec::Exec for WasmExec {
         backend.name() != "nil"
     }
 }
-
-#[cfg(test)]
-pub(crate) mod test {
-    use super::WasmExec;
-    use crate::exec::Exec;
-
-    // Check that wasmldr.exec() gives us the binary contents
-    #[test]
-    fn is_builtin() {
-        let wasmldr = Box::new(WasmExec);
-        assert_eq!(
-            wasmldr.exec(),
-            include_bytes!(env!("CARGO_BIN_FILE_ENARX_EXEC_WASMTIME_BIN"))
-        );
-    }
-}


### PR DESCRIPTION
Add new unit tests to the Enarx crate to guard against regressions in binary size for the shims.

Tests are only run in release mode, and will fail if a shim exceeds 500 KB in size.

This also removes a useless test from exec-wasmtime.

Closes #1609.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
