### PR TITLE
refactor: reduce crate feature surface area

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [".github/"]
 default = []
 
 # non-default features
-gdb = ["gdbstub", "enarx-shim-kvm/gdb", "enarx-shim-sgx/gdb"]
+gdb = ["dep:gdbstub", "enarx-shim-kvm/gdb", "enarx-shim-sgx/gdb"]
 dbg = [ "enarx-shim-kvm/dbg", "enarx-shim-sgx/dbg" ]
 disable-sgx-attestation = ["enarx-shim-sgx/disable-sgx-attestation"]
 

--- a/crates/sallyport/Cargo.toml
+++ b/crates/sallyport/Cargo.toml
@@ -10,12 +10,12 @@ keywords = ["enarx", "syscall"]
 categories = ["no-std"]
 
 [features]
-doc = ["gdbstub"]
+doc = ["dep:gdbstub"]
 
 [dependencies]
 goblin = { version = "0.5", features = ["elf64"], default-features = false }
 
-# optional features
+# optional dependencies
 gdbstub = { version = "0.6", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/crates/shim-kvm/Cargo.toml
+++ b/crates/shim-kvm/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/enarx/sallyport"
 license = "Apache-2.0"
 
 [features]
-gdb = ["gdbstub", "gdbstub_arch", "dbg"]
+gdb = ["dep:gdbstub", "dep:gdbstub_arch", "dbg"]
 dbg = []
 
 [dependencies]

--- a/crates/shim-sgx/Cargo.toml
+++ b/crates/shim-sgx/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/enarx/sallyport"
 license = "Apache-2.0"
 
 [features]
-gdb = ["gdbstub", "gdbstub_arch", "dbg"]
+gdb = ["dep:gdbstub", "dep:gdbstub_arch", "dbg"]
 dbg = []
 disable-sgx-attestation = []
 


### PR DESCRIPTION
By default, making a crate into an optional dependency also makes it into a crate feature. Using a recent Cargo feature, we can disable this behavior and reduce the number of crate features to only those that are explicitly declared.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
