### PR TITLE
build(nix): various improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,5 +150,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v16
+    - run: nix build -L '.#enarx-static'
     - run: nix run -L '.#enarx-static' info
+    - run: ./result/bin/enarx info
     - run: nix build -L '.#enarx-docker'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
     - run: nix develop -L --ignore-environment --impure -c cargo test 'wasm::'
 
   nix-dynamic:
-    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,13 @@ jobs:
           - name: release
             flag: --release
 
+  nix-check:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v17
+    - run: nix flake check --impure
+
   nix-develop:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,22 +134,22 @@ jobs:
   nix-develop:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v16
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v17
     - run: nix develop -L --ignore-environment --impure -c cargo test 'wasm::'
 
   nix-dynamic:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v16
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v17
     - run: nix run -L . info
 
   nix-static:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v16
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v17
     - run: nix build -L '.#enarx-static'
     - run: nix run -L '.#enarx-static' info
     - run: ./result/bin/enarx info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,11 +131,24 @@ jobs:
           - name: release
             flag: --release
 
-  nix:
+  nix-develop:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v16
-    - run: nix develop --impure --ignore-environment -c cargo test 'wasm::'
-    - run: nix build -L
+    - run: nix develop -L --ignore-environment --impure -c cargo test 'wasm::'
+
+  nix-dynamic:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v16
+    - run: nix run -L . info
+
+  nix-static:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v16
+    - run: nix run -L '.#enarx-static' info
     - run: nix build -L '.#enarx-docker'

--- a/flake.nix
+++ b/flake.nix
@@ -60,9 +60,9 @@
                 } // extraArgs);
             in
             {
-              "${name}" = buildPackage pkgs { };
+              "${cargoToml.package.name}" = buildPackage pkgs { };
 
-              "${name}-static" = buildPackage pkgs.pkgsStatic rec {
+              "${cargoToml.package.name}-static" = buildPackage pkgs.pkgsStatic rec {
                 CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
                 CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
                 CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = with pkgs.pkgsMusl.stdenv; "${cc}/bin/${cc.targetPrefix}gcc";
@@ -70,19 +70,19 @@
                 depsBuildBuild = [ pkgs.stdenv.cc ];
 
                 postBuild = ''
-                  ldd target/${CARGO_BUILD_TARGET}/release/${name} | grep -q 'statically linked' || (echo "binary is not statically linked"; exit 1)
+                  ldd target/${CARGO_BUILD_TARGET}/release/${cargoToml.package.name} | grep -q 'statically linked' || (echo "binary is not statically linked"; exit 1)
                 '';
 
-                meta.mainProgram = name;
+                meta.mainProgram = cargoToml.package.name;
               };
 
-              "${name}-docker" = pkgs.dockerTools.buildImage {
-                inherit name;
-                tag = version;
+              "${cargoToml.package.name}-docker" = pkgs.dockerTools.buildImage {
+                inherit (cargoToml.package) name;
+                tag = cargoToml.package.version;
                 runAsRoot = ''
-                  install -D "${self.packages.${system}."${name}-static"}/bin/${name}" "/bin/${name}"
+                  install -D "${self.packages.${system}."${cargoToml.package.name}-static"}/bin/${cargoToml.package.name}" "/bin/${cargoToml.package.name}"
                 '';
-                config.Cmd = [ "enarx" ];
+                config.Cmd = [ cargoToml.package.name ];
                 config.Env = [ "PATH=/bin" ];
               };
             };

--- a/flake.nix
+++ b/flake.nix
@@ -76,10 +76,14 @@
                 meta.mainProgram = name;
               };
 
-              enarx-docker = pkgs.dockerTools.buildImage {
-                name = "${cargoToml.package.name}-docker";
-                tag = "${cargoToml.package.version}";
-                config.Cmd = [ "${self.packages.${system}.enarx}/bin/enarx" ];
+              "${name}-docker" = pkgs.dockerTools.buildImage {
+                inherit name;
+                tag = version;
+                runAsRoot = ''
+                  install -D "${self.packages.${system}."${name}-static"}/bin/${name}" "/bin/${name}"
+                '';
+                config.Cmd = [ "enarx" ];
+                config.Env = [ "PATH=/bin" ];
               };
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -79,11 +79,11 @@
               ociImage = pkgs.dockerTools.buildImage {
                 inherit (cargoToml.package) name;
                 tag = cargoToml.package.version;
-                runAsRoot = ''
-                  install -D "${staticBin}/bin/${cargoToml.package.name}" "/bin/${cargoToml.package.name}"
-                '';
+                contents = [
+                  staticBin
+                ];
                 config.Cmd = [ cargoToml.package.name ];
-                config.Env = [ "PATH=/bin" ];
+                config.Env = [ "PATH=${staticBin}/bin" ];
               };
             in
             {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,19 @@
                 ({
                   inherit (cargoToml.package) name version;
 
-                src = pkgs.nix-gitignore.gitignoreRecursiveSource [ ] self;
+                  src = pkgs.nix-gitignore.gitignoreRecursiveSource [
+                    "*.nix"
+                    "*.yml"
+                    "/.github"
+                    "/docs"
+                    "/README-DEBUG.md"
+                    "/SECURITY.md"
+                    "deny.toml"
+                    "flake.lock"
+                    "LICENSE"
+                    "rust-toolchain.toml"
+                  ]
+                    self;
 
                   cargoLock.lockFileContents = builtins.readFile "${self}/Cargo.lock";
 

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,10 @@
 
                 depsBuildBuild = [ pkgs.stdenv.cc ];
 
+                postBuild = ''
+                  ldd target/${CARGO_BUILD_TARGET}/release/${name} | grep -q 'statically linked' || (echo "binary is not statically linked"; exit 1)
+                '';
+
                 meta.mainProgram = name;
               };
 


### PR DESCRIPTION
- Enable `nix run .`, i.e. users can now do `nix run github:enarx/enarx info` to build and test `enarx` compiled for the host target directly from `main` and run on success `enarx info` (or any other subcommand) with no other dependency than `nix` on any x86_64 Linux distribution supported by `nix`
- Refactor `enarx-docker` to provide an `enarx` binary in `PATH`
- Split the nix CI job to benefit from concurrent builds and get clearer output
- Filter the source to improve caching efficiency
- Test, whether the binary is indeed static as part of the build
- Execute the static binary on Ubuntu

For testing Docker image (will be added to CI):
```
docker run --rm $(docker load < ./result | sed 's/Loaded image(s): \(.*\)/\1/') enarx info
```