### PR TITLE
ci(m1): add build target for self-hosted aarch64 darwin runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
     - main
@@ -27,7 +28,9 @@ jobs:
           target: x86_64-unknown-linux-musl
           nix: x86_64-linux
 
-        # TODO: Enable aarch64
+        - os: aarch64-apple-darwin
+          target: aarch64-apple-darwin
+          nix: aarch64-darwin
 
     runs-on: ${{ matrix.platform.os }}
     steps:
@@ -54,8 +57,24 @@ jobs:
         name: enarx-${{ matrix.platform.target }}-oci
         path: enarx-${{ matrix.platform.target }}-oci
 
-  test-bin:
+  universal-binary:
     needs: build
+    runs-on: macos-11
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: enarx-aarch64-apple-darwin
+    - uses: actions/download-artifact@v3
+      with:
+        name: enarx-x86_64-apple-darwin
+    - run: lipo -create ./enarx-aarch64-apple-darwin ./enarx-x86_64-apple-darwin -output ./enarx-universal-darwin
+    - uses: actions/upload-artifact@v3
+      with:
+        name: enarx-universal-darwin
+        path: enarx-universal-darwin
+
+  test-bin:
+    needs: universal-binary
     strategy:
       matrix:
         platform:
@@ -64,6 +83,15 @@ jobs:
 
         - os: ubuntu-20.04
           target: x86_64-unknown-linux-musl
+
+        - os: aarch64-apple-darwin
+          target: aarch64-apple-darwin
+
+        - os: macos-11
+          target: universal-darwin
+
+        - os: aarch64-apple-darwin
+          target: universal-darwin
 
         # TODO: Enable aarch64
 
@@ -93,6 +121,9 @@ jobs:
     - run: docker load < enarx-${{ matrix.platform.target }}-oci
     # TODO: Attempt to run `enarx info` within the loaded container
 
+
+
+
   release:
     if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
     needs: [ build, test-bin, test-oci ]
@@ -103,7 +134,10 @@ jobs:
       with:
         draft: true
         files: |
+          enarx-aarch64-apple-darwin
+          enarx-aarch64-apple-darwin-oci
           enarx-x86_64-apple-darwin
           enarx-x86_64-apple-darwin-oci
           enarx-x86_64-unknown-linux-musl
           enarx-x86_64-unknown-linux-musl-oci
+          enarx-universal-darwin


### PR DESCRIPTION
Signed-off-by: Paul Pietkiewicz <paul@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
