### PR TITLE
build: use new Cargo sparse registry support

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -11,3 +11,4 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 [unstable]
 bindeps = true
+sparse-registry = true


### PR DESCRIPTION
The registry is the list of crate versions from crates.io, which Cargo uses to resolve dependency versions. As originally implemented, this registry is stored as a Git repo, which is cloned on first use and pulled for updates. However, as crates.io has grown the size of the registry has become a bottleneck, and Cargo is preparing to address this by supporting "sparse registries", which involves only pulling dependency information for crates that are actually being used for the compilation. This promises to be somewhat faster for regular development and much faster for CI builds.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
