### PR TITLE
docs: add Quickstart installation guide

### DIFF
--- a/docs/Quickstart.mdx
+++ b/docs/Quickstart.mdx
@@ -6,12 +6,14 @@ import TabItem from '@theme/TabItem';
 This is the quick installation guide for Enarx. The goal is to help you get started using Enarx right away for development/debugging purposes on Windows, macOS, and Linux.
 
 :::note
-To build from source, please refer to the [complete installation guide](https://enarx.dev/docs/Install).
+To build from source, please refer to the [complete installation guide](Install).
 :::
 
 :::note
 Full [TEE](https://enarx.dev/docs/Start/TEE) (Intel SGX/AMD SEV-SNP) and KVM support is available with the published statically compiled Linux binary.
 :::
+
+Please select your operating system:
 
 <Tabs>
   <TabItem value="windows" label="Windows">

--- a/docs/Quickstart.mdx
+++ b/docs/Quickstart.mdx
@@ -45,7 +45,7 @@ There are two ways to install Enarx on macOS, either downloading the binary or u
 
 To download and install the macOS binary, enter in the macOS terminal the following commands:
 
-`curl -L https://github.com/enarx/enarx/releases/download/v0.5.2/enarx-universal-darwin --output enarx`
+`curl -L https://github.com/enarx/enarx/releases/download/v0.5.1/enarx-universal-darwin --output enarx`
 
 `sudo install -m 755 enarx /usr/local/bin/enarx`
 
@@ -82,7 +82,7 @@ To install Enarx on Linux, you can download the Enarx binary. For `X86_64` archi
 
 Download the appropriate Enarx binary (in the case below, we are downloading for `X86_64`):
 
-`wget https://github.com/enarx/enarx/releases/download/v0.5.2/enarx-x86_64-unknown-linux-musl`
+`wget https://github.com/enarx/enarx/releases/download/v0.5.1/enarx-x86_64-unknown-linux-musl`
 
 ![linux wget](https://enarx.dev/img/install/linux_wget.png?raw=true)
 

--- a/docs/Quickstart.mdx
+++ b/docs/Quickstart.mdx
@@ -28,7 +28,7 @@ Open PowerShell from the Start menu and type `winget install Enarx` to install E
 
 ![windows install enarx](https://enarx.dev/img/install/win_install_enarx.png?raw=true)
 
-To test `enarx` we should download a sample WebAssembly file (`hello-word.wasm`) to test it:
+To test `enarx` we should download a sample WebAssembly file (`hello-word.wasm`):
 
 `iwr https://enarx.dev/hello-world.wasm -OutFile hello-world.wasm`
 
@@ -45,7 +45,7 @@ There are two ways to install Enarx on macOS, either downloading the binary or u
 
 To download and install the macOS binary, enter in the macOS terminal the following commands:
 
-`curl -L https://github.com/enarx/enarx/releases/download/v0.5.1/enarx-universal-darwin --output enarx`
+`curl -L https://github.com/enarx/enarx/releases/download/v0.5.2/enarx-universal-darwin --output enarx`
 
 `sudo install -m 755 enarx /usr/local/bin/enarx`
 
@@ -65,7 +65,7 @@ To install Enarx, simply type:
 
 ![mac install enarx](https://enarx.dev/img/install/mac_install_enarx.png?raw=true)
 
-To test `enarx` we should download a sample WebAssembly file (`hello-word.wasm`) to test it:
+To test `enarx` we should download a sample WebAssembly file (`hello-word.wasm`):
 
 `curl https://enarx.dev/hello-world.wasm -o hello-world.wasm`
 
@@ -96,7 +96,7 @@ Now type the following to install Enarx:
 
 ![linux install enarx](https://enarx.dev/img/install/linux_install_enarx.png?raw=true)
 
-To test `enarx` we should download a sample WebAssembly file (`hello-word.wasm`) to test it:
+To test `enarx` we should download a sample WebAssembly file (`hello-word.wasm`):
 
 `wget https://enarx.dev/hello-world.wasm`
 

--- a/docs/Quickstart.mdx
+++ b/docs/Quickstart.mdx
@@ -1,0 +1,98 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Quick Installation
+
+This is the quick installation guide for Enarx. The goal is to help you get started using Enarx right away for development/debugging purposes.
+
+:::note
+To ensure that you are going to execute your application in a [Trusted Execution Environment](https://enarx.dev/docs/Start/TEE), please refer to the [complete installation guide](https://enarx.dev/docs/Install).
+:::
+
+<Tabs>
+  <TabItem value="windows" label="Windows">
+
+Before installing Enarx, we'll install PowerShell (Windows' command line) and winget (Windows' package manager) from the Microsoft Store.
+
+Click on the Start menu, type `store`, and open Microsoft Store.
+
+In the search bar, type `powershell` and click on the `Get` button to install PowerShell.
+
+Do the same for winget. Type `winget` in the search bar, and click on the `Get` button to install winget.
+
+Open PowerShell from the Start menu and type `winget install Enarx` to install Enarx.
+
+![windows install enarx](https://enarx.dev/img/install/win_install_enarx.png?raw=true)
+
+Let's download a WebAssembly file (`hello-word.wasm`) to test it:
+
+`iwr https://enarx.dev/hello-world.wasm -OutFile hello-world.wasm`
+
+Now run it using the `enarx run` command:
+
+`enarx run hello-world.wasm`
+
+![windows enarx info and run](https://enarx.dev/img/install/win_enarx_run.png?raw=true)
+
+  </TabItem>
+  <TabItem value="macos" label="macOS">
+
+We'll install Enarx using Homebrew, an open-source macOS package manager:
+
+https://brew.sh/
+
+Type the following command in the macOS terminal to install Homebrew:
+
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+
+![mac install brew](https://enarx.dev/img/install/mac_brew.png?raw=true)
+
+To install Enarx, simply type:
+
+`brew install enarx`
+
+![mac install enarx](https://enarx.dev/img/install/mac_install_enarx.png?raw=true)
+
+Let's download a WebAssembly file (`hello-word.wasm`) to test it:
+
+`curl https://enarx.dev/hello-world.wasm -o hello-world.wasm`
+
+Now run it using the `enarx run` command:
+
+`enarx run hello-world.wasm`
+
+![mac enarx](https://enarx.dev/img/install/mac_enarx_run.png?raw=true)
+
+  </TabItem>
+  <TabItem value="linux" label="Linux">
+
+You can download the Enarx binary by typing the following command in the terminal:
+
+`wget https://github.com/enarx/enarx/releases/download/v0.5.2/enarx-x86_64-unknown-linux-musl`
+
+![linux wget](https://enarx.dev/img/install/linux_wget.png?raw=true)
+
+:::note
+The `enarx-x86_64-unknown-linux-musl` binary supports only the "nil" backend, and does not use a Trusted Execution Environment (TEE) to run the Wasm application.
+:::
+
+Now type the following to install Enarx:
+
+`sudo install -m 4711 -o root enarx-x86_64-unknown-linux-musl /usr/bin/enarx`
+
+![linux install enarx](https://enarx.dev/img/install/linux_install_enarx.png?raw=true)
+
+Let's download a WebAssembly file (`hello-word.wasm`) to test it:
+
+`wget https://enarx.dev/hello-world.wasm`
+
+Now run it using the `enarx run` command:
+
+`enarx run hello-world.wasm`
+
+![linux enarx run and info](https://enarx.dev/img/install/linux_enarx_run.png?raw=true)
+
+  </TabItem>
+</Tabs>
+
+What's next? Learn how you can compile your application to WebAssembly from various programming languages by studying the [WebAssembly Guide](https://enarx.dev/docs/WebAssembly/Introduction).

--- a/docs/Quickstart.mdx
+++ b/docs/Quickstart.mdx
@@ -3,28 +3,32 @@ import TabItem from '@theme/TabItem';
 
 # Quick Installation
 
-This is the quick installation guide for Enarx. The goal is to help you get started using Enarx right away for development/debugging purposes.
+This is the quick installation guide for Enarx. The goal is to help you get started using Enarx right away for development/debugging purposes on Windows, macOS, and Linux.
 
 :::note
-To ensure that you are going to execute your application in a [Trusted Execution Environment](https://enarx.dev/docs/Start/TEE), please refer to the [complete installation guide](https://enarx.dev/docs/Install).
+To build from source, please refer to the [complete installation guide](https://enarx.dev/docs/Install).
+:::
+
+:::note
+Full [TEE](https://enarx.dev/docs/Start/TEE) (Intel SGX/AMD SEV-SNP) and KVM support is available with the published statically compiled Linux binary.
 :::
 
 <Tabs>
   <TabItem value="windows" label="Windows">
 
-Before installing Enarx, we'll install PowerShell (Windows' command line) and winget (Windows' package manager) from the Microsoft Store.
+Before installing Enarx, we need to install PowerShell (Windows' command line) and winget (Windows' package manager) from the Microsoft Store.
 
 Click on the Start menu, type `store`, and open Microsoft Store.
 
-In the search bar, type `powershell` and click on the `Get` button to install PowerShell.
+In the search bar, type `powershell` and click on the `Get` button to install [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows). 
 
-Do the same for winget. Type `winget` in the search bar, and click on the `Get` button to install winget.
+Do the same for winget. Type `winget` in the search bar, and click on the `Get` button to install [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/).
 
 Open PowerShell from the Start menu and type `winget install Enarx` to install Enarx.
 
 ![windows install enarx](https://enarx.dev/img/install/win_install_enarx.png?raw=true)
 
-Let's download a WebAssembly file (`hello-word.wasm`) to test it:
+To test `enarx` we should download a sample WebAssembly file (`hello-word.wasm`) to test it:
 
 `iwr https://enarx.dev/hello-world.wasm -OutFile hello-world.wasm`
 
@@ -37,11 +41,19 @@ Now run it using the `enarx run` command:
   </TabItem>
   <TabItem value="macos" label="macOS">
 
-We'll install Enarx using Homebrew, an open-source macOS package manager:
+There are two ways to install Enarx on macOS, either downloading the binary or using Homebrew.
+
+To download and install the macOS binary, enter in the macOS terminal the following commands:
+
+`curl -L https://github.com/enarx/enarx/releases/download/v0.5.1/enarx-universal-darwin --output enarx`
+
+`sudo install -m 755 enarx /usr/local/bin/enarx`
+
+You can also install Enarx using Homebrew, an open-source macOS package manager:
 
 https://brew.sh/
 
-Type the following command in the macOS terminal to install Homebrew:
+Type the following command in the macOS terminal to install [Homebrew](https://brew.sh/):
 
 `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 
@@ -53,7 +65,7 @@ To install Enarx, simply type:
 
 ![mac install enarx](https://enarx.dev/img/install/mac_install_enarx.png?raw=true)
 
-Let's download a WebAssembly file (`hello-word.wasm`) to test it:
+To test `enarx` we should download a sample WebAssembly file (`hello-word.wasm`) to test it:
 
 `curl https://enarx.dev/hello-world.wasm -o hello-world.wasm`
 
@@ -66,23 +78,25 @@ Now run it using the `enarx run` command:
   </TabItem>
   <TabItem value="linux" label="Linux">
 
-You can download the Enarx binary by typing the following command in the terminal:
+To install Enarx on Linux, you can download the Enarx binary. For `X86_64` architectures (the most common), you would download the `enarx-x86_64-unknown-linux-musl` binary and for `AARCH64` architectures (ARM64 processors) you would download the `enarx-aarch64-unknown-linux-musl` binary.
+
+Download the appropriate Enarx binary (in the case below, we are downloading for `X86_64`):
 
 `wget https://github.com/enarx/enarx/releases/download/v0.5.2/enarx-x86_64-unknown-linux-musl`
 
 ![linux wget](https://enarx.dev/img/install/linux_wget.png?raw=true)
 
 :::note
-The `enarx-x86_64-unknown-linux-musl` binary supports only the "nil" backend, and does not use a Trusted Execution Environment (TEE) to run the Wasm application.
+The `enarx-aarch64-unknown-linux-musl` binary supports only the "nil" backend, and does not use a Trusted Execution Environment (TEE) to run the Wasm application, unlike the `enarx-x86_64-unknown-linux-musl` binary.
 :::
 
 Now type the following to install Enarx:
 
-`sudo install -m 4711 -o root enarx-x86_64-unknown-linux-musl /usr/bin/enarx`
+`sudo install -m 4755 -o root enarx-x86_64-unknown-linux-musl /usr/bin/enarx`
 
 ![linux install enarx](https://enarx.dev/img/install/linux_install_enarx.png?raw=true)
 
-Let's download a WebAssembly file (`hello-word.wasm`) to test it:
+To test `enarx` we should download a sample WebAssembly file (`hello-word.wasm`) to test it:
 
 `wget https://enarx.dev/hello-world.wasm`
 


### PR DESCRIPTION
Adding Quickstart installation guide with instructions for Windows, macOS, and Linux using the appropriates binaries.

Closes #1895 

Signed-off-by: Nick Vidal <nick@profian.com>