### PR TITLE
fix(tcp_server): harden the server and fix proto tls vs tcp

### DIFF
--- a/examples/tcp_server/Enarx.toml
+++ b/examples/tcp_server/Enarx.toml
@@ -9,6 +9,6 @@ kind = "stderr"
 
 [[files]]
 kind = "listen"
-prot = "tls"
+prot = "tcp"
 port = 9000
 name = "TEST_TCP_LISTEN"

--- a/examples/tcp_server/README.md
+++ b/examples/tcp_server/README.md
@@ -114,3 +114,14 @@ Connection closed
 
 To modify the port and listen address see the `Enarx.toml` file in the
 example directory.
+
+### Transparent TLS
+
+Enarx automatically wraps the TCP connection in a TLS session, if you change the `proto` field in the `Enarx.toml` from `tcp` to `tls`.
+In this case you can connect to the echo server via `openssl`
+
+```
+$ openssl s_client -connect 127.0.0.1:9000
+```
+
+Enter your messages manually, and to end the connection enter `ctrl-d` or `Q`.


### PR DESCRIPTION
### fix(tcp_server): no TLS for `ncat` example

The README.md uses plain TCP to test the echo server.

### docs(tcp_server): document `proto=tls`
    
 What it does and how to connect to the server.
    
### fix(tcp_server): harden the server
    
Don't panic out on unexpected errors, but print error messages.
Flush stdout here and there, so the user sees the messages.
    
