### PR TITLE
docs: fix docs to use new `enarx cpu info` command

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -284,7 +284,7 @@ If you want to suppress the debug output, add `2>/dev/null`.
 appropriate deployment backend. To see what backends are supported on your
 system, run:
 ```sh:git;
-$ enarx info
+$ enarx cpu info
 ```
 You can manually select a backend with the `--backend` option, or by
 setting the `ENARX_BACKEND` environment variable:
@@ -300,7 +300,7 @@ $ ENARX_BACKEND=sgx enarx run target/wasm32-wasi/release/hello-world.wasm
 2. KVM
 3. "nil" (a debug/developer backend without TEEs, isolation or any additional security guarentees)
 
-The status of whether or not enarx was able to find the driver can be checked with the command `enarx info`. If the output shows any of the backends with a green "tick" or "checkmark", you are ready to use enarx with that backend.
+The status of whether or not enarx was able to find the driver can be checked with the command `enarx cpu info`. If the output shows any of the backends with a green "tick" or "checkmark", you are ready to use enarx with that backend.
 
 When you execute the `enarx run` command, enarx tries to automatically select the appropriate backend. But if you want to specifically use the another supported backend you can pass the backend name ("sgx", "sev", "kvm" or "nil") as a parameter to `--backend` option, or set the `ENARX_BACKEND` environment variable with the name:
 


### PR DESCRIPTION
Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
