### PR TITLE
fix(sgx): revert the use of AVX2 and AVX512

### DIFF
--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -27,14 +27,7 @@ pub const ENCL_SIZE_BITS: u8 = 32;
 /// FIXME: doc
 pub const ENCL_SIZE: usize = 1 << ENCL_SIZE_BITS;
 
-const XFRM: Xfrm = Xfrm::from_bits_truncate(
-    Xfrm::X87.bits()
-        | Xfrm::SSE.bits()
-        | Xfrm::AVX.bits()
-        | Xfrm::OPMASK.bits()
-        | Xfrm::ZMM_HI256.bits()
-        | Xfrm::HI16_ZMM.bits(),
-);
+const XFRM: Xfrm = Xfrm::from_bits_truncate(Xfrm::X87.bits() | Xfrm::SSE.bits());
 
 /// Default enclave CPU attributes
 pub const ATTR: Attributes = Attributes::new(Features::MODE64BIT, XFRM);


### PR DESCRIPTION
Fixes: 55caa95159c9 ("feat(shim-sgx): enable AVX2 and AVX512 usage in the enclave")
Closes: #1459
Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
