### PR TITLE
chore: add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+Harald Hoyer <harald@profian.com> 		    <harald@hoyer.xyz>
+Harald Hoyer <harald@profian.com> 		    <harald@redhat.com>
+Axel Simon <github@axelsimon.net>           <axel@redhat.com>
+Axel Simon <github@axelsimon.net>
+Nathaniel McCallum <nathaniel@profian.com>  <nathaniel@congru.us>
+Nathaniel McCallum <nathaniel@profian.com>  <npmccallum@redhat.com>
+Jarkko Sakkinen <jarkko@profian.com>        <jarkko.sakkinen@iki.fi>
+Paul Pietkiewicz <paul@profian.com>         <pawel.pietkiewicz@gmail.com>
+Will Woods <will@profian.com>               <will@congru.us>
+Lily Sturmann <lsturman@redhat.com>
+Matthew Ross <mross20@myseneca.ca>          <matt_ross_16@hotmail.com>


### PR DESCRIPTION
To map email addresses of git authors.

Minimize the output of:

```
$ git shortlog  --numbered --summary -e |while read _ rest || [ -n "$rest" ]; do echo $rest;done | sort
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
