### PR TITLE
feat(shim-kvm): enable CR0 WRITE_PROTECT

### DIFF
--- a/crates/shim-kvm/src/allocator.rs
+++ b/crates/shim-kvm/src/allocator.rs
@@ -290,6 +290,9 @@ impl EnarxAllocator {
             let p = self.alloc_pages(size);
 
             if let Ok(p) = p {
+                unsafe {
+                    core::ptr::write_bytes(p.as_ptr(), 0, size);
+                }
                 return (p.as_ptr(), size);
             }
 

--- a/crates/shim-kvm/src/hostcall.rs
+++ b/crates/shim-kvm/src/hostcall.rs
@@ -459,12 +459,10 @@ impl Handler for HostCall<'_> {
                         eprintln!("SC> mmap(0, {}, …) = ENOMEM", length);
                         ENOMEM
                     })?;
-                eprintln!("SC> mmap(0, {}, …) = {:#?}", length, mem_slice.as_ptr());
-                unsafe {
-                    core::ptr::write_bytes(mem_slice.as_mut_ptr(), 0, length);
-                }
-                *NEXT_MMAP_RWLOCK.write().deref_mut() = virt_addr + (len_aligned as u64);
 
+                eprintln!("SC> mmap(0, {}, …) = {:#?}", length, mem_slice.as_ptr());
+
+                *NEXT_MMAP_RWLOCK.write().deref_mut() = virt_addr + (len_aligned as u64);
                 Ok(NonNull::new(mem_slice.as_mut_ptr() as *mut c_void).unwrap())
             }
             (addr, ..) => {

--- a/crates/shim-kvm/src/main.rs
+++ b/crates/shim-kvm/src/main.rs
@@ -485,7 +485,7 @@ pub unsafe extern "sysv64" fn _start() -> ! {
         SEV_GHCB_MSR = const 0xC001_0130u32,
         CR4_FLAGS = const (Cr4Flags::FSGSBASE.bits() | Cr4Flags::PHYSICAL_ADDRESS_EXTENSION.bits() | Cr4Flags::OSFXSR.bits() | Cr4Flags::OSXMMEXCPT_ENABLE.bits() | Cr4Flags::OSXSAVE.bits()),
         PROTECTED_MODE_ENABLE = const Cr0Flags::PROTECTED_MODE_ENABLE.bits(),
-        CR0_PAGING = const Cr0Flags::PAGING.bits(),
+        CR0_PAGING = const Cr0Flags::PAGING.bits()  | Cr0Flags::WRITE_PROTECT.bits() ,
 
         options(noreturn)
     )


### PR DESCRIPTION
Disallow writing to write protected pages.

Clear the pages on raw allocation from the linked list allocator before
referencing them from the user space page table.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
