### PR TITLE
fix(deps): update linked_list_allocator requirement from 0.9.1 to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,9 +1911,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
+checksum = "636c3bc929db632724303109c88d5d559a2a60f62243bb041387f03fa081d94a"
 
 [[package]]
 name = "linux-raw-sys"

--- a/crates/shim-kvm/Cargo.toml
+++ b/crates/shim-kvm/Cargo.toml
@@ -17,7 +17,7 @@ array-const-fn-init = { version = "0.1", default-features = false }
 const-default = { version = "1.0", features = ["derive"], default-features = false }
 crt0stack = { version = "0.1", default-features = false }
 goblin = { version = "0.5", features = ["elf64"], default-features = false }
-linked_list_allocator = { version = "0.9.1", default-features = false }
+linked_list_allocator = { version = "0.10.1", default-features = false }
 lset = { version = "0.3", default-features = false }
 nbytes = { version = "0.1", default-features = false }
 noted = { version = "1.0.0", default-features = false }

--- a/crates/shim-kvm/src/exec.rs
+++ b/crates/shim-kvm/src/exec.rs
@@ -106,7 +106,7 @@ fn map_elf(app_virt_start: VirtAddr) -> &'static Header {
         debug_assert_eq!(ph.p_align, Page::<Size4KiB>::SIZE);
 
         ALLOCATOR
-            .write()
+            .lock()
             .map_memory(
                 map_from,
                 map_to,

--- a/crates/shim-kvm/src/hostcall.rs
+++ b/crates/shim-kvm/src/hostcall.rs
@@ -360,7 +360,7 @@ impl Handler for HostCall<'_> {
 
                 // unmap the rest
                 ALLOCATOR
-                    .write()
+                    .lock()
                     .unmap_memory(VirtAddr::new(addr_u64_aligned), len as usize)
                     .unwrap();
 
@@ -382,7 +382,7 @@ impl Handler for HostCall<'_> {
                 let len = addr_u64_aligned.checked_sub(brk_line.end.as_u64()).unwrap();
 
                 ALLOCATOR
-                    .write()
+                    .lock()
                     .allocate_and_map_memory(
                         brk_line.end,
                         len as usize,
@@ -446,7 +446,7 @@ impl Handler for HostCall<'_> {
                 let len_aligned = align_up(length as _, Page::<Size4KiB>::SIZE) as _;
 
                 let mem_slice = ALLOCATOR
-                    .write()
+                    .lock()
                     .allocate_and_map_memory(
                         virt_addr,
                         len_aligned,
@@ -530,11 +530,13 @@ impl Handler for HostCall<'_> {
         addr: NonNull<c_void>,
         length: c_size_t,
     ) -> sallyport::Result<()> {
+        eprintln!("SC> munmap({:#?}, {}) = 0", addr, length);
+
         let addr: &[u8] = platform.validate_slice(addr.as_ptr() as _, length)?;
 
         // It is not an error if the indicated range does not contain any mapped pages.
         let _ = ALLOCATOR
-            .write()
+            .lock()
             .unmap_memory(VirtAddr::from_ptr(addr.as_ptr()), length);
 
         Ok(())

--- a/crates/shim-kvm/src/pagetables.rs
+++ b/crates/shim-kvm/src/pagetables.rs
@@ -128,7 +128,7 @@ pub fn smash(addr: VirtAddr) -> Result<(), Error> {
                 let page = Page::<Size2MiB>::containing_address(addr);
                 let new_pagetable: &mut PageTable = unsafe {
                     &mut *(ALLOCATOR
-                        .write()
+                        .lock()
                         .try_alloc(Layout::from_size_align_unchecked(
                             size_of::<PageTable>(),
                             Page::<Size4KiB>::SIZE as _,
@@ -178,7 +178,7 @@ pub fn smash(addr: VirtAddr) -> Result<(), Error> {
                 let page = Page::<Size1GiB>::containing_address(addr);
                 let new_pagetable: &mut PageTable = unsafe {
                     &mut *(ALLOCATOR
-                        .write()
+                        .lock()
                         .try_alloc(Layout::from_size_align_unchecked(
                             size_of::<PageTable>(),
                             Page::<Size4KiB>::SIZE as _,

--- a/crates/shim-kvm/src/shim_stack.rs
+++ b/crates/shim-kvm/src/shim_stack.rs
@@ -21,7 +21,7 @@ pub fn init_stack_with_guard(
     stack_size: u64,
     extra_flags: PageTableFlags,
 ) -> GuardedStack {
-    let mut allocator = ALLOCATOR.write();
+    let mut allocator = ALLOCATOR.lock();
 
     // guard page
     allocator


### PR DESCRIPTION
This requires switching from `RwLock` to `Mutex`, because the inner Allocator is not `Sync`.

Supercedes: https://github.com/enarx/enarx/pull/1992

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
