### PR TITLE
ci(nix): enable caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v17
+    - uses: cachix/cachix-action@v10
+      with:
+        name: enarx
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix develop -L --ignore-environment --impure -c cargo test 'wasm::'
 
   nix-dynamic:
@@ -150,6 +154,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v17
+    - uses: cachix/cachix-action@v10
+      with:
+        name: enarx
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix run -L . info
 
   nix-static:
@@ -157,6 +165,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v17
+    - uses: cachix/cachix-action@v10
+      with:
+        name: enarx
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix build -L '.#enarx-static'
     - run: nix run -L '.#enarx-static' info
     - run: ./result/bin/enarx info


### PR DESCRIPTION
Closes #1875 

This will enable https://app.cachix.org/cache/enarx binary cache.
Already built artifacts will be pulled from the content-addressable cache by their hash, rather than being built.

On successful CI jobs from within this repo, artifacts will be pushed.
So we'll only see benefits of this once we merge the PR.