### PR TITLE
build(nix): provide static, reproducible builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,11 +130,11 @@ jobs:
           - name: debug
           - name: release
             flag: --release
-  # nix:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #   - uses: actions/checkout@v2.4.0
-  #   - uses: cachix/install-nix-action@v16
-  #   - run: nix flake check
-  #   - run: nix develop --ignore-environment -c cargo build
-  #   - run: nix build -L
+
+  nix:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v16
+    - run: nix develop --impure --ignore-environment -c cargo test 'wasm::'
+    - run: nix build -L

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,3 +138,4 @@ jobs:
     - uses: cachix/install-nix-action@v16
     - run: nix develop --impure --ignore-environment -c cargo test 'wasm::'
     - run: nix build -L
+    - run: nix build -L '.#enarx-docker'

--- a/flake.lock
+++ b/flake.lock
@@ -53,26 +53,6 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1639947939,
-        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1647125019,
@@ -94,7 +74,6 @@
         "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,15 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1647345112,
-        "narHash": "sha256-x2CufZxzJcQek4+XcV+Tt7FO4AjFRYE3+QNXiyOlTWU=",
-        "owner": "rvolosatovs",
+        "lastModified": 1652077709,
+        "narHash": "sha256-tvpHXGtgopAV+DkCFNDa1FIgz3ByKX/kzsL8Eypzq2E=",
+        "owner": "nix-community",
         "repo": "fenix",
-        "rev": "c1a1b0672de1154c2111884702bbb8d028b11a79",
+        "rev": "4fd8f4e9ccc72d82b1f79ab2ab00a95adb12169c",
         "type": "github"
       },
       "original": {
-        "owner": "rvolosatovs",
-        "ref": "fix/rustc-patch",
+        "owner": "nix-community",
         "repo": "fenix",
         "type": "github"
       }
@@ -25,11 +24,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {
@@ -40,11 +39,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {
@@ -55,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1647125019,
-        "narHash": "sha256-PXA76/iIqtbrA0ydCyc7Wpdw7TQTnfEowM87YtTXfB4=",
+        "lastModified": 1652082323,
+        "narHash": "sha256-7GSVLvfCJtH9dJ3om9Lg4fsi9UKvoxxR69gUTcx0ol8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0e141e3fe13ec21f50429773d2e3890e02a80da",
+        "rev": "2a3aac479caeba0a65b2ad755fe5f284f1fde74d",
         "type": "github"
       },
       "original": {
@@ -80,15 +79,15 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1647163555,
-        "narHash": "sha256-Ivq9ZlzoNwkVSiKVj7CO2m6+/QhCxPNfgN4NnBnfaec=",
-        "owner": "rust-analyzer",
+        "lastModified": 1651933512,
+        "narHash": "sha256-dM1vc+dZ/xZ1XSOFnutXjpJnnzu6xs9qikZnLmrFi7Y=",
+        "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "5e8515870674983cce5b945946045bc1e9b80200",
+        "rev": "5d5bbec9b60010dd7389a084c56693baf6bda780",
         "type": "github"
       },
       "original": {
-        "owner": "rust-analyzer",
+        "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,12 @@
 {
   description = "Tools for deploying WebAssembly into Enarx Keeps.";
 
+  inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.fenix.url = github:nix-community/fenix;
   inputs.flake-compat.flake = false;
   inputs.flake-compat.url = github:edolstra/flake-compat;
   inputs.flake-utils.url = github:numtide/flake-utils;
   inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
-  inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.fenix.url = github:rvolosatovs/fenix?ref=fix/rustc-patch;
 
   outputs = { self, nixpkgs, fenix, flake-utils, ... }:
     # NOTE: musl is only supported on Linux.


### PR DESCRIPTION
Closes #1865 
Closes #1851 

Removed the https://github.com/nix-community/fenix fork, since https://github.com/nix-community/fenix/pull/68 was merged.

This PR is based upon brilliant work by @veehaitch in https://github.com/enarx/enarx/pull/1564 (thanks!)

We now have reproducible, static builds of Enarx via Nix, including an OCI image containing the binary.
We also now test the validity of Nix flake itself, the dev environment, the build of the binary and the build of the Docker image in CI.

For testing the Docker image:
```sh
$ nix build '.#enarx-docker'
$ docker load < result                               
ERRO[0000] Error refreshing container 505a8667e52c84d998c6af764705754000f2aa06357a8834194f34c8884fc19d: error retrieving temporary directory for container 505a8667e52c84d998c6af764705754000f2aa06357a8834194f34c8884fc19d: no such container 
Getting image source signatures
Copying blob db04cad00d37 done  
Copying config a3523555f5 done  
Writing manifest to image destination
Storing signatures
Loaded image(s): localhost/enarx-docker:0.4.0
$ docker run localhost/enarx-docker:0.4.0
enarx 
`enarx` subcommands and their options/arguments

USAGE:
    enarx [OPTIONS] <SUBCOMMAND>

OPTIONS:
    -h, --help                       Print help information
        --log-filter <LOG_FILTER>    Set fancier logging filters [env: ENARX_LOG=]
        --log-target <LOG_TARGET>    Set log output target ("stderr", "stdout") [default: stderr]
    -v, --verbose                    Increase log verbosity. Pass multiple times for more log output

SUBCOMMANDS:
    deploy    Run an Enarx package inside an Enarx Keep
    help      Print this message or the help of the given subcommand(s)
    info      Show details about backend support on this system
    run       Run a WebAssembly module inside an Enarx Keep
    sgx       SGX-specific functionality
    snp       SNP-specific functionality
 ```