### PR TITLE
chore: bump Rust toolchain to 2022-07-19

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,11 +59,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-06-28 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-07-19 -y
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-06-28
+          toolchain: nightly-2022-07-19
           profile: minimal
           components: llvm-tools-preview
 

--- a/.github/workflows/sbom_manifest_action.yml
+++ b/.github/workflows/sbom_manifest_action.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-musl
-          toolchain: nightly-2022-06-28
+          toolchain: nightly-2022-07-19
           override: true
 
       - name: Install cargo-cyclonedx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-06-28 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-07-19 -y
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-06-28
+          toolchain: nightly-2022-07-19
           profile: minimal
 
       - uses: actions-rs/cargo@v1

--- a/crates/exec-wasmtime/src/lib.rs
+++ b/crates/exec-wasmtime/src/lib.rs
@@ -5,7 +5,6 @@
 #![deny(missing_docs)]
 #![deny(clippy::all)]
 #![warn(rust_2018_idioms)]
-#![feature(core_ffi_c)]
 
 mod loader;
 

--- a/crates/exec-wasmtime/src/main.rs
+++ b/crates/exec-wasmtime/src/main.rs
@@ -4,7 +4,6 @@
 #![deny(missing_docs)]
 #![deny(clippy::all)]
 #![warn(rust_2018_idioms)]
-#![feature(core_ffi_c)]
 
 use enarx_exec_wasmtime::execute;
 

--- a/crates/sallyport/src/guest/alloc/phase_alloc.rs
+++ b/crates/sallyport/src/guest/alloc/phase_alloc.rs
@@ -26,7 +26,7 @@ pub(crate) mod phase {
 #[derive(Debug)]
 pub struct Alloc<'a, Phase> {
     /// Write-only pointer to memory location, where next object will be allocated.
-    ptr: NonNull<[u8]>,
+    pub(crate) ptr: NonNull<[u8]>,
     /// Byte offset of the next allocated ptr object within allocation buffer.
     offset: usize,
 

--- a/crates/sallyport/src/guest/call/syscall/alloc.rs
+++ b/crates/sallyport/src/guest/call/syscall/alloc.rs
@@ -17,7 +17,7 @@ use core::ffi::c_long;
 /// # Examples
 ///
 /// ```rust
-/// # #![feature(c_size_t, core_ffi_c)]
+/// # #![feature(c_size_t)]
 /// use sallyport::guest::alloc::{Allocator, Collector, Output};
 /// use sallyport::guest::call::types::Argv;
 /// use sallyport::guest::syscall::Alloc;

--- a/crates/sallyport/src/guest/call/syscall/passthrough.rs
+++ b/crates/sallyport/src/guest/call/syscall/passthrough.rs
@@ -21,7 +21,6 @@ use core::ffi::{c_int, c_long};
 ///
 /// # Example
 /// ```rust
-/// # #![feature(core_ffi_c)]
 /// use sallyport::guest::call::types::Argv;
 /// use sallyport::guest::syscall::PassthroughAlloc;
 /// use sallyport::Result;

--- a/crates/sallyport/src/lib.rs
+++ b/crates/sallyport/src/lib.rs
@@ -8,7 +8,6 @@
 #![deny(clippy::all)]
 // TODO: Enable https://github.com/enarx/sallyport/issues/32
 //#![deny(missing_docs)]
-#![feature(core_ffi_c)]
 #![feature(c_size_t)]
 #![feature(nonnull_slice_from_raw_parts)]
 #![feature(slice_ptr_get)]

--- a/crates/sallyport/tests/integration.rs
+++ b/crates/sallyport/tests/integration.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #![cfg(all(target_arch = "x86_64", target_os = "linux", not(miri)))]
-#![feature(c_size_t, core_ffi_c)]
+#![feature(c_size_t)]
 
 mod enarxcall;
 mod gdbcall;

--- a/crates/sallyport/tests/integration.rs
+++ b/crates/sallyport/tests/integration.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#![cfg(all(target_arch = "x86_64", target_os = "linux", not(miri)))]
 #![feature(c_size_t, core_ffi_c)]
 
 mod enarxcall;

--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -12,7 +12,7 @@
 #![deny(clippy::all)]
 #![cfg_attr(not(test), deny(clippy::integer_arithmetic))]
 #![deny(missing_docs)]
-#![feature(asm_const, asm_sym, c_size_t, core_ffi_c, naked_functions)]
+#![feature(asm_const, asm_sym, c_size_t, naked_functions)]
 #![warn(rust_2018_idioms)]
 #![cfg_attr(coverage, feature(no_coverage))]
 

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -9,7 +9,7 @@
 //! instructions) from the enclave code and proxies them to the host.
 
 #![cfg_attr(not(test), no_std)]
-#![feature(c_size_t, core_ffi_c)]
+#![feature(c_size_t)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -211,20 +211,20 @@ $ cargo install --locked --bin enarx --path ./
 
 :::note
 
-Rust version nightly-2022-06-28 is required when installing Enarx 0.6.0 from crates.io.
+Rust version nightly-2022-07-19 is required when installing Enarx 0.6.0 from crates.io.
 
 :::
 
 For installing Enarx from crates.io on X86_64 Linux please run:
 ```sh:crates;
-$ rustup toolchain install nightly-2022-06-28 -t x86_64-unknown-linux-musl,x86_64-unknown-linux-gnu,x86_64-unknown-none
-$ CARGO_TARGET_X86_64_UNKNOWN_NONE_RUSTFLAGS="-C linker=gcc" cargo +nightly-2022-06-28 -Z bindeps install --locked --bin enarx --version 0.6.0 -- enarx
+$ rustup toolchain install nightly-2022-07-19 -t x86_64-unknown-linux-musl,x86_64-unknown-linux-gnu,x86_64-unknown-none
+$ CARGO_TARGET_X86_64_UNKNOWN_NONE_RUSTFLAGS="-C linker=gcc" cargo +nightly-2022-07-19 -Z bindeps install --locked --bin enarx --version 0.6.0 -- enarx
 ```
 
 For installing Enarx from crates.io on non-x86_64 Linux please run:
 ```console
-$ rustup toolchain install nightly-2022-06-28
-$ cargo +nightly-2022-06-28 -Z bindeps install --locked --bin enarx --version 0.6.0 -- enarx
+$ rustup toolchain install nightly-2022-07-19
+$ cargo +nightly-2022-07-19 -Z bindeps install --locked --bin enarx --version 0.6.0 -- enarx
 ```
 
 ### Install from Nix

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1657002438,
-        "narHash": "sha256-BHStt2enlVTYoFBSIFLYLKiqbg85ghVSI/S3th2HX1g=",
+        "lastModified": 1658212081,
+        "narHash": "sha256-zy+sNlqK/yqmMpSzZUIp54OT1yet62r4AZcRR8HiITY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "7958c5e906a20f8d3308928cc184592cc413ccbe",
+        "rev": "69069698c3aa14fc211c66c6635c1e34f4d6b441",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656947410,
-        "narHash": "sha256-htDR/PZvjUJGyrRJsVqDmXR8QeoswBaRLzHt13fd0iY=",
+        "lastModified": 1658233628,
+        "narHash": "sha256-RFRVrPSMwIWUQlisB6T3EOMETkZW++D+rNKfCT3bbfU=",
         "owner": "profianinc",
         "repo": "nixpkgs",
-        "rev": "e8d47977286a44955262adbc76f2c8a66e7419d5",
+        "rev": "173209ef123580254fbd37ac96d1fdb1ca69cd7c",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1656953957,
-        "narHash": "sha256-oYX2K4Tk3eGgEnNBIRmnBv9421hEEXDj3KF3w8cIu1k=",
+        "lastModified": 1658182792,
+        "narHash": "sha256-NOpxaEiFT9n7oSe02puqerKAt2VRsO8XtZ0Ra83JOOY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "e1a8c0b1534f26d4f04df79cfa11fd309365639b",
+        "rev": "567a5e9ef7c753e03d528cbc19110db99e8d6878",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-06-28"
+channel = "nightly-2022-07-19"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-unknown-none", "wasm32-wasi"]
 profile = "minimal"
 components = ["rustfmt", "clippy", "miri", "rust-src"]

--- a/src/backend/sev/snp/vcek.rs
+++ b/src/backend/sev/snp/vcek.rs
@@ -183,7 +183,7 @@ mod tests {
         let file_path_write = file_path.clone();
 
         join_handles.push(thread::spawn(move || {
-            thread::sleep(std::time::Duration::from_millis(500));
+            thread::sleep(std::time::Duration::from_millis(200));
             let path = write(tmp_dir_path.clone(), "test".to_string(), || {
                 Ok(Box::new(b"test test".as_slice()))
             })
@@ -195,7 +195,7 @@ mod tests {
             let tmp_dir_path = tmp_dir.path().to_path_buf();
             let file_path = file_path.clone();
             join_handles.push(thread::spawn(move || {
-                let mut retries = 10;
+                let mut retries = 100;
 
                 while retries > 0 {
                     match read(tmp_dir_path.clone(), "test".to_string()) {

--- a/src/backend/sgx/builder.rs
+++ b/src/backend/sgx/builder.rs
@@ -101,13 +101,13 @@ impl super::super::Mapper for Builder {
         );
 
         // Update the enclave.
-        let mut ap = AddPages::new(&*pages, to, &with.0, with.1);
+        let mut ap = AddPages::new(&pages, to, &with.0, with.1);
         ENCLAVE_ADD_PAGES
             .ioctl(&mut self.file, &mut ap)
             .context("Failed to add pages to SGX enclave")?;
 
         // Update the hasher.
-        self.hash.load(&*pages, to, with.0, with.1).unwrap();
+        self.hash.load(&pages, to, with.0, with.1).unwrap();
 
         // Save permissions fixups for later.
         let mut addr = self.mmap.addr() + to;

--- a/src/backend/sgx/hasher.rs
+++ b/src/backend/sgx/hasher.rs
@@ -28,7 +28,7 @@ impl super::super::Mapper for Hasher {
         to: usize,
         with: (SecInfo, bool),
     ) -> anyhow::Result<()> {
-        self.0.load(&*pages, to, with.0, with.1).unwrap();
+        self.0.load(&pages, to, with.0, with.1).unwrap();
         Ok(())
     }
 }

--- a/tests/crates/enarx_exec_tests/src/bin/cpuid.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/cpuid.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(core_ffi_c)]
-
 use enarx_exec_tests::musl_fsbase_fix;
 
 musl_fsbase_fix!();

--- a/tests/crates/enarx_exec_tests/src/bin/echo.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/echo.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(core_ffi_c)]
-
 use enarx_exec_tests::musl_fsbase_fix;
 use std::io::{self, Read, Write};
 

--- a/tests/crates/enarx_exec_tests/src/bin/memory_stress_test.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/memory_stress_test.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(core_ffi_c)]
 use enarx_exec_tests::musl_fsbase_fix;
 
 musl_fsbase_fix!();

--- a/tests/crates/enarx_exec_tests/src/bin/memspike.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/memspike.rs
@@ -4,8 +4,6 @@
 //! VM-based keeps. This will help test the ballooning itself as well
 //! as memory pinning for SEV.
 
-#![feature(core_ffi_c)]
-
 use enarx_exec_tests::musl_fsbase_fix;
 use std::collections::TryReserveError;
 

--- a/tests/crates/enarx_exec_tests/src/bin/sev_attestation.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/sev_attestation.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(core_ffi_c)]
-
 use enarx_exec_tests::musl_fsbase_fix;
 
 use std::arch::asm;

--- a/tests/crates/enarx_exec_tests/src/bin/sgx_attestation.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/sgx_attestation.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-#![feature(core_ffi_c)]
 
 use enarx_exec_tests::musl_fsbase_fix;
 

--- a/tests/crates/enarx_exec_tests/src/bin/unix_echo.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/unix_echo.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(core_ffi_c)]
-
 use enarx_exec_tests::musl_fsbase_fix;
 use std::io::{self, stdin, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};


### PR DESCRIPTION
This gets a bugfix for Cargo's sparse registry feature, updates some code for some new clippy lints, removes a newly-unnecessary feature flag, and temporarily disables some tests under miri (see #2066).

Supersedes #2057.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
