### PR TITLE
ci: update code coverage tool

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,13 +62,12 @@ jobs:
           rustup show
           rustup component add llvm-tools-preview
 
-      # Use this special version until https://github.com/haraldh/cargo-llvm-cov/commit/a16a14be4a8f2b522f44eed54231b1022e174906
-      # is upstream or in our own enarx repo. It is needed because of our bindeps and enclaves.
+      # TODO: remove this git dependency when cargo-llvm-cov has issued a new release
       - name: Install cargo-llvm-cov
-        run: cargo install --git https://github.com/haraldh/cargo-llvm-cov/ --branch target_rustflags --bin cargo-llvm-cov cargo-llvm-cov
+        run: cargo install --git https://github.com/taiki-e/cargo-llvm-cov/ --rev 6db3a020609073a9bfd5cdd9bbe2f7816057a4e1 cargo-llvm-cov
 
       - name: Run cargo-llvm-cov
-        run: cargo llvm-cov --target x86_64-unknown-linux-gnu --manifest-path ${{ matrix.crate.path }}/Cargo.toml --lcov --output-path lcov.info ${{ matrix.crate.flags }}
+        run: cargo llvm-cov --coverage-target-only --target x86_64-unknown-linux-gnu --manifest-path ${{ matrix.crate.path }}/Cargo.toml --lcov --output-path lcov.info ${{ matrix.crate.flags }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
This uses the new flag added in https://github.com/taiki-e/cargo-llvm-cov/pull/167

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
