### PR TITLE
fix(sallyport): avoid UB by removing implicit reference from indexing with range

### DIFF
--- a/crates/sallyport/src/lib.rs
+++ b/crates/sallyport/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(core_ffi_c)]
 #![feature(c_size_t)]
 #![feature(nonnull_slice_from_raw_parts)]
+#![feature(slice_ptr_get)]
 #![feature(slice_ptr_len)]
 
 pub mod elf;


### PR DESCRIPTION
This potential source of UB was discovered while upgrading the Rust toolchain, which upgrades us to a new version of Miri with stricter rules around raw pointers. Specifically, an expression like `addr_of_mut!((*(ptr))[offset..])` is deliberately attempting to operate only on raw pointers while avoiding any intermediate references, since references have invariants that raw pointers do not (e.g. aliasing). However, there is in fact an implicit reference here that is created as a result of the indexing operation. This is both surprising and not surprising, for interesting reasons.

First, it should not be surprising because indexing is governed by the Index traits, whose methods return references, so their presence here is natural.

On the other hand, it is surprising because Rust already special cases `(*ptr)[foo]` when `ptr` is a raw slice and `foo` is not a range to avoid the Index traits entirely, which allows it to avoid emitting an intermediate reference.

The ideal solution here is for Rust to be smart enough to not introduce the intermediate reference here at all, which is tracked at https://github.com/rust-lang/rust/issues/73987 .

In addition, while investigating this issue I brought it up to the Unsafe Code Guidelines team, who saw fit to file https://github.com/rust-lang/rust/issues/99437 as a more specific example of the potential pitfalls of the current behavior.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>
