### PR TITLE
feat: support custom credential helpers

### DIFF
--- a/docs/Credentials.md
+++ b/docs/Credentials.md
@@ -1,0 +1,82 @@
+# Credential handling
+
+By default, login credentials are stored securely using the secure store provided by your platform, e.g. on Linux it would use the [D-Bus secrets service](https://specifications.freedesktop.org/secret-service/latest/).
+
+## Credential helpers
+
+It is also possible to override the keychain storage and use a custom credential helper instead.
+
+A credential helper is a program, which is called by `enarx` with two positional arguments a `mode` as the first and an `oidc_domain` as the second like so: `<credential helper> <insert|show> <oidc_domain>`.
+
+### `insert` mode
+
+When called with `"insert"` in the first argument, credential helper should read and securely store the secret associated with `oidc_domain` passed in the second argument from stdin.
+
+Example invocation:
+
+```sh
+enarx-credential-helper-mybackend insert auth.profian.com
+```
+
+### `show` mode
+
+When called with `"show"` in the first argument, credential helper should write the secret associated with `oidc_domain` passed in the second argument to stdout.
+
+Example invocation:
+
+```sh
+enarx-credential-helper-mybackend show auth.profian.com
+```
+
+### Configuration
+
+In order to use a credential helper, either set `ENARX_CREDENTIAL_HELPER` environment variable equal to absolute path to an executable credential helper or pass it via `credential-helper` command-line flag.
+
+Example invocation:
+```sh 
+enarx user login --credential-helper /usr/bin/enarx-credential-helper-gopass
+```
+
+Alternatively:
+```sh 
+ENARX_CREDENTIAL_HELPER=/usr/bin/enarx-credential-helper-gopass enarx user login
+```
+
+Eventually, it will be possible to configure credential helpers via a CLI configuration file. Please follow https://github.com/enarx/enarx/issues/2021 for more details.
+
+### Example credential helpers
+
+#### Pass
+
+The following credential helper can be used to store credentials in [`pass`](https://www.passwordstore.org/):
+
+```sh
+#!/bin/sh
+set -e
+if [ "${1}" = "insert" ]; then
+    exec pass insert -f -m "misc/enarx/${2}" 1> /dev/null
+elif [ "${1}" = "show" ]; then
+    exec pass show "misc/enarx/${2}"
+else
+    echo "Unknown command '${1}'"
+    exit 1
+fi
+```
+
+#### Gopass
+
+The following credential helper can be used to store credentials in [`gopass`](https://www.gopass.pw/):
+
+```sh
+#!/bin/sh
+set -e
+if [ "${1}" = "insert" ]; then
+    exec gopass insert -f "misc/enarx/${2}"
+elif [ "${1}" = "show" ]; then
+    gopass find misc/enarx 1>/dev/null 2>/dev/null
+    exec gopass show -n -o "misc/enarx/${2}"
+else
+    echo "Unknown command '${1}'"
+    exit 1
+fi
+```

--- a/src/cli/package/info.rs
+++ b/src/cli/package/info.rs
@@ -2,6 +2,8 @@
 
 use crate::drawbridge::{client, TagSpec};
 
+use std::ffi::OsString;
+
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
@@ -13,12 +15,19 @@ pub struct Options {
     ca_bundle: Option<Utf8PathBuf>,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
+    #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
+    credential_helper: Option<OsString>,
     spec: TagSpec,
 }
 
 impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
-        let cl = client(self.spec.host, self.insecure_auth_token, self.ca_bundle)?;
+        let cl = client(
+            &self.spec.host,
+            &self.insecure_auth_token,
+            &self.ca_bundle,
+            &self.credential_helper,
+        )?;
         let tag = cl.tag(&self.spec.ctx);
         let tag_entry = tag
             .get()

--- a/src/cli/package/info.rs
+++ b/src/cli/package/info.rs
@@ -7,12 +7,15 @@ use std::ffi::OsString;
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
+use oauth2::url::Url;
 
 /// Retrieve information about a published package.
 #[derive(Args, Debug)]
 pub struct Options {
     #[clap(long, env = "ENARX_CA_BUNDLE")]
     ca_bundle: Option<Utf8PathBuf>,
+    #[clap(long, default_value = "https://auth.profian.com/")]
+    oidc_domain: Url,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
     #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
@@ -24,6 +27,7 @@ impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
         let cl = client(
             &self.spec.host,
+            &self.oidc_domain,
             &self.insecure_auth_token,
             &self.ca_bundle,
             &self.credential_helper,

--- a/src/cli/package/publish.rs
+++ b/src/cli/package/publish.rs
@@ -2,6 +2,8 @@
 
 use crate::drawbridge::{client, TagSpec};
 
+use std::ffi::OsString;
+
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
@@ -13,13 +15,20 @@ pub struct Options {
     ca_bundle: Option<Utf8PathBuf>,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
+    #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
+    credential_helper: Option<OsString>,
     spec: TagSpec,
     path: Utf8PathBuf,
 }
 
 impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
-        let cl = client(self.spec.host, self.insecure_auth_token, self.ca_bundle)?;
+        let cl = client(
+            &self.spec.host,
+            &self.insecure_auth_token,
+            &self.ca_bundle,
+            &self.credential_helper,
+        )?;
         let tag = cl.tag(&self.spec.ctx);
         let (_tag_created, _tree_created) = tag
             .create_from_path_unsigned(self.path)

--- a/src/cli/package/publish.rs
+++ b/src/cli/package/publish.rs
@@ -7,12 +7,15 @@ use std::ffi::OsString;
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
+use oauth2::url::Url;
 
 /// Publish a new package.
 #[derive(Args, Debug)]
 pub struct Options {
     #[clap(long, env = "ENARX_CA_BUNDLE")]
     ca_bundle: Option<Utf8PathBuf>,
+    #[clap(long, default_value = "https://auth.profian.com/")]
+    oidc_domain: Url,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
     #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
@@ -25,6 +28,7 @@ impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
         let cl = client(
             &self.spec.host,
+            &self.oidc_domain,
             &self.insecure_auth_token,
             &self.ca_bundle,
             &self.credential_helper,

--- a/src/cli/repo/info.rs
+++ b/src/cli/repo/info.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
 use drawbridge_client::types::{RepositoryConfig, TagName};
+use oauth2::url::Url;
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -21,6 +22,8 @@ struct RepoInfo {
 pub struct Options {
     #[clap(long, env = "ENARX_CA_BUNDLE")]
     ca_bundle: Option<Utf8PathBuf>,
+    #[clap(long, default_value = "https://auth.profian.com/")]
+    oidc_domain: Url,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
     #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
@@ -32,6 +35,7 @@ impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
         let cl = client(
             &self.spec.host,
+            &self.oidc_domain,
             &self.insecure_auth_token,
             &self.ca_bundle,
             &self.credential_helper,

--- a/src/cli/repo/info.rs
+++ b/src/cli/repo/info.rs
@@ -2,6 +2,8 @@
 
 use crate::drawbridge::{client, RepoSpec};
 
+use std::ffi::OsString;
+
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
@@ -21,12 +23,19 @@ pub struct Options {
     ca_bundle: Option<Utf8PathBuf>,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
+    #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
+    credential_helper: Option<OsString>,
     spec: RepoSpec,
 }
 
 impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
-        let cl = client(self.spec.host, self.insecure_auth_token, self.ca_bundle)?;
+        let cl = client(
+            &self.spec.host,
+            &self.insecure_auth_token,
+            &self.ca_bundle,
+            &self.credential_helper,
+        )?;
         let repo = cl.repository(&self.spec.ctx);
         let config = repo
             .get()

--- a/src/cli/repo/register.rs
+++ b/src/cli/repo/register.rs
@@ -8,12 +8,15 @@ use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
 use drawbridge_client::types::RepositoryConfig;
+use oauth2::url::Url;
 
 /// Register a new repository.
 #[derive(Args, Debug)]
 pub struct Options {
     #[clap(long, env = "ENARX_CA_BUNDLE")]
     ca_bundle: Option<Utf8PathBuf>,
+    #[clap(long, default_value = "https://auth.profian.com/")]
+    oidc_domain: Url,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
     #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
@@ -25,6 +28,7 @@ impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
         let cl = client(
             &self.spec.host,
+            &self.oidc_domain,
             &self.insecure_auth_token,
             &self.ca_bundle,
             &self.credential_helper,

--- a/src/cli/repo/register.rs
+++ b/src/cli/repo/register.rs
@@ -2,6 +2,8 @@
 
 use crate::drawbridge::{client, RepoSpec};
 
+use std::ffi::OsString;
+
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
@@ -14,12 +16,19 @@ pub struct Options {
     ca_bundle: Option<Utf8PathBuf>,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
+    #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
+    credential_helper: Option<OsString>,
     spec: RepoSpec,
 }
 
 impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
-        let cl = client(self.spec.host, self.insecure_auth_token, self.ca_bundle)?;
+        let cl = client(
+            &self.spec.host,
+            &self.insecure_auth_token,
+            &self.ca_bundle,
+            &self.credential_helper,
+        )?;
         let repo = cl.repository(&self.spec.ctx);
         let repo_config = RepositoryConfig {
             // TODO: support deploying from private repos

--- a/src/cli/user/info.rs
+++ b/src/cli/user/info.rs
@@ -2,6 +2,8 @@
 
 use crate::drawbridge::{client, UserSpec};
 
+use std::ffi::OsString;
+
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
@@ -13,12 +15,19 @@ pub struct Options {
     ca_bundle: Option<Utf8PathBuf>,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
+    #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
+    credential_helper: Option<OsString>,
     spec: UserSpec,
 }
 
 impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
-        let cl = client(self.spec.host, self.insecure_auth_token, self.ca_bundle)?;
+        let cl = client(
+            &self.spec.host,
+            &self.insecure_auth_token,
+            &self.ca_bundle,
+            &self.credential_helper,
+        )?;
         let user = cl.user(&self.spec.ctx);
         let record = user
             .get()

--- a/src/cli/user/info.rs
+++ b/src/cli/user/info.rs
@@ -7,12 +7,15 @@ use std::ffi::OsString;
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
+use oauth2::url::Url;
 
 /// Retrieve information about a user account on an Enarx package host.
 #[derive(Args, Debug)]
 pub struct Options {
     #[clap(long, env = "ENARX_CA_BUNDLE")]
     ca_bundle: Option<Utf8PathBuf>,
+    #[clap(long, default_value = "https://auth.profian.com/")]
+    oidc_domain: Url,
     #[clap(long, env = "ENARX_INSECURE_AUTH_TOKEN")]
     insecure_auth_token: Option<String>,
     #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
@@ -24,6 +27,7 @@ impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
         let cl = client(
             &self.spec.host,
+            &self.oidc_domain,
             &self.insecure_auth_token,
             &self.ca_bundle,
             &self.credential_helper,

--- a/src/cli/user/login.rs
+++ b/src/cli/user/login.rs
@@ -2,6 +2,8 @@
 
 use crate::drawbridge::login;
 
+use std::ffi::OsString;
+
 use clap::Args;
 use oauth2::url::Url;
 
@@ -12,16 +14,19 @@ pub struct Options {
     oidc_domain: Url,
     #[clap(long, default_value = "4NuaJxkQv8EZBeJKE56R57gKJbxrTLG2")]
     oidc_client_id: String,
+    #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
+    credential_helper: Option<OsString>,
 }
 
 impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
         let Self {
-            oidc_domain,
+            ref oidc_domain,
             oidc_client_id,
+            ref credential_helper,
         } = self;
 
-        login(oidc_domain, oidc_client_id)?;
+        login(oidc_domain, oidc_client_id, credential_helper)?;
 
         println!("Login successful.");
 

--- a/src/cli/user/register.rs
+++ b/src/cli/user/register.rs
@@ -42,13 +42,14 @@ impl Options {
         } = self;
 
         // If we don't find a token saved locally, initiate an interactive login
-        let token = match get_token(insecure_auth_token, credential_helper) {
+        let token = match get_token(oidc_domain, insecure_auth_token, credential_helper) {
             Ok(token) => token,
             _ => login(oidc_domain, oidc_client_id.clone(), credential_helper)?,
         };
 
         let cl = client(
             &spec.host,
+            oidc_domain,
             &Some(token.clone()),
             ca_bundle,
             credential_helper,


### PR DESCRIPTION
Closes #2019 

This should really be configured via CLI config #2021 

E.g. for https://github.com/gopasspw/gopass this can be used the following way:

`enarx-credential-helper-gopass`
```
#!/bin/sh
set -e
if [ "${1}" = "insert" ]; then
    exec gopass insert -f misc/enarx
elif [ "${1}" = "show" ]; then
    gopass find misc/enarx 2>/dev/null
    exec gopass show -n -o misc/enarx
else
    echo "Unknown command '${1}'"
    exit 1
fi
```

`enarx user register myuser --credential-helper ./enarx-credential-helper-gopass`

Once we add the plugin system for `enarx`, this will can also be looked up from `PATH`, i.e. users could contribute and install custom `enarx-credential-helper-*` and these would be picked up from the path.

This is a standard approach used by a variety of other tools, e.g.:
- https://github.com/docker/docker-credential-helpers
- https://git-scm.com/docs/gitcredentials


This also fixes a bug, where credentials for different providers would be stored in the same namespace (`"oidc_domain"`, which clearly should have been a variable)