### PR TITLE
feat: add `--version` and extend `--help`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,16 @@ use log::info;
 #[cfg(enarx_with_shim)]
 use mmarinus::{perms, Map, Private};
 
-// This defines the toplevel `enarx` CLI
+/// Tool to deploy WebAssembly into Enarx Keeps
+///
+/// Enarx is a tool for running Webassembly inside an Enarx Keep
+/// - that is a hardware isolated environment using technologies
+/// such as Intel SGX or AMD SEV.
+///
+/// For more information about the project and the technology used
+/// visit the Enarx Project home page https://enarx.dev/.
 #[derive(Parser, Debug)]
+#[clap(version)]
 struct Options {
     /// Logging options
     #[clap(flatten)]


### PR DESCRIPTION
Add the `--version` argument:
```console
$ enarx --version
enarx 0.5.0
```

Extend the prologue of the `--help` output.
Before:
```console
$ enarx --help
enarx
`enarx` subcommands and their options/arguments

USAGE:
    enarx [OPTIONS] <SUBCOMMAND>
[...]
```

After:
```console
$ enarx --help
enarx 0.5.0
Tool to deploy WebAssembly into Enarx Keeps

Enarx is a tool for running Webassembly inside an Enarx Keep - that is a hardware isolated
environment using technologies such as Intel SGX or AMD SEV.

For more information about the project and the technology used visit the Enarx Project home page
https://enarx.dev/.

USAGE:
    enarx [OPTIONS] <SUBCOMMAND>
[...]
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
