### PR TITLE
feat(exec-wasmtime): add `addr` to `listen` in Enarx.toml

### DIFF
--- a/crates/exec-wasmtime/src/config.rs
+++ b/crates/exec-wasmtime/src/config.rs
@@ -6,8 +6,12 @@ use std::{collections::HashMap, ops::Deref};
 use serde::{de::Error as _, Deserialize, Deserializer};
 use url::Url;
 
-fn default_port() -> u16 {
+const fn default_port() -> u16 {
     443
+}
+
+fn default_addr() -> String {
+    "::".into()
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -105,6 +109,9 @@ pub enum File {
 
         #[serde(default)]
         prot: Protocol,
+
+        #[serde(default = "default_addr")]
+        addr: String,
     },
 
     #[serde(rename = "connect")]
@@ -188,14 +195,15 @@ mod test {
                 File::Listen {
                     name: "X".into(),
                     port: 9000,
-                    prot: Protocol::Tcp
+                    prot: Protocol::Tcp,
+                    addr: default_addr()
                 },
                 File::Stdout { name: None },
                 File::Null { name: None },
                 File::Stderr { name: None },
                 File::Connect {
                     name: None,
-                    port: 443,
+                    port: default_port(),
                     prot: Protocol::Tls,
                     host: "google.com".into(),
                 },

--- a/tests/wasm/mod.rs
+++ b/tests/wasm/mod.rs
@@ -243,6 +243,7 @@ kind = "listen"
 prot = "tcp"
 port = {cport}
 name = "LISTEN"
+addr = "0.0.0.0"
 
 [[files]]
 kind = "connect"


### PR DESCRIPTION
This adds the `addr` field to the `listen` entry in Enarx.toml, in case
somebody wants to restrict the listen address to a specific IP,
rather than the `::` IPV6 any address, which binds to all interfaces.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
