### PR TITLE
chore: exclude docs and tests dirs from published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/enarx/enarx"
 license = "Apache-2.0"
 keywords = ["sgx", "sev", "kvm", "tee"]
 categories = ["os", "os::linux-apis", "network-programming", "hardware-support"]
-exclude = [".github/"]
+exclude = [".github/", "docs/", "tests/"]
 
 [features]
 default = []


### PR DESCRIPTION
Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
