### PR TITLE
fix(sgx): prevent aesmd error 42 - ATT_KEY_NOT_INITIALIZED

### DIFF
--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -446,6 +446,10 @@ impl<'a> Handler<'a> {
             return Ok([0, 0]);
         }
 
+        let mut target_info = TargetInfo::default();
+
+        self.get_sgx_target_info(&mut target_info)?;
+
         let quote_size = self.get_sgx_quote_size()?;
 
         if buf == 0 {
@@ -472,10 +476,6 @@ impl<'a> Handler<'a> {
         };
 
         let buf = platform.validate_slice_mut::<u8>(buf, buf_len)?;
-
-        let mut target_info = TargetInfo::default();
-
-        self.get_sgx_target_info(&mut target_info)?;
 
         // Generate Report
         let report: Report = target_info.enclu_ereport(&ReportData(hash));

--- a/src/backend/sgx/attestation.rs
+++ b/src/backend/sgx/attestation.rs
@@ -25,6 +25,123 @@ const AESM_REQUEST_TIMEOUT: u32 = 1_000_000;
 const SGX_KEY_ID_SIZE: u32 = 256;
 const SGX_REPORT_SIZE: usize = 432;
 
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum AesmError {
+    UnexpectedError,
+    NoDeviceError,
+    ParameterError,
+    EpidblobError,
+    EpidRevokedError,
+    GetLicensetokenError,
+    SessionInvalid,
+    MaxNumSessionReached,
+    PsdaUnavailable,
+    EphSessionFailed,
+    LongTermPairingFailed,
+    NetworkError,
+    NetworkBusyError,
+    ProxySettingAssist,
+    FileAccessError,
+    SgxProvisionFailed,
+    ServiceStopped,
+    Busy,
+    BackendServerBusy,
+    UpdateAvailable,
+    OutOfMemoryError,
+    MsgError,
+    ThreadError,
+    SgxDeviceNotAvailable,
+    EnableSgxDeviceFailed,
+    PlatformInfoBlobInvalidSig,
+    ServiceNotAvailable,
+    KdfMismatch,
+    OutOfEpc,
+    ServiceUnavailable,
+    UnrecognizedPlatform,
+    EcdsaIdMismatch,
+    PathnameBufferOverflowError,
+    ErrorStoredKey,
+    PubKeyIdMismatch,
+    InvalidPceSigScheme,
+    AttKeyBlobError,
+    UnsupportedAttKeyId,
+    UnsupportedLoadingPolicy,
+    InterfaceUnavailable,
+    PlatformLibUnavailable,
+    AttKeyNotInitialized,
+    AttKeyCertDataInvalid,
+    NoPlatformCertData,
+    ErrorReport,
+    EnclaveLost,
+    InvalidReport,
+    EnclaveLoadError,
+    UnableToGenerateQeReport,
+    KeyCertificationError,
+    ConfigUnsupported,
+    Unknown(u32),
+}
+
+impl From<u32> for AesmError {
+    fn from(n: u32) -> AesmError {
+        use self::AesmError::*;
+        match n {
+            1 => UnexpectedError,
+            2 => NoDeviceError,
+            3 => ParameterError,
+            4 => EpidblobError,
+            5 => EpidRevokedError,
+            6 => GetLicensetokenError,
+            7 => SessionInvalid,
+            8 => MaxNumSessionReached,
+            9 => PsdaUnavailable,
+            10 => EphSessionFailed,
+            11 => LongTermPairingFailed,
+            12 => NetworkError,
+            13 => NetworkBusyError,
+            14 => ProxySettingAssist,
+            15 => FileAccessError,
+            16 => SgxProvisionFailed,
+            17 => ServiceStopped,
+            18 => Busy,
+            19 => BackendServerBusy,
+            20 => UpdateAvailable,
+            21 => OutOfMemoryError,
+            22 => MsgError,
+            23 => ThreadError,
+            24 => SgxDeviceNotAvailable,
+            25 => EnableSgxDeviceFailed,
+            26 => PlatformInfoBlobInvalidSig,
+            27 => ServiceNotAvailable,
+            28 => KdfMismatch,
+            29 => OutOfEpc,
+            30 => ServiceUnavailable,
+            31 => UnrecognizedPlatform,
+            32 => EcdsaIdMismatch,
+            33 => PathnameBufferOverflowError,
+            34 => ErrorStoredKey,
+            35 => PubKeyIdMismatch,
+            36 => InvalidPceSigScheme,
+            37 => AttKeyBlobError,
+            38 => UnsupportedAttKeyId,
+            39 => UnsupportedLoadingPolicy,
+            40 => InterfaceUnavailable,
+            41 => PlatformLibUnavailable,
+            42 => AttKeyNotInitialized,
+            43 => AttKeyCertDataInvalid,
+            44 => NoPlatformCertData,
+            45 => ErrorReport,
+            46 => EnclaveLost,
+            47 => InvalidReport,
+            48 => EnclaveLoadError,
+            49 => UnableToGenerateQeReport,
+            50 => KeyCertificationError,
+            51 => ConfigUnsupported,
+            _ => Unknown(n),
+        }
+    }
+}
+
 struct AesmTransaction(Request);
 
 impl Deref for AesmTransaction {
@@ -94,7 +211,7 @@ fn get_key_id_num() -> Result<u32, Error> {
             ErrorKind::Other,
             format!(
                 "Received error code {:?} in GetSupportedAttKeyIDNum",
-                res.get_errorCode()
+                AesmError::from(res.get_errorCode())
             ),
         ));
     }
@@ -119,7 +236,10 @@ fn get_key_ids(num_key_ids: u32) -> Result<Vec<Vec<u8>>, Error> {
     if res.get_errorCode() != 0 {
         return Err(Error::new(
             ErrorKind::InvalidData,
-            format!("GetSupportedAttKeyIDs: error: {:?}", res.get_errorCode()),
+            format!(
+                "GetSupportedAttKeyIDs: error: {:?}",
+                AesmError::from(res.get_errorCode())
+            ),
         ));
     }
 
@@ -187,7 +307,10 @@ pub fn get_target_info(akid: Vec<u8>, size: usize, out_buf: &mut [u8]) -> Result
     if res.get_errorCode() != 0 {
         return Err(Error::new(
             ErrorKind::InvalidData,
-            format!("InitQuoteExRequest: error: {:?}", res.get_errorCode()),
+            format!(
+                "InitQuoteExRequest: error: {:?}",
+                AesmError::from(res.get_errorCode())
+            ),
         ));
     }
 
@@ -226,7 +349,10 @@ pub fn get_key_size(akid: Vec<u8>) -> Result<usize, Error> {
     if res.get_errorCode() != 0 {
         return Err(Error::new(
             ErrorKind::InvalidData,
-            format!("InitQuoteEx error: {:?}", res.get_errorCode()),
+            format!(
+                "InitQuoteEx error: {:?}",
+                AesmError::from(res.get_errorCode())
+            ),
         ));
     }
 
@@ -249,7 +375,10 @@ pub fn get_quote_size(akid: Vec<u8>) -> Result<usize, Error> {
     if res.get_errorCode() != 0 {
         return Err(Error::new(
             ErrorKind::InvalidData,
-            format!("GetQuoteSizeEx error: {:?}", res.get_errorCode()),
+            format!(
+                "GetQuoteSizeEx error: {:?}",
+                AesmError::from(res.get_errorCode())
+            ),
         ));
     }
 
@@ -275,7 +404,10 @@ pub fn get_quote(report: &[u8], akid: Vec<u8>, out_buf: &mut [u8]) -> Result<usi
     if res.get_errorCode() != 0 {
         return Err(Error::new(
             ErrorKind::InvalidData,
-            format!("GetQuoteEx error: {:?}", res.get_errorCode()),
+            format!(
+                "GetQuoteEx error: {:?}",
+                AesmError::from(res.get_errorCode())
+            ),
         ));
     }
 


### PR DESCRIPTION
With a freshly started PCCS daemon, the aesmd returns `AttKeyNotInitialized` and according to
https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/fe200aa160bc159f92149f02e703f0b02e4348d2/QuoteGeneration/quote_wrapper/ql/sgx_dcap_ql_wrapper.cpp#L423-L424

> ATT_KEY_NOT_INITIALIZED The platform quoting infrastructure does not have the attestation key available to generate quotes. `sgx_qe_get_target_info()` must be called again.
    
So, calling `get_sgx_target_info()` before `get_sgx_quote_size()` prevents the problem.
    
Also translate the numeric errors from aesmd to names according to `psw/ae/inc/internal/aesm_error.h`
    
Signed-off-by: Harald Hoyer <harald@profian.com>


PCCS log in error case:
```
Jun 22 12:14:06 localhost pccs[538425]: 2022-06-22 12:14:06.100 [info]: Client Request-ID : 6cf777d6a6c64e5f9eeeeb757d1073da
Jun 22 12:14:06 localhost pccs[538425]: 2022-06-22 12:14:06.107 [error]: TypeError: Cannot read property '1' of undefined
Jun 22 12:14:06 localhost pccs[538425]:     at new PccsError (/opt/intel/sgx-dcap-pccs/utils/PccsError.js:35:14)
Jun 22 12:14:06 localhost podman[537974]:     at new PccsError (/opt/intel/sgx-dcap-pccs/utils/PccsError.js:35:14)
Jun 22 12:14:06 localhost podman[537974]:     at Proxy.getPckCertFromPCS (/opt/intel/sgx-dcap-pccs/services/logic/commonCacheLogic.js:77:13)
Jun 22 12:14:06 localhost podman[537974]:     at LazyCachingMode.getPckCertFromPCS (/opt/intel/sgx-dcap-pccs/services/caching_modes/cachingMode.js:126:35)
Jun 22 12:14:06 localhost podman[537974]:     at CachingModeManager.getPckCertFromPCS (/opt/intel/sgx-dcap-pccs/services/caching_modes/cachingModeManager.js:54:23)
Jun 22 12:14:06 localhost podman[537974]:     at Proxy.getPckCert (/opt/intel/sgx-dcap-pccs/services/pckcertService.js:115:41)
Jun 22 12:14:06 localhost podman[537974]:     at async getPckCert (/opt/intel/sgx-dcap-pccs/controllers/pckcertController.js:77:25)
Jun 22 12:14:06 localhost pccs[538425]:     at Proxy.getPckCertFromPCS (/opt/intel/sgx-dcap-pccs/services/logic/commonCacheLogic.js:77:13)
Jun 22 12:14:06 localhost pccs[538425]:     at LazyCachingMode.getPckCertFromPCS (/opt/intel/sgx-dcap-pccs/services/caching_modes/cachingMode.js:126:35)
Jun 22 12:14:06 localhost pccs[538425]:     at CachingModeManager.getPckCertFromPCS (/opt/intel/sgx-dcap-pccs/services/caching_modes/cachingModeManager.js:54:23)
Jun 22 12:14:06 localhost pccs[538425]:     at Proxy.getPckCert (/opt/intel/sgx-dcap-pccs/services/pckcertService.js:115:41)
Jun 22 12:14:06 localhost pccs[538425]:     at async getPckCert (/opt/intel/sgx-dcap-pccs/controllers/pckcertController.js:77:25)
Jun 22 12:14:06 localhost pccs[538425]: 2022-06-22 12:14:06.109 [info]: 127.0.0.1 - - [22/Jun/2022:12:14:06 +0000] "GET /sgx/certification/v3/pckcert?qeid=E25D0F4E649CD7D8C788BFC27BCA4F78&encrypted_ppid=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000&cpusvn=06080E0DFFFF00000000000000000000&pcesvn=0C00&pceid=0000 HTTP/1.1" 500 31 "-" "-"
```

PCCS log in working case:
```
Jun 22 12:23:53 localhost pccs[560464]: 2022-06-22 12:23:53.497 [info]: Client Request-ID : ac84891b2d9f4e8e914178eb70c1a688
Jun 22 12:23:55 localhost pccs[560464]: 2022-06-22 12:23:55.703 [info]: Request-ID is : e0d845de8a4e42fd91f116b0bd6eb04a
Jun 22 12:23:55 localhost pccs[560464]: 2022-06-22 12:23:55.724 [info]: Request-ID is : 6e6f4d79bb4141a2b7da4c3e92751757
Jun 22 12:24:05 localhost pccs[560464]: 2022-06-22 12:24:05.569 [info]: 127.0.0.1 - - [22/Jun/2022:12:24:05 +0000] "GET /sgx/certification/v3/pckcert?qeid=E25D0F4E649CD7D8C788BFC27BCA4F78&encrypted_ppid=23713607E91910FDAAFE4A7DFD70936F2D3974BDD1B91BE087A0246A8B52ADB393609B1E7425F6E07C29EFE277C55E9DDBE61272FB8FFB4346C972F8FB95E9AFA77748311B4A9B8FFD8B6ACBC1B1B74CD203AE05DA69F74A957E2F035DB416F76D3C4B552CCC8AB50F00FDFC37EC9EADD1E4BB8A1BDFD7F620CF7FDEBEE4CA3BFE94433BCE64A10CA9197F8E90257BE8296E093605DA48638AEF2816FDD9497F40FD3F97F593A79640DFC1756B55F292D67E8831D30F7AF0D3AF67F70421BC80E45DE263EDAF481BE9059ADF5050084F227089A98BF9B6907C54082D3418EA33788D0D66C7EF26471587D8E0986A7119A2F48BCD541D59942B4134F2BC0D801105CCA66E1A3FC44D3520EC0B1ED4B262C2961DBC1BB55F2B8E45EFB69BE0FED92ACFF706004402DE7FEAA8F6DCA4E33E73D8BAEA91BF0800888DA25062FC025DEF85ABA79A681C484A22AC98E7A6D83D7AD8AAC25D465E729A64AFBC94D5EDC1C24A6204B36B1BEC2165F01C0541E8AB74D642ABFE1F3BEBB96EE983F977E76D&cpusvn=06080E0DFFFF00000000000000000000&pcesvn=0C00&pceid=0000 HTTP/1.1" 200 1777 "-" "-"
```


