### PR TITLE
ci: use codecov-action v3

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,17 +33,17 @@ jobs:
             host: [ self-hosted, linux ]
           - name: nil
             path: .
-            host: [ self-hosted, linux ]
+            host: ubuntu-20.04
             flags: "--test integration --bin enarx -- wasm::"
           - name: exec-wasmtime
             path: ./crates/exec-wasmtime
             host: [ self-hosted, linux ]
           - name: shim-kvm
             path: ./crates/shim-kvm
-            host: [ self-hosted, linux ]
+            host: [ self-hosted, linux, sev-snp ]
           - name: shim-sgx
             path: ./crates/shim-sgx
-            host: [ self-hosted, linux ]
+            host: [ self-hosted, linux, sgx ]
           - name: sallyport
             path: ./crates/sallyport
             host: [ self-hosted, linux ]
@@ -71,7 +71,7 @@ jobs:
         run: cargo llvm-cov --target x86_64-unknown-linux-gnu --manifest-path ${{ matrix.crate.path }}/Cargo.toml --lcov --output-path lcov.info ${{ matrix.crate.flags }}
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           directory: ./
           fail_ci_if_error: false


### PR DESCRIPTION
and distribute a little more on the runners

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
