### PR TITLE
feat(sev): remove vcek cache directory in `$HOME`

### DIFF
--- a/src/cli/platform/snp/info.rs
+++ b/src/cli/platform/snp/info.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::backend::sev::snp::vcek::{
-    get_vcek_reader, get_vcek_reader_with_paths, paths, UpdateMode,
-};
+use crate::backend::sev::snp::vcek::{get_vcek_reader, get_vcek_reader_with_path, sev_cache_dir};
 
 use std::io::{self, ErrorKind};
 
@@ -19,7 +17,7 @@ pub struct Options {
 impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
         if self.file {
-            match get_vcek_reader_with_paths(paths(), UpdateMode::ReadOnly) {
+            match get_vcek_reader_with_path(sev_cache_dir()?) {
                 Ok((path, _)) => {
                     println!("{:?}", path);
                     Ok(())

--- a/src/cli/platform/snp/update.rs
+++ b/src/cli/platform/snp/update.rs
@@ -1,23 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::backend::sev::snp::vcek::{get_vcek_reader_with_paths, paths, UpdateMode};
+use crate::backend::sev::snp::vcek::vcek_write;
 
 use clap::Args;
 
 /// Download the VCEK certificate for this platform.
 ///
-/// The certificate will be saved to a cache file in
-/// `/var/cache/amd-sev/` or `$XDG_CACHE_HOME` or `$HOME/.cache/`
+/// The certificate will be saved to a cache file in `/var/cache/amd-sev/`
 #[derive(Args, Debug)]
-// TODO: add option to let user select location to save file to
 pub struct Options {}
 
 impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
-        // try to write to the system level path first and fallback to home dir
-        let mut paths = paths();
-        paths.reverse();
-        get_vcek_reader_with_paths(paths, UpdateMode::ReadWrite)?;
+        // try to write to the system cache
+        vcek_write()?;
         Ok(())
     }
 }


### PR DESCRIPTION
If there is no vcek certificate cached in `/var/cache/amd-sev`, fail.

There must be a system service setting up the cache file.
`enarx platform snp update` does exactly that.

This removes all confusion about which file is used and when it should be created.

Fixes: https://github.com/enarx/enarx/issues/2045

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
