### PR TITLE
fix(sev): return proper io::Error for `register_enc_memory_region()`

### DIFF
--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -34,13 +34,14 @@ struct SnpKeepPersonality {
 }
 
 impl KeepPersonality for SnpKeepPersonality {
-    fn map(vm_fd: &mut VmFd, region: &Region) -> std::io::Result<()> {
+    fn map(vm_fd: &mut VmFd, region: &Region) -> io::Result<()> {
         let memory_region = kvm_enc_region {
             addr: region.backing().as_ptr() as _,
             size: region.backing().len() as _,
         };
-        vm_fd.register_enc_memory_region(&memory_region).unwrap();
-        Ok(())
+        vm_fd
+            .register_enc_memory_region(&memory_region)
+            .map_err(|e| io::Error::from_raw_os_error(e.errno()))
     }
     fn enarxcall<'a>(
         &mut self,


### PR DESCRIPTION
Turn the `unwrap()` for `register_enc_memory_region()` into a proper
`io::Error` and return it, rather than panic.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
