### PR TITLE
feat: add Windows support with the `nil` backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,18 @@ jobs:
           command: test
           args: --test integration
 
+  windows:
+    name: enarx Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        run: rustup show
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --test integration
+
   bindeps:
     name: ${{ matrix.crate.name }} nightly ${{ matrix.profile.name }}
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --test integration
+          args: --workspace
 
   windows:
     name: enarx Windows
@@ -87,7 +87,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --test integration
+          args: --workspace
 
   bindeps:
     name: ${{ matrix.crate.name }} nightly ${{ matrix.profile.name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "const-oid 0.9.0",
  "env_logger",
  "getrandom",
+ "io-extras",
  "io-lifetimes",
  "libc",
  "pkcs8 0.9.0-pre.1",

--- a/crates/exec-wasmtime/Cargo.toml
+++ b/crates/exec-wasmtime/Cargo.toml
@@ -34,5 +34,8 @@ wiggle = { version = "0.36", default-features = false }
 x509-cert = { version = "0.0.2", features = ["std"], default-features = false }
 zeroize = { version = "1.5.4", features = ["alloc"], default-features = false }
 
+[target.'cfg(windows)'.dependencies]
+io-extras = { version = "0.13.2", default-features = false }
+
 [dev-dependencies]
 wat = { version = "1.0", default-features = false }

--- a/crates/exec-wasmtime/src/main.rs
+++ b/crates/exec-wasmtime/src/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 #![deny(clippy::all)]

--- a/crates/sallyport/src/lib.rs
+++ b/crates/sallyport/src/lib.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-
+#![cfg(any(
+    all(test, target_arch = "x86_64", target_os = "linux"),
+    target_vendor = "unknown"
+))]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(test), no_std)]
 #![deny(clippy::all)]

--- a/crates/sallyport/tests/integration.rs
+++ b/crates/sallyport/tests/integration.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #![feature(c_size_t, core_ffi_c)]
 
 mod enarxcall;

--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-
+#![cfg(any(
+    all(test, target_arch = "x86_64", target_os = "linux"),
+    target_vendor = "unknown"
+))]
 //! The SEV shim
 //!
 //! This crate contains the system/kernel that handles the syscalls (and cpuid instructions)

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-
+#![cfg(any(
+    all(test, target_arch = "x86_64", target_os = "linux"),
+    target_vendor = "unknown"
+))]
 //! The SGX shim
 //!
 //! This crate contains the system that traps the syscalls (and cpuid

--- a/examples/tcp_server/Cargo.toml
+++ b/examples/tcp_server/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 
-[dependencies]
+[target.'cfg(any(unix, target_os="wasm32-wasi"))'.dependencies]
 env_logger = { version = "0.9.0", default-features = false }
 mio = { version = "0.8.3", features = ["os-poll", "net"], default-features = false }

--- a/examples/tcp_server/src/main.rs
+++ b/examples/tcp_server/src/main.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+#![cfg(any(unix, target_os = "wasm32-wasi"))]
+
 // modified version of https://github.com/tokio-rs/mio/blob/master/examples/tcp_server.rs
 
 use std::collections::HashMap;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -23,6 +23,8 @@ use binary::{Binary, Loader, Mapper};
 use std::sync::Arc;
 
 use anyhow::Result;
+#[cfg(windows)]
+use enarx_exec_wasmtime::Args;
 use libc::c_int;
 use once_cell::sync::Lazy;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
@@ -60,6 +62,10 @@ pub trait Backend: Sync + Send {
     fn have(&self) -> bool {
         !self.data().iter().fold(false, |e, d| e | !d.pass)
     }
+
+    #[cfg(windows)]
+    /// set wasmtime args directly
+    fn set_args(&self, _args: Args) {}
 }
 
 impl Serialize for dyn Backend {
@@ -110,7 +116,7 @@ pub static BACKENDS: Lazy<Vec<Box<dyn Backend>>> = Lazy::new(|| {
         Box::new(sev::Backend),
         #[cfg(enarx_with_shim)]
         Box::new(kvm::Backend),
-        Box::new(nil::Backend),
+        Box::new(nil::Backend::default()),
     ]
 });
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -86,6 +86,7 @@ pub fn keepldr_exec<'a>(bin: impl Into<PathBuf>, input: impl Into<Option<&'a [u8
         }
     }
 
+    #[cfg(unix)]
     assert!(
         output.status.code().is_some(),
         "process `{}` terminated by signal {:?}",

--- a/tests/wasm/mod.rs
+++ b/tests/wasm/mod.rs
@@ -53,6 +53,7 @@ fn enarx<'a>(
         }
     }
 
+    #[cfg(unix)]
     assert!(
         output.status.code().is_some(),
         "process terminated by signal {:?}",


### PR DESCRIPTION
Also support `test --workspace` on MacOS and Windows.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
