### PR TITLE
fix(sgx): filter attestation keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ name = "enarx_exec_tests"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "sallyport",
 ]
 
 [[package]]

--- a/src/backend/sgx/attestation.rs
+++ b/src/backend/sgx/attestation.rs
@@ -448,7 +448,9 @@ mod tests {
 
         let mut output = [1u8; SGX_TI_SIZE];
 
-        let akid = get_attestation_key_id().expect("error obtaining attestation key id");
+        let akid = get_attestation_key_id().expect(
+            "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
+        );
         let pkeysize = get_key_size(akid.clone()).expect("error obtaining key size");
         assert_eq!(
             get_target_info(akid, pkeysize, &mut output).unwrap(),

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -115,10 +115,15 @@ fn sgx_enarxcall<'a>(
                     .map_err(io::Error::from_raw_os_error)
                     .context("sgx_enarxcall deref")?
             };
-
-            let akid = get_attestation_key_id().context("error obtaining attestation key id")?;
-            let pkeysize = get_key_size(akid.clone()).context("error obtaining key size")?;
-            *ret = get_target_info(akid, pkeysize, out_buf).context("error getting target info")?;
+            let akid = get_attestation_key_id().context(
+                "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
+            )?;
+            let pkeysize = get_key_size(akid.clone()).context(
+                "Error obtaining key size. Check your aesmd / pccs service installation.",
+            )?;
+            *ret = get_target_info(akid, pkeysize, out_buf).context(
+                "Error getting target info. Check your aesmd / pccs service installation.",
+            )?;
 
             Ok(None)
         }
@@ -146,8 +151,11 @@ fn sgx_enarxcall<'a>(
                     .context("sgx_enarxcall deref")?
             };
 
-            let akid = get_attestation_key_id().context("error obtaining attestation key id")?;
-            *ret = get_quote(report_buf, akid, quote_buf).context("error getting quote")?;
+            let akid = get_attestation_key_id().context(
+                "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
+            )?;
+            *ret = get_quote(report_buf, akid, quote_buf)
+                .context("Error getting quote. Check your aesmd / pccs service installation.")?;
 
             Ok(None)
         }
@@ -157,8 +165,12 @@ fn sgx_enarxcall<'a>(
             ret,
             ..
         } => {
-            let akid = get_attestation_key_id().context("error obtaining attestation key id")?;
-            *ret = get_quote_size(akid).context("error getting quote size")?;
+            let akid = get_attestation_key_id().context(
+                "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
+            )?;
+            *ret = get_quote_size(akid).context(
+                "Error getting quote size. Check your aesmd / pccs service installation.",
+            )?;
 
             Ok(None)
         }

--- a/tests/crates/enarx_exec_tests/Cargo.toml
+++ b/tests/crates/enarx_exec_tests/Cargo.toml
@@ -6,3 +6,4 @@ license = "Apache-2.0"
 
 [dependencies]
 libc = { version = "0.2.102", default-features = false }
+sallyport = { path = "../../../crates/sallyport", default-features = false }

--- a/tests/crates/enarx_exec_tests/src/bin/sgx_attestation.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/sgx_attestation.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+#![feature(core_ffi_c)]
+
+use enarx_exec_tests::musl_fsbase_fix;
+
+use std::arch::asm;
+use std::convert::TryFrom;
+
+musl_fsbase_fix!();
+
+const QUOTE_SIG_START: usize = 436;
+const QE_AUTH_LEN_START: usize = 576;
+const QE_AUTH_LEN_END: usize = 578;
+
+#[repr(u64)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone)]
+pub enum TeeTech {
+    None = 0,
+    Sev = 1,
+    Sgx = 2,
+}
+
+pub struct TryFromIntError(pub(crate) ());
+
+impl TryFrom<u64> for TeeTech {
+    type Error = TryFromIntError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::None),
+            1 => Ok(Self::Sev),
+            2 => Ok(Self::Sgx),
+            _ => Err(TryFromIntError(())),
+        }
+    }
+}
+
+pub fn get_att_syscall(
+    nonce: Option<&mut [u8]>,
+    buf: Option<&mut [u8]>,
+) -> std::io::Result<(usize, TeeTech)> {
+    let rax: i64;
+    let rdx: u64;
+
+    let nonce_ptr = if let Some(ref nonce) = nonce {
+        nonce.as_ptr() as usize
+    } else {
+        0usize
+    };
+
+    let nonce_len = if let Some(ref nonce) = nonce {
+        nonce.len()
+    } else {
+        0usize
+    };
+
+    let buf_len = if let Some(ref buf) = buf {
+        buf.len()
+    } else {
+        0usize
+    };
+
+    let buf_ptr = if let Some(buf) = buf {
+        buf.as_mut_ptr() as usize
+    } else {
+        0usize
+    };
+
+    unsafe {
+        asm!(
+            "syscall",
+            inlateout("rax") sallyport::item::enarxcall::SYS_GETATT => rax,
+            in("rdi") nonce_ptr,
+            in("rsi") nonce_len,
+            inlateout("rdx") buf_ptr => rdx,
+            in("r10") buf_len,
+            in("r8") 0,
+            in("r9") 0,
+            lateout("rcx") _, // clobbered
+            lateout("r11") _, // clobbered
+        );
+    }
+
+    if rax < 0 {
+        return Err(std::io::Error::from_raw_os_error(-rax as _));
+    }
+
+    let tech = TeeTech::try_from(rdx)
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidData))?;
+
+    Ok((rax as _, tech))
+}
+
+fn main() -> std::io::Result<()> {
+    let (len, tech) = get_att_syscall(None, None)?;
+
+    assert!(matches!(tech, TeeTech::Sgx));
+
+    let mut nonce: [u8; 64] = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
+        0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D,
+        0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C,
+        0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B,
+        0x3C, 0x3D, 0x3E, 0x3F,
+    ];
+
+    let mut buffer = vec![0u8; len];
+
+    let (len, tech) = get_att_syscall(Some(&mut nonce[..]), Some(&mut buffer))?;
+
+    assert!(matches!(tech, TeeTech::Sgx));
+
+    let bytes = &buffer[QUOTE_SIG_START..len];
+
+    let mut qe_auth_len_bytes = [0u8; 2];
+    qe_auth_len_bytes.copy_from_slice(&bytes[QE_AUTH_LEN_START..QE_AUTH_LEN_END]);
+    let qe_auth_len: usize = u16::from_le_bytes(qe_auth_len_bytes).into();
+    let qe_auth_end = qe_auth_len + QE_AUTH_LEN_END;
+
+    let mut qe_cert_data_type_bytes = [0u8; 2];
+    qe_cert_data_type_bytes.copy_from_slice(&bytes[qe_auth_end..][..2]);
+    let qe_cert_data_type = u16::from_le_bytes(qe_cert_data_type_bytes);
+
+    // PCKCertChain
+    assert!(qe_cert_data_type == 5);
+
+    Ok(())
+}

--- a/tests/exec/mod.rs
+++ b/tests/exec/mod.rs
@@ -89,6 +89,19 @@ fn rust_sev_attestation() {
 }
 
 #[test]
+#[cfg_attr(not(host_can_test_sgx), ignore = "Backend does not support SGX")]
+#[serial]
+fn rust_sgx_attestation() {
+    if let Ok(backend) = std::env::var("ENARX_BACKEND") {
+        if backend != "sgx" {
+            return;
+        }
+    }
+    let bin = env!("CARGO_BIN_FILE_ENARX_EXEC_TESTS_sgx_attestation");
+    run_test(bin, 0, None, None, None);
+}
+
+#[test]
 #[serial]
 fn memspike() {
     let bin = env!("CARGO_BIN_FILE_ENARX_EXEC_TESTS_memspike");


### PR DESCRIPTION
Closes https://github.com/enarx/enarx/issues/2050

Instead of:
```
thread 'backend::sgx::attestation::tests::request_target_info' panicked at '
error obtaining attestation key id:
Custom { kind: Other, error: "Unexpected number of key IDs: 3 != 1" }',
src/backend/sgx/attestation.rs:445:45
```

This PR now filters for the exact attestation key algorithm id `SGX_QL_ALG_ECDSA_P256`.
Additionally the error messages were extended to give a hint to the `aesmd` and `pccs` services.
Additionally the `rust_sgx_attestation` test was added, checking that the quote report contains a certificate chain.
