### PR TITLE
chore(shim-kvm): mark coverage regions to exclude

### DIFF
--- a/crates/shim-kvm/src/debug.rs
+++ b/crates/shim-kvm/src/debug.rs
@@ -2,6 +2,8 @@
 
 //! Debug functions
 
+#![cfg_attr(coverage, no_coverage)]
+
 use core::arch::asm;
 
 use x86_64::instructions::tables::lidt;

--- a/crates/shim-kvm/src/gdt.rs
+++ b/crates/shim-kvm/src/gdt.rs
@@ -2,6 +2,8 @@
 
 //! Global Descriptor Table init
 
+#![cfg_attr(coverage, no_coverage)]
+
 use crate::shim_stack::{init_stack_with_guard, GuardedStack};
 use crate::syscall::_syscall_enter;
 

--- a/crates/shim-kvm/src/interrupts.rs
+++ b/crates/shim-kvm/src/interrupts.rs
@@ -2,6 +2,8 @@
 
 //! Interrupt handling
 
+#![cfg_attr(coverage, no_coverage)]
+
 #[cfg(feature = "dbg")]
 use crate::debug::{interrupt_trace, print_stack_trace};
 #[cfg(any(debug_assertions, feature = "dbg"))]
@@ -126,6 +128,7 @@ macro_rules! declare_interrupt {
 
     ($name:ident => $push_or_exchange:literal, { $code:block }, $($id:ident: $t:ty),*) => {
         #[naked]
+        #[cfg_attr(coverage, no_coverage)]
         unsafe extern "sysv64" fn $name() -> ! {
             extern "sysv64" fn inner ( $($id: $t,)* ) {
                 $code

--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -11,6 +11,7 @@
 #![deny(missing_docs)]
 #![feature(asm_const, asm_sym, c_size_t, core_ffi_c, naked_functions)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(coverage, feature(no_coverage))]
 
 use crate::snp::cpuid_page::CpuidPage;
 

--- a/crates/shim-kvm/src/main.rs
+++ b/crates/shim-kvm/src/main.rs
@@ -3,7 +3,8 @@
 //! The SEV shim
 //!
 //! Contains the startup code and the main function.
-
+#![cfg_attr(coverage, feature(no_coverage))]
+#![cfg_attr(coverage, no_coverage)]
 #![no_std]
 #![deny(clippy::all)]
 #![deny(clippy::integer_arithmetic)]

--- a/crates/shim-kvm/src/snp/ghcb.rs
+++ b/crates/shim-kvm/src/snp/ghcb.rs
@@ -248,6 +248,7 @@ fn ghcb_msr_make_page_shared(page_virt: VirtAddr) {
 ///
 /// # Safety
 /// Unknown request codes can trigger exceptions
+#[cfg_attr(coverage, no_coverage)]
 #[inline(always)]
 pub unsafe fn vmgexit_msr(request_code: u64, value: u64, expected_response: u64) -> u64 {
     let val = request_code | value;
@@ -307,6 +308,7 @@ impl<'a> GhcbHandle<'a> {
     ///
     /// # Safety
     /// undefined behaviour if not everything is setup according to the GHCB protocol
+    #[cfg_attr(coverage, no_coverage)]
     unsafe fn vmgexit(
         &mut self,
         exit_code: u64,

--- a/crates/shim-kvm/src/snp/mod.rs
+++ b/crates/shim-kvm/src/snp/mod.rs
@@ -64,6 +64,7 @@ pub enum PvalidateSize {
 ///   a #GP(0) exception.
 /// - VMPL or CPL not zero will result in a #GP(0) exception.
 #[inline(always)]
+#[cfg_attr(coverage, no_coverage)]
 pub fn pvalidate(addr: VirtAddr, size: PvalidateSize, validated: bool) -> Result<bool, Error> {
     let rmp_changed: u32;
     let ret: u64;

--- a/crates/shim-kvm/src/sse.rs
+++ b/crates/shim-kvm/src/sse.rs
@@ -12,6 +12,7 @@ use x86_64::registers::{
 };
 
 /// Setup and check SSE relevant stuff
+#[cfg_attr(coverage, no_coverage)]
 pub fn init_sse() {
     const XSAVE_SUPPORTED_BIT: u32 = 1 << 26;
     let xsave_supported = (cpuid_count(1, 0).ecx & XSAVE_SUPPORTED_BIT) != 0;

--- a/crates/shim-kvm/src/syscall.rs
+++ b/crates/shim-kvm/src/syscall.rs
@@ -26,6 +26,7 @@ struct X8664DoubleReturn {
 /// # Safety
 ///
 /// This function is not be called from rust.
+#[cfg_attr(coverage, no_coverage)]
 #[naked]
 pub unsafe extern "sysv64" fn _syscall_enter() -> ! {
     // TaskStateSegment.privilege_stack_table[0]

--- a/crates/shim-kvm/src/usermode.rs
+++ b/crates/shim-kvm/src/usermode.rs
@@ -12,6 +12,7 @@ use const_default::ConstDefault;
 ///
 /// Because the caller can give any `entry_point` and `stack_pointer`
 /// including 0, this function is unsafe.
+#[cfg_attr(coverage, no_coverage)]
 pub unsafe fn usermode(ip: u64, sp: u64) -> ! {
     static XSAVE: xsave::XSave = <xsave::XSave as ConstDefault>::DEFAULT;
 


### PR DESCRIPTION
Related: https://github.com/enarx/enarx/issues/1894

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
