### PR TITLE
build(toolchain): bump Rust to 2022-05-28

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-05-03"
+channel = "nightly-2022-05-28"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-unknown-none", "wasm32-wasi"]
 profile = "minimal"
-components = ["rustfmt", "clippy", "miri", "rust-src"]
+components = ["rustfmt", "clippy", "miri"]


### PR DESCRIPTION
Also remove the rust-src component, which is no longer necessary now that build-std is no longer being used.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
