### PR TITLE
test(snp): add some testaso tests for the SEV-SNP backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "sgx",
  "static_assertions",
  "tempfile",
+ "testaso",
  "tiedcrossing-client",
  "toml",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ protobuf-codegen-pure = { version = "2.27", default-features = false }
 [dev-dependencies]
 process_control = { version = "3.3", default-features = false }
 serial_test = { version = "0.8", default-features = false }
+testaso = { version = "0.1", default-features = false }
 tempfile = { version = "3.3.0", default-features = false }
 wat = { version = "1.0", default-features = false }
 

--- a/src/backend/sev/snp/firmware/linux.rs
+++ b/src/backend/sev/snp/firmware/linux.rs
@@ -57,7 +57,7 @@ impl<'a> GetId<'a> {
 /// Query the SEV-SNP platform status.
 ///
 /// (Chapter 8.3; Table 38)
-#[derive(Default)]
+#[derive(Default, Debug)]
 #[repr(C)]
 struct SnpPlatformStatus {
     /// The firmware API version (major.minor)
@@ -168,5 +168,24 @@ impl Firmware {
 impl AsRawFd for Firmware {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use testaso::testaso;
+
+    testaso! {
+        struct SnpPlatformStatus: 4, 32 => {
+            version: 0,
+            state: 2,
+            is_rmp_init: 3,
+            build_id: 4,
+            mask_chip_id: 8,
+            guest_count: 12,
+            platform_tcb_version: 16,
+            reported_tcb_version: 24
+        }
     }
 }

--- a/src/backend/sev/snp/firmware/mod.rs
+++ b/src/backend/sev/snp/firmware/mod.rs
@@ -183,6 +183,8 @@ pub struct TcbVersion {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::mem::size_of;
+    use testaso::testaso;
 
     #[test]
     fn test_vcek_url() {
@@ -205,5 +207,19 @@ mod test {
         };
 
         assert_eq!(URL, id.vcek_url(&tcb));
+    }
+
+    #[test]
+    fn test_tcbversion() {
+        assert_eq!(size_of::<TcbVersion>(), size_of::<u64>())
+    }
+
+    testaso! {
+        struct TcbVersion: 1, 8 => {
+            bootloader: 0,
+            tee: 1,
+            snp: 6,
+            microcode: 7
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
