### PR TITLE
fix(shim-kvm): revert support old CPUs

### DIFF
--- a/crates/shim-kvm/src/exec.rs
+++ b/crates/shim-kvm/src/exec.rs
@@ -12,7 +12,6 @@ use crate::usermode::usermode;
 use core::convert::TryFrom;
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::hostcall::CPU_HAS_FSGSBASE;
 use crt0stack::{self, Builder, Entry};
 use goblin::elf::header::header64::Header;
 use goblin::elf::header::ELFMAG;
@@ -173,7 +172,7 @@ fn crt0setup(
         Entry::PHnum(header.e_phnum as _),
         Entry::HwCap(hwcap as _),
         // FSGSBASE flag is 1 << 1
-        Entry::HwCap2(if *CPU_HAS_FSGSBASE { 2 } else { 0 }),
+        Entry::HwCap2(2),
         Entry::Random(rand),
         Entry::Entry(ph_entry.as_u64() as _),
     ] {

--- a/crates/shim-kvm/src/gdt.rs
+++ b/crates/shim-kvm/src/gdt.rs
@@ -7,13 +7,11 @@ use crate::syscall::_syscall_enter;
 
 use core::ops::Deref;
 
-use crate::hostcall::CPU_HAS_FSGSBASE;
 use nbytes::bytes;
 use spinning::Lazy;
 use x86_64::instructions::segmentation::{Segment, Segment64, CS, DS, ES, FS, GS, SS};
 use x86_64::instructions::tables::load_tss;
-use x86_64::registers::control::{Cr4, Cr4Flags};
-use x86_64::registers::model_specific::{GsBase, KernelGsBase, LStar, SFMask, Star};
+use x86_64::registers::model_specific::{KernelGsBase, LStar, SFMask, Star};
 use x86_64::registers::rflags::RFlags;
 use x86_64::structures::gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector};
 use x86_64::structures::paging::{Page, PageTableFlags, Size2MiB, Size4KiB};
@@ -172,11 +170,5 @@ pub unsafe fn init() {
     // Important: TSS.deref() != &TSS because of lazy_static
     let base = VirtAddr::new(TSS.deref() as *const _ as u64);
     KernelGsBase::write(base);
-
-    if *CPU_HAS_FSGSBASE {
-        Cr4::update(|f| *f |= Cr4Flags::FSGSBASE);
-        GS::write_base(base);
-    } else {
-        GsBase::write(base);
-    }
+    GS::write_base(base);
 }

--- a/crates/shim-kvm/src/main.rs
+++ b/crates/shim-kvm/src/main.rs
@@ -478,7 +478,7 @@ pub unsafe extern "sysv64" fn _start() -> ! {
         _ENARX_PML4 = const 0xFFE0_1000u32, // Can't use `sym` because linker does not recognize absolute addresses
         _ENARX_CPUID = const 0xFFE0_2000u32, // Can't use `sym` because linker does not recognize absolute addresses
         SEV_GHCB_MSR = const 0xC001_0130u32,
-        CR4_FLAGS = const (Cr4Flags::PHYSICAL_ADDRESS_EXTENSION.bits() | Cr4Flags::OSFXSR.bits() | Cr4Flags::OSXMMEXCPT_ENABLE.bits() | Cr4Flags::OSXSAVE.bits()),
+        CR4_FLAGS = const (Cr4Flags::FSGSBASE.bits() | Cr4Flags::PHYSICAL_ADDRESS_EXTENSION.bits() | Cr4Flags::OSFXSR.bits() | Cr4Flags::OSXMMEXCPT_ENABLE.bits() | Cr4Flags::OSXSAVE.bits()),
         PROTECTED_MODE_ENABLE = const Cr0Flags::PROTECTED_MODE_ENABLE.bits(),
         CR0_PAGING = const Cr0Flags::PAGING.bits(),
 

--- a/crates/shim-kvm/src/random.rs
+++ b/crates/shim-kvm/src/random.rs
@@ -2,31 +2,14 @@
 
 //! Random functions
 
-use crate::snp::{cpuid, snp_active};
-
-use spinning::Lazy;
-
-/// Flag, if the CPU supports RDRAND
-pub static CPU_HAS_RDRAND: Lazy<bool> = Lazy::new(|| cpuid(1).ecx & (1 << 30) != 0);
-
 /// Get a random number
 pub fn random() -> u64 {
     let mut r: u64 = 0;
 
-    if *CPU_HAS_RDRAND {
-        for _ in 0..1024 {
-            if unsafe { core::arch::x86_64::_rdrand64_step(&mut r) } == 1 {
-                return r;
-            }
+    for _ in 0..1024 {
+        if unsafe { core::arch::x86_64::_rdrand64_step(&mut r) } == 1 {
+            return r;
         }
-    } else {
-        // This is an absolute fallback for old CPUs to be able to run in KVM simulation mode
-
-        if snp_active() {
-            panic!("No rdrand on SNP");
-        }
-
-        return unsafe { core::arch::x86_64::_rdtsc() };
     }
 
     panic!("Could not get random!")

--- a/src/backend/kvm/data.rs
+++ b/src/backend/kvm/data.rs
@@ -30,10 +30,26 @@ pub fn kvm_version() -> Datum {
     }
 }
 
-pub const CPUIDS: &[CpuId] = &[CpuId {
-    name: "CPU",
-    leaf: 0x80000000,
-    subl: 0x00000000,
-    func: |res| CpuId::cpu_identifier(res, None),
-    vend: None,
-}];
+pub const CPUIDS: &[CpuId] = &[
+    CpuId {
+        name: "CPU",
+        leaf: 0x80000000,
+        subl: 0x00000000,
+        func: |res| CpuId::cpu_identifier(res, None),
+        vend: None,
+    },
+    CpuId {
+        name: " CPU supports FSGSBASE instructions",
+        leaf: 0x00000007,
+        subl: 0x00000000,
+        func: |res| (res.ebx & 0x1 != 0, None),
+        vend: None,
+    },
+    CpuId {
+        name: " CPU supports RDRAND instruction",
+        leaf: 0x00000001,
+        subl: 0x00000000,
+        func: |res| (res.ecx & (1 << 30) != 0, None),
+        vend: None,
+    },
+];


### PR DESCRIPTION
This reverts commit e20965b4ca78f6766cefa8a48869fc30e19485e1.
This reverts commit 0cd613c2ba1c302ad07098f02e474928f52d74e1.

We now have the `nil` backend for those users.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
