### PR TITLE
feat: add `enarx config init`

### DIFF
--- a/crates/enarx-config/Enarx_toml.md
+++ b/crates/enarx-config/Enarx_toml.md
@@ -14,7 +14,9 @@ All elements are optional.
 #### Example
 
 ```toml
-env = { "FOO" = "foo", "BAR" = "bar" }
+[env]
+VAR1 = "var1"
+VAR2 = "var2"
 ```
 
 ### `args`
@@ -24,7 +26,10 @@ env = { "FOO" = "foo", "BAR" = "bar" }
 #### Example
 
 ```toml
-args = [ "arg1", "arg2" ]
+args = [
+     "--argument1",
+     "--argument2=foo"
+]
 ```
 
 ### `steward`
@@ -89,9 +94,20 @@ The default value is `443`.
 
 ## Example
 ```toml
-env = { "VAR1" = "var1", "VAR2" = "var2" }
-args = [ "--argument1", "--argument2=foo" ]
+# Configuration for a WASI application in an Enarx Keep
 
+# Arguments
+args = [
+     "--argument1",
+     "--argument2=foo"
+]
+
+# Environment variables
+[env]
+VAR1 = "var1"
+VAR2 = "var2"
+
+# Pre-opened file descriptors
 [[files]]
 kind = "null"
 
@@ -101,16 +117,18 @@ kind = "stdout"
 [[files]]
 kind = "stderr"
 
+# A listen socket
 [[files]]
 name = "LISTEN"
 kind = "listen"
-prot = "tls"
+prot = "tls" # or prot = "tcp"
 port = 12345
 
+# An outgoing connected socket
 [[files]]
 name = "CONNECT"
 kind = "connect"
-prot = "tcp"
+prot = "tcp" # or prot = "tls"
 host = "127.0.0.1"
 port = 23456
 ```

--- a/src/cli/config/init.rs
+++ b/src/cli/config/init.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+use std::path::Path;
+
+use anyhow::bail;
+use clap::Args;
+use enarx_config::CONFIG_TEMPLATE;
+
+/// Generate an `Enarx.toml` template
+#[derive(Args, Debug)]
+pub struct Options;
+
+impl Options {
+    pub fn execute(self) -> anyhow::Result<()> {
+        let enarx_toml_path = Path::new("Enarx.toml");
+        if enarx_toml_path.exists() {
+            bail!("{enarx_toml_path:?} does already exist.");
+        }
+
+        let mut enarx_toml = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(enarx_toml_path)?;
+
+        enarx_toml.write_all(CONFIG_TEMPLATE.as_bytes())?;
+        Ok(())
+    }
+}

--- a/src/cli/config/mod.rs
+++ b/src/cli/config/mod.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod init;
+
+use clap::Subcommand;
+
+/// Commands for working with Enarx configuration files.
+#[derive(Subcommand, Debug)]
+pub enum Subcommands {
+    Init(init::Options),
+}
+
+impl Subcommands {
+    pub fn dispatch(self) -> anyhow::Result<()> {
+        match self {
+            Self::Init(cmd) => cmd.execute(),
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod config;
 mod deploy;
 mod package;
 mod platform;
@@ -55,6 +56,8 @@ enum Subcommands {
     Run(run::Options),
     Deploy(deploy::Options),
     #[clap(subcommand)]
+    Config(config::Subcommands),
+    #[clap(subcommand)]
     Platform(platform::Subcommands),
     #[clap(subcommand)]
     Package(package::Subcommands),
@@ -72,6 +75,7 @@ impl Subcommands {
     fn dispatch(self) -> anyhow::Result<()> {
         match self {
             Self::Run(cmd) => cmd.execute(),
+            Self::Config(subcmd) => subcmd.dispatch(),
             Self::Deploy(cmd) => cmd.execute(),
             Self::Platform(subcmd) => subcmd.dispatch(),
             Self::Package(subcmd) => subcmd.dispatch(),


### PR DESCRIPTION
Related: https://github.com/enarx/enarx/issues/1958

```
$ enarx config --help
enarx-config
Commands for working with users on an Enarx package host

USAGE:
    enarx config <SUBCOMMAND>

OPTIONS:
    -h, --help    Print help information

SUBCOMMANDS:
    help    Print this message or the help of the given subcommand(s)
    init    Generate an `Enarx.toml` template

$ enarx config init
$ cat Enarx.toml
## Configuration for a WASI application in an Enarx Keep

## Arguments
# args = [
#      "--argument1",
#      "--argument2=foo"
# ]

## Steward
# steward = "https://steward.example.com"

## Environment variables
# [env]
# VAR1 = "var1"
# VAR2 = "var2"

## Pre-opened file descriptors
[[files]]
kind = "stdin"

[[files]]
kind = "stdout"

[[files]]
kind = "stderr"

## A listen socket
# [[files]]
# name = "LISTEN"
# kind = "listen"
# prot = "tls" # or prot = "tcp"
# port = 12345

## An outgoing connected socket
# [[files]]
# name = "CONNECT"
# kind = "connect"
# prot = "tls" # or prot = "tcp"
# host = "127.0.0.1"
# port = 23456

$ enarx config init
Error: "Enarx.toml" does already exist.
```

Signed-off-by: Harald Hoyer <harald@profian.com>
