### PR TITLE
ci: lower expectations for code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,11 +11,11 @@ coverage:
       shim-kvm:
         paths: [ "crates/shim-kvm" ]
         target: auto  # auto compares coverage to the previous base commit
-        threshold: 0.05%  # the leniency in hitting the target
+        threshold: 5%  # the leniency in hitting the target
       shim-sgx:
         paths: [ "crates/shim-sgx" ]
         target: auto  # auto compares coverage to the previous base commit
-        threshold: 0.05%  # the leniency in hitting the target
+        threshold: 5%  # the leniency in hitting the target
       sallyport:
         paths: [ "crates/sallyport" ]
         target: auto  # auto compares coverage to the previous base commit
@@ -32,12 +32,10 @@ coverage:
       default: false
       shim-kvm:
         paths: [ "crates/shim-kvm" ]
-        target: auto  # auto compares coverage to the previous base commit
-        threshold: 0.05%  # the leniency in hitting the target
+        target: 0
       shim-sgx:
         paths: [ "crates/shim-sgx" ]
-        target: auto  # auto compares coverage to the previous base commit
-        threshold: 0.05%  # the leniency in hitting the target
+        target: 0
       sallyport:
         paths: [ "crates/sallyport" ]
         target: auto  # auto compares coverage to the previous base commit


### PR DESCRIPTION
for the shims, which can't report full coverage

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
