### PR TITLE
docs(sgx): reburnish the SGX GDB documentation

### DIFF
--- a/crates/shim-sgx/src/handler/gdb.rs
+++ b/crates/shim-sgx/src/handler/gdb.rs
@@ -75,7 +75,7 @@ impl<'a> super::Handler<'a> {
         let mut buf = [0; 4096];
         debugln!(self, "Starting GDB session...");
         debugln!(self, "symbol-file -o {:#x} <shim>", shim_address());
-        debugln!(self, "symbol-file -o {:#x} <exec>", unsafe {
+        debugln!(self, "add-symbol-file -o {:#x} <exec>", unsafe {
             &ENARX_EXEC_START as *const u8 as u64
         });
 


### PR DESCRIPTION
Link: #1938
Closes: #1930
