### PR TITLE
ci: specify x64 runners for CI jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,14 +30,14 @@ jobs:
             host: [ self-hosted, linux, sgx ]
           - name: kvm
             path: .
-            host: [ self-hosted, linux ]
+            host: [ self-hosted, linux, x64 ]
           - name: nil
             path: .
             host: ubuntu-20.04
             flags: "--test integration --bin enarx -- wasm::"
           - name: exec-wasmtime
             path: ./crates/exec-wasmtime
-            host: [ self-hosted, linux ]
+            host: [ self-hosted, linux, x64 ]
           - name: shim-kvm
             path: ./crates/shim-kvm
             host: [ self-hosted, linux, sev-snp ]
@@ -46,7 +46,7 @@ jobs:
             host: [ self-hosted, linux, sgx ]
           - name: sallyport
             path: ./crates/sallyport
-            host: [ self-hosted, linux ]
+            host: [ self-hosted, linux, x64 ]
 
     steps:
       - run: sudo apt -o Acquire::Retries=3 update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         backend:
           - {name: sev, host: [self-hosted, linux, sev-snp]}
           - {name: sgx, host: [self-hosted, linux, sgx]}
-          - {name: kvm, host: [self-hosted, linux]}
+          - {name: kvm, host: [self-hosted, linux, x64]}
         profile:
           - name: debug
           - name: debug with dbg


### PR DESCRIPTION
After adding some ARM builders we have to specify x64 for jobs that require it, otherwise tests fail randomly.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
