### PR TITLE
ci: fix toolchain

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,10 @@ jobs:
   test:
     name: ${{ matrix.crate.name }} coverage
     runs-on: ${{ matrix.crate.host }}
+    container:
+      image: nixos/nix
+      volumes:
+        - /dev:/dev
     env:
       ENARX_BACKEND: ${{ matrix.crate.name }}
 
@@ -53,7 +57,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v17
       - uses: cachix/cachix-action@v10
         with:
           name: enarx

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,11 +55,10 @@ jobs:
       - run: sudo apt -o Acquire::Retries=3 update
       - run: sudo apt -o Acquire::Retries=3 install -y musl-tools lcov
       - uses: actions/checkout@v2
+      - run: cp rust-toolchain.toml rust-toolchain
       - uses: actions-rs/toolchain@v1
         with:
-          target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-06-28
-          profile: minimal
+          default: true
       - name: Setup Rust toolchain
         run: |
           rustup show

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,24 +52,17 @@ jobs:
             host: [ self-hosted, linux, x64 ]
 
     steps:
-      - run: sudo apt -o Acquire::Retries=3 update
-      - run: sudo apt -o Acquire::Retries=3 install -y musl-tools lcov
       - uses: actions/checkout@v2
-      - run: cp rust-toolchain.toml rust-toolchain
-      - uses: actions-rs/toolchain@v1
+      - uses: cachix/install-nix-action@v17
+      - uses: cachix/cachix-action@v10
         with:
-          default: true
-      - name: Setup Rust toolchain
-        run: |
-          rustup show
-          rustup component add llvm-tools-preview
-
+          name: enarx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install --impure '.#devShell.x86_64-linux'
       - name: Install cargo-llvm-cov
         run: cargo install --version 0.4.1 cargo-llvm-cov
-
       - name: Run cargo-llvm-cov
         run: cargo llvm-cov --coverage-target-only --target x86_64-unknown-linux-gnu --manifest-path ${{ matrix.crate.path }}/Cargo.toml --lcov --output-path lcov.info ${{ matrix.crate.flags }}
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Rust toolchain
-        run: rustup show
+      - uses: cachix/install-nix-action@v17
+      - uses: cachix/cachix-action@v10
+        with:
+          name: enarx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install --impure '.#devShell.x86_64-linux'
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -34,11 +38,13 @@ jobs:
     name: cargo clippy (${{ matrix.crate.name }})
     runs-on: ubuntu-20.04
     steps:
-      - run: sudo apt -o Acquire::Retries=3 update
-      - run: sudo apt -o Acquire::Retries=3 install -y musl-tools
       - uses: actions/checkout@v2
-      - name: Setup Rust toolchain
-        run: rustup show
+      - uses: cachix/install-nix-action@v17
+      - uses: cachix/cachix-action@v10
+        with:
+          name: enarx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install --impure '.#devShell.x86_64-linux'
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          target: x86_64-unknown-linux-musl
-          toolchain: nightly-2022-06-28
+          toolchain: stable
           profile: minimal
+          override: true
       - name: Setup Rust toolchain
         run: >
             rustup override unset || :

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,14 @@ jobs:
   main:
     name: enarx ${{ matrix.backend.name }} nightly ${{ matrix.profile.name }}
     runs-on: ${{ matrix.backend.host }}
+    container:
+      image: nixos/nix
+      volumes:
+        - /dev:/dev
     env:
         ENARX_BACKEND: ${{ matrix.backend.name }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v17
       - uses: cachix/cachix-action@v10
         with:
           name: enarx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,13 @@ jobs:
     env:
         ENARX_BACKEND: ${{ matrix.backend.name }}
     steps:
-      - run: sudo apt -o Acquire::Retries=3 update
-      - run: sudo apt -o Acquire::Retries=3 install -y musl-tools
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: cachix/install-nix-action@v17
+      - uses: cachix/cachix-action@v10
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - name: Setup Rust toolchain
-        run: >
-            rustup override unset || :
-            && rustup target add wasm32-wasi
-            && rustup show
+          name: enarx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install --impure '.#devShell.x86_64-linux'
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -48,11 +42,13 @@ jobs:
     name: enarx build-only nightly ${{ matrix.profile.name }}
     runs-on: ubuntu-20.04
     steps:
-      - run: sudo apt -o Acquire::Retries=3 update
-      - run: sudo apt -o Acquire::Retries=3 install -y musl-tools
       - uses: actions/checkout@v2
-      - name: Setup Rust toolchain
-        run: rustup show
+      - uses: cachix/install-nix-action@v17
+      - uses: cachix/cachix-action@v10
+        with:
+          name: enarx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install --impure '.#devShell.x86_64-linux'
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -70,8 +66,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Rust toolchain
-        run: rustup show
+      - uses: cachix/install-nix-action@v17
+      - uses: cachix/cachix-action@v10
+        with:
+          name: enarx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install --impure '.#devShell.x86_64-linux'
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -94,8 +94,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Rust toolchain
-        run: rustup show
+      - uses: cachix/install-nix-action@v17
+      - uses: cachix/cachix-action@v10
+        with:
+          name: enarx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install --impure '.#devShell.x86_64-linux'
       - run: cargo build ${{ matrix.profile.flag }} --target wasm32-wasi --manifest-path ${{ matrix.crate.path }}/Cargo.toml
     strategy:
       fail-fast: false
@@ -111,11 +115,13 @@ jobs:
     name: ${{ matrix.crate.name }} nightly ${{ matrix.profile.name }}
     runs-on: ubuntu-20.04
     steps:
-      - run: sudo apt -o Acquire::Retries=3 update
-      - run: sudo apt -o Acquire::Retries=3 install -y musl-tools
       - uses: actions/checkout@v2
-      - name: Setup Rust toolchain
-        run: rustup show
+      - uses: cachix/install-nix-action@v17
+      - uses: cachix/cachix-action@v10
+        with:
+          name: enarx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install --impure '.#devShell.x86_64-linux'
       - run: cargo test ${{ matrix.profile.flag }} --target x86_64-unknown-linux-gnu --manifest-path ${{ matrix.crate.path }}/Cargo.toml
     strategy:
       fail-fast: false
@@ -135,16 +141,13 @@ jobs:
     name: ${{ matrix.crate.name }} miri ${{ matrix.profile.name }}
     runs-on: ubuntu-20.04
     steps:
-      - run: sudo apt -o Acquire::Retries=3 update
-      - run: sudo apt -o Acquire::Retries=3 install -y musl-tools
       - uses: actions/checkout@v2
-      - name: Setup Rust toolchain
-        run: rustup show
-      - uses: actions-rs/cargo@v1
-        name: cargo miri setup
+      - uses: cachix/install-nix-action@v17
+      - uses: cachix/cachix-action@v10
         with:
-          command: miri
-          args: setup --manifest-path ${{ matrix.crate.path }}/Cargo.toml
+          name: enarx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install --impure '.#devShell.x86_64-linux'
       - uses: actions-rs/cargo@v1
         name: cargo miri test
         env:

--- a/flake.nix
+++ b/flake.nix
@@ -157,11 +157,13 @@
           };
 
           devShell = pkgs.mkShell {
-            buildInputs = [
-              (fenix.packages.${system}.fromToolchainFile {
-                file = "${self}/rust-toolchain.toml";
-              })
-            ];
+            buildInputs =
+              [
+                (fenix.packages.${system}.fromToolchainFile {
+                  file = "${self}/rust-toolchain.toml";
+                })
+              ]
+              ++ pkgs.lib.optional (system == x86_64-linux || system == aarch64-linux) pkgs.musl;
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,7 @@
                 (fenix.packages.${system}.fromToolchainFile {
                   file = "${self}/rust-toolchain.toml";
                 })
+                pkgs.lcov
               ]
               ++ pkgs.lib.optional (system == x86_64-linux || system == aarch64-linux) pkgs.musl;
           };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 channel = "nightly-2022-06-28"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-unknown-none", "wasm32-wasi"]
 profile = "minimal"
-components = ["rustfmt", "clippy", "miri", "rust-src"]
+components = ["rustfmt", "clippy", "miri", "rust-src", "llvm-tools-preview"]


### PR DESCRIPTION
Alternative soluton to #2060 , which should prevent such situations from occuring in the future by relying on all packages locked in a lock file and cached via `nix`.
That also means that we can manage our rust toolchain version and components in one standard location (`rust-toolchain.toml`)