### PR TITLE
ci(release): add built assets to release draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,8 +196,34 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/download-artifact@v3
-    - name: Display structure of downloaded files
-      run: ls -R
+      with:
+        name: enarx-x86_64-windows.exe
+    - uses: actions/download-artifact@v3
+      with:
+        name: enarx-x86_64-windows.msi
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: enarx-x86_64-apple-darwin
+    - uses: actions/download-artifact@v3
+      with:
+        name: enarx-x86_64-apple-darwin-oci
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: enarx-x86_64-unknown-linux-musl
+    - uses: actions/download-artifact@v3
+      with:
+        name: enarx-x86_64-unknown-linux-musl-oci
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: enarx-aarch64-unknown-linux-musl
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: enarx-universal-darwin
+
     - uses: softprops/action-gh-release@v1
       with:
         draft: true
@@ -205,6 +231,7 @@ jobs:
         files: |
           enarx-x86_64-windows.exe
           enarx-x86_64-windows.msi
+          enarx-x86_64-apple-darwin
           enarx-x86_64-apple-darwin-oci
           enarx-x86_64-unknown-linux-musl
           enarx-x86_64-unknown-linux-musl-oci


### PR DESCRIPTION
The following job step is currently a no-op since none of the configured artifacts are actually present at the paths. By default `download-artifact` action downloads "all artifacts" into a directory.
Specify each artifact name explicitly to fail fast on missing artifacts and to make following step actually add assets to the draft release

Just like https://github.com/profianinc/drawbridge/blob/9f889cbadd0d066aee566f2ff44221aaa31c8c45/.github/workflows/release.yml#L85-L98