### PR TITLE
chore(shim-kvm): mark coverage regions to exclude

### DIFF
--- a/crates/shim-kvm/src/debug.rs
+++ b/crates/shim-kvm/src/debug.rs
@@ -19,6 +19,7 @@ use crate::snp::snp_active;
 ///
 /// This function causes a triple fault!
 #[inline(never)]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub unsafe fn _early_debug_panic(reason: u64, value: u64) -> ! {
     let mut rbp: u64;
 
@@ -56,6 +57,7 @@ pub unsafe fn _early_debug_panic(reason: u64, value: u64) -> ! {
 ///
 /// This function causes a triple fault!
 #[inline(never)]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub unsafe fn _enarx_asm_triple_fault() -> ! {
     let mut rbp: u64;
 
@@ -74,6 +76,7 @@ pub unsafe fn _enarx_asm_triple_fault() -> ! {
 /// Load an invalid DescriptorTablePointer with no base and limit and
 /// provoke an #UD, which will lead to a triple fault
 #[inline(always)]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 unsafe fn _inline_ud2_triple_fault(frames: [u64; 16]) -> ! {
     _load_invalid_idt();
 
@@ -101,6 +104,7 @@ unsafe fn _inline_ud2_triple_fault(frames: [u64; 16]) -> ! {
 
 /// Load an invalid DescriptorTablePointer with no base and limit
 #[inline(always)]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 unsafe fn _load_invalid_idt() {
     let dtp = DescriptorTablePointer {
         limit: 0,
@@ -119,6 +123,7 @@ unsafe fn backtrace(_rbp: u64) -> [u64; 16] {
 #[cfg(feature = "dbg")]
 /// Produce a backtrace from a frame pointer
 #[inline(always)]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 unsafe fn backtrace(mut rbp: u64) -> [u64; 16] {
     use core::mem::size_of;
 
@@ -151,6 +156,7 @@ unsafe fn backtrace(mut rbp: u64) -> [u64; 16] {
 #[cfg(feature = "dbg")]
 #[inline(never)]
 /// print a stack trace from a stack frame pointer
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub fn print_stack_trace() {
     let mut rbp: usize;
 
@@ -161,6 +167,7 @@ pub fn print_stack_trace() {
 }
 
 #[cfg(feature = "dbg")]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 unsafe fn stack_trace_from_rbp(mut rbp: usize) {
     use crate::exec::EXEC_VIRT_ADDR;
     use crate::paging::SHIM_PAGETABLE;
@@ -228,6 +235,7 @@ unsafe fn stack_trace_from_rbp(mut rbp: usize) {
 }
 
 #[cfg(feature = "dbg")]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub(crate) fn interrupt_trace(stack_frame: &crate::interrupts::ExtendedInterruptStackFrame) {
     use crate::exec::EXEC_VIRT_ADDR;
 

--- a/crates/shim-kvm/src/interrupts.rs
+++ b/crates/shim-kvm/src/interrupts.rs
@@ -126,6 +126,7 @@ macro_rules! declare_interrupt {
 
     ($name:ident => $push_or_exchange:literal, { $code:block }, $($id:ident: $t:ty),*) => {
         #[naked]
+        #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
         unsafe extern "sysv64" fn $name() -> ! {
             extern "sysv64" fn inner ( $($id: $t,)* ) {
                 $code
@@ -240,6 +241,7 @@ declare_interrupt!(
 );
 
 /// The global IDT
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
     unsafe {
@@ -255,6 +257,7 @@ pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
 });
 
 /// Initialize the IDT
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub fn init() {
     #[cfg(debug_assertions)]
     eprintln!("interrupts::init");
@@ -265,6 +268,7 @@ pub fn init() {
 mod debug {
     use super::*;
 
+    #[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
     pub(crate) fn idt_add_debug_exception_handlers(idt: &mut InterruptDescriptorTable) {
         unsafe {
             let virt = VirtAddr::new_unsafe(divide_error_handler as usize as u64);

--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -14,6 +14,7 @@
 #![deny(missing_docs)]
 #![feature(asm_const, asm_sym, c_size_t, core_ffi_c, naked_functions)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(any(coverage, coverage_nightly), feature(no_coverage))]
 
 use crate::snp::cpuid_page::CpuidPage;
 

--- a/crates/shim-kvm/src/main.rs
+++ b/crates/shim-kvm/src/main.rs
@@ -3,7 +3,6 @@
 //! The SEV shim
 //!
 //! Contains the startup code and the main function.
-
 #![no_std]
 #![deny(clippy::all)]
 #![deny(clippy::integer_arithmetic)]
@@ -11,6 +10,7 @@
 #![warn(rust_2018_idioms)]
 #![no_main]
 #![feature(asm_const, asm_sym, naked_functions)]
+#![cfg_attr(any(coverage, coverage_nightly), feature(no_coverage))]
 
 #[allow(unused_extern_crates)]
 extern crate rcrt1;
@@ -57,6 +57,7 @@ static INITIAL_SHIM_STACK: [Page; INITIAL_STACK_PAGES] = [Page::zeroed(); INITIA
 /// This function is unsafe, because the caller has to ensure a 16 byte
 /// aligned usable stack.
 #[allow(clippy::integer_arithmetic)]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 unsafe fn switch_shim_stack(ip: extern "sysv64" fn() -> !, sp: u64) -> ! {
     debug_assert_eq!(sp % 16, 0);
 
@@ -78,6 +79,7 @@ unsafe fn switch_shim_stack(ip: extern "sysv64" fn() -> !, sp: u64) -> ! {
 ///
 /// # Safety
 /// Do not call from Rust.
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 unsafe extern "sysv64" fn _pre_main(c_bit_mask: u64) -> ! {
     C_BIT_MASK.store(c_bit_mask, Ordering::Relaxed);
 
@@ -91,6 +93,7 @@ unsafe extern "sysv64" fn _pre_main(c_bit_mask: u64) -> ! {
 }
 
 /// The main function for the shim with stack setup
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 extern "sysv64" fn main() -> ! {
     unsafe { gdt::init() };
     sse::init_sse();
@@ -106,6 +109,7 @@ extern "sysv64" fn main() -> ! {
 /// if it can't print the panic and exit normally with an error code.
 #[panic_handler]
 #[cfg(not(test))]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
     use core::sync::atomic::AtomicBool;
     use enarx_shim_kvm::debug::_enarx_asm_triple_fault;
@@ -179,6 +183,7 @@ macro_rules! correct_table_c_bit {
 #[no_mangle]
 #[naked]
 #[link_section = ".reset"]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub unsafe extern "sysv64" fn _start() -> ! {
     asm!(
         ".set reset_vector_page, 0xFFFFF000",

--- a/crates/shim-kvm/src/snp/mod.rs
+++ b/crates/shim-kvm/src/snp/mod.rs
@@ -64,6 +64,7 @@ pub enum PvalidateSize {
 ///   a #GP(0) exception.
 /// - VMPL or CPL not zero will result in a #GP(0) exception.
 #[inline(always)]
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub fn pvalidate(addr: VirtAddr, size: PvalidateSize, validated: bool) -> Result<bool, Error> {
     let rmp_changed: u32;
     let ret: u64;

--- a/crates/shim-kvm/src/sse.rs
+++ b/crates/shim-kvm/src/sse.rs
@@ -12,6 +12,7 @@ use x86_64::registers::{
 };
 
 /// Setup and check SSE relevant stuff
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub fn init_sse() {
     const XSAVE_SUPPORTED_BIT: u32 = 1 << 26;
     let xsave_supported = (cpuid_count(1, 0).ecx & XSAVE_SUPPORTED_BIT) != 0;

--- a/crates/shim-kvm/src/syscall.rs
+++ b/crates/shim-kvm/src/syscall.rs
@@ -26,6 +26,7 @@ struct X8664DoubleReturn {
 /// # Safety
 ///
 /// This function is not be called from rust.
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 #[naked]
 pub unsafe extern "sysv64" fn _syscall_enter() -> ! {
     // TaskStateSegment.privilege_stack_table[0]

--- a/crates/shim-kvm/src/usermode.rs
+++ b/crates/shim-kvm/src/usermode.rs
@@ -12,6 +12,7 @@ use const_default::ConstDefault;
 ///
 /// Because the caller can give any `entry_point` and `stack_pointer`
 /// including 0, this function is unsafe.
+#[cfg_attr(any(coverage, coverage_nightly), no_coverage)]
 pub unsafe fn usermode(ip: u64, sp: u64) -> ! {
     static XSAVE: xsave::XSave = <xsave::XSave as ConstDefault>::DEFAULT;
 


### PR DESCRIPTION
Since `#[no_coverage]` is unstable, it is recommended to use it together with `cfg(coverage)` or `cfg(coverage_nightly)` set by `cargo-llvm-cov`.

See https://github.com/taiki-e/cargo-llvm-cov/#exclude-function-from-coverage

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
