### PR TITLE
fix(tcp_server): correct target_os

### DIFF
--- a/examples/tcp_server/Cargo.toml
+++ b/examples/tcp_server/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 
-[target.'cfg(any(unix, target_os="wasm32-wasi"))'.dependencies]
+[target.'cfg(any(unix, target_os="wasi"))'.dependencies]
 env_logger = { version = "0.9.0", default-features = false }
 mio = { version = "0.8.3", features = ["os-poll", "net"], default-features = false }

--- a/examples/tcp_server/src/main.rs
+++ b/examples/tcp_server/src/main.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-#![cfg(any(unix, target_os = "wasm32-wasi"))]
+#![cfg(any(unix, target_os = "wasi"))]
 
 // modified version of https://github.com/tokio-rs/mio/blob/master/examples/tcp_server.rs
 


### PR DESCRIPTION
It's `target_os="wasi"` and not `target_os="wasm32-wasi"`.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
