### PR TITLE
chore(shim-kvm): mark coverage regions to exclude

### DIFF
--- a/crates/shim-kvm/src/debug.rs
+++ b/crates/shim-kvm/src/debug.rs
@@ -2,6 +2,8 @@
 
 //! Debug functions
 
+#![cfg_attr(any(coverage, coverage_nightly), no_coverage)]
+
 use core::arch::asm;
 
 use x86_64::instructions::tables::lidt;

--- a/crates/shim-kvm/src/gdt.rs
+++ b/crates/shim-kvm/src/gdt.rs
@@ -2,6 +2,8 @@
 
 //! Global Descriptor Table init
 
+#![cfg_attr(any(coverage, coverage_nightly), no_coverage)]
+
 use crate::shim_stack::{init_stack_with_guard, GuardedStack};
 use crate::syscall::_syscall_enter;
 

--- a/crates/shim-kvm/src/interrupts.rs
+++ b/crates/shim-kvm/src/interrupts.rs
@@ -2,6 +2,8 @@
 
 //! Interrupt handling
 
+#![cfg_attr(any(coverage, coverage_nightly), no_coverage)]
+
 #[cfg(feature = "dbg")]
 use crate::debug::{interrupt_trace, print_stack_trace};
 #[cfg(any(debug_assertions, feature = "dbg"))]
@@ -126,6 +128,7 @@ macro_rules! declare_interrupt {
 
     ($name:ident => $push_or_exchange:literal, { $code:block }, $($id:ident: $t:ty),*) => {
         #[naked]
+        #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
         unsafe extern "sysv64" fn $name() -> ! {
             extern "sysv64" fn inner ( $($id: $t,)* ) {
                 $code
@@ -240,6 +243,7 @@ declare_interrupt!(
 );
 
 /// The global IDT
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
     unsafe {
@@ -255,6 +259,7 @@ pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
 });
 
 /// Initialize the IDT
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub fn init() {
     #[cfg(debug_assertions)]
     eprintln!("interrupts::init");
@@ -265,6 +270,7 @@ pub fn init() {
 mod debug {
     use super::*;
 
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     pub(crate) fn idt_add_debug_exception_handlers(idt: &mut InterruptDescriptorTable) {
         unsafe {
             let virt = VirtAddr::new_unsafe(divide_error_handler as usize as u64);

--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -11,6 +11,7 @@
 #![deny(missing_docs)]
 #![feature(asm_const, asm_sym, c_size_t, core_ffi_c, naked_functions)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(any(coverage, coverage_nightly), feature(no_coverage))]
 
 use crate::snp::cpuid_page::CpuidPage;
 

--- a/crates/shim-kvm/src/main.rs
+++ b/crates/shim-kvm/src/main.rs
@@ -3,7 +3,8 @@
 //! The SEV shim
 //!
 //! Contains the startup code and the main function.
-
+#![cfg_attr(any(coverage, coverage_nightly), feature(no_coverage))]
+#![cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 #![no_std]
 #![deny(clippy::all)]
 #![deny(clippy::integer_arithmetic)]

--- a/crates/shim-kvm/src/snp/ghcb.rs
+++ b/crates/shim-kvm/src/snp/ghcb.rs
@@ -215,6 +215,7 @@ enum GhcbError {
 }
 
 /// make a page shared with the GHCB MSR Protocol
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 fn ghcb_msr_make_page_shared(page_virt: VirtAddr) {
     // const SNP_PAGE_STATE_PRIVATE: u64 = 1;
     const SNP_PAGE_STATE_SHARED: u64 = 2;
@@ -248,6 +249,7 @@ fn ghcb_msr_make_page_shared(page_virt: VirtAddr) {
 ///
 /// # Safety
 /// Unknown request codes can trigger exceptions
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 #[inline(always)]
 pub unsafe fn vmgexit_msr(request_code: u64, value: u64, expected_response: u64) -> u64 {
     let val = request_code | value;
@@ -273,6 +275,7 @@ pub struct GhcbHandle<'a> {
 }
 
 /// The global Enarx guest hypervisor communication block - GHCB
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub static GHCB: Lazy<RwLocked<GhcbHandle<'_>>> = Lazy::new(|| {
     #[link_section = ".ghcb"]
     static GHCB: RacyCell<Ghcb> = RacyCell::new(<Ghcb as ConstDefault>::DEFAULT);
@@ -283,6 +286,7 @@ pub static GHCB: Lazy<RwLocked<GhcbHandle<'_>>> = Lazy::new(|| {
 });
 
 impl<'a> GhcbHandle<'a> {
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     fn new(ghcb: &'a mut Ghcb) -> Self {
         let ghcb_virt = VirtAddr::from_ptr(ghcb);
 
@@ -307,6 +311,7 @@ impl<'a> GhcbHandle<'a> {
     ///
     /// # Safety
     /// undefined behaviour if not everything is setup according to the GHCB protocol
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     unsafe fn vmgexit(
         &mut self,
         exit_code: u64,
@@ -372,6 +377,7 @@ impl<'a> GhcbHandle<'a> {
     }
 
     /// clear all bits in the valid offset bitfield
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     pub fn invalidate(&mut self) {
         self.ghcb.save_area.sw_exit_code = 0;
         self.ghcb
@@ -392,6 +398,7 @@ impl<'a> GhcbHandle<'a> {
 
 impl RwLocked<GhcbHandle<'_>> {
     /// GHCB IOIO_PROT
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     pub fn do_io_out(&self, portnumber: u16, value: u16) {
         const IOIO_TYPE_OUT: u64 = 0;
         const IOIO_DATA_16: u64 = 1 << 5;
@@ -422,6 +429,7 @@ impl RwLocked<GhcbHandle<'_>> {
     }
 
     /// turn physical pages to decrypted / shared
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     pub fn set_memory_shared(&self, virt_addr: VirtAddr, npages: usize) {
         const SVM_VMGEXIT_PSC: u64 = 0x80000010;
 
@@ -506,6 +514,7 @@ impl RwLocked<GhcbHandle<'_>> {
     ///
     /// # Safety
     /// undefined behaviour, if the parameters don't follow the GHCB protocol
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     pub unsafe fn guest_req(&self, req_gpa: PhysAddr, resp_gpa: PhysAddr) -> Result<(), u64> {
         const SVM_VMGEXIT_GUEST_REQUEST: u64 = 0x80000011;
 
@@ -531,6 +540,7 @@ impl RwLocked<GhcbHandle<'_>> {
     ///
     /// # Safety
     /// undefined behaviour, if the parameters don't follow the GHCB protocol
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     pub unsafe fn guest_req_ext(
         &self,
         data_gpa: PhysAddr,
@@ -598,6 +608,7 @@ pub static GHCB_EXT: Lazy<Locked<&mut GhcbExtHandle>> = Lazy::new(|| unsafe {
 });
 
 impl GhcbExtHandle {
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     fn init(&mut self) {
         let request_virt = VirtAddr::from_ptr(&self.request);
 
@@ -608,6 +619,7 @@ impl GhcbExtHandle {
         GHCB.set_memory_shared(response_virt, 1);
     }
 
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     unsafe fn guest_req(&mut self) -> Result<(), u64> {
         let req_gpa =
             PhysAddr::new((VirtAddr::from_ptr(&self.request) - SHIM_VIRT_OFFSET).as_u64());

--- a/crates/shim-kvm/src/snp/mod.rs
+++ b/crates/shim-kvm/src/snp/mod.rs
@@ -64,6 +64,7 @@ pub enum PvalidateSize {
 ///   a #GP(0) exception.
 /// - VMPL or CPL not zero will result in a #GP(0) exception.
 #[inline(always)]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub fn pvalidate(addr: VirtAddr, size: PvalidateSize, validated: bool) -> Result<bool, Error> {
     let rmp_changed: u32;
     let ret: u64;

--- a/crates/shim-kvm/src/sse.rs
+++ b/crates/shim-kvm/src/sse.rs
@@ -12,6 +12,7 @@ use x86_64::registers::{
 };
 
 /// Setup and check SSE relevant stuff
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub fn init_sse() {
     const XSAVE_SUPPORTED_BIT: u32 = 1 << 26;
     let xsave_supported = (cpuid_count(1, 0).ecx & XSAVE_SUPPORTED_BIT) != 0;

--- a/crates/shim-kvm/src/syscall.rs
+++ b/crates/shim-kvm/src/syscall.rs
@@ -26,6 +26,7 @@ struct X8664DoubleReturn {
 /// # Safety
 ///
 /// This function is not be called from rust.
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 #[naked]
 pub unsafe extern "sysv64" fn _syscall_enter() -> ! {
     // TaskStateSegment.privilege_stack_table[0]

--- a/crates/shim-kvm/src/usermode.rs
+++ b/crates/shim-kvm/src/usermode.rs
@@ -12,6 +12,7 @@ use const_default::ConstDefault;
 ///
 /// Because the caller can give any `entry_point` and `stack_pointer`
 /// including 0, this function is unsafe.
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub unsafe fn usermode(ip: u64, sp: u64) -> ! {
     static XSAVE: xsave::XSave = <xsave::XSave as ConstDefault>::DEFAULT;
 


### PR DESCRIPTION
Since `#[no_coverage]` is unstable, it is recommended to use it together with `cfg(coverage)` or `cfg(coverage_nightly)` set by `cargo-llvm-cov`.

See https://github.com/taiki-e/cargo-llvm-cov/#exclude-function-from-coverage


Related: https://github.com/enarx/enarx/issues/1894

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
