### PR TITLE
revert: disable sparse registry to address cargo publish issues

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -11,4 +11,4 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 [unstable]
 bindeps = true
-sparse-registry = true
+# sparse-registry = true


### PR DESCRIPTION
Signed-off-by: Paul Pietkiewicz <paul@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
