### PR TITLE
fix(release): rename windows artifact locations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,33 +197,25 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: enarx-x86_64-windows.exe
+        name: enarx-x86_64-windows
     - uses: actions/download-artifact@v3
       with:
-        name: enarx-x86_64-windows.msi
-
-    - uses: actions/download-artifact@v3
-      with:
-        name: enarx-x86_64-apple-darwin
+        name: enarx-x86_64-windows-msi
     - uses: actions/download-artifact@v3
       with:
         name: enarx-x86_64-apple-darwin-oci
-
     - uses: actions/download-artifact@v3
       with:
         name: enarx-x86_64-unknown-linux-musl
     - uses: actions/download-artifact@v3
       with:
         name: enarx-x86_64-unknown-linux-musl-oci
-
     - uses: actions/download-artifact@v3
       with:
         name: enarx-aarch64-unknown-linux-musl
-
     - uses: actions/download-artifact@v3
       with:
         name: enarx-universal-darwin
-
     - uses: softprops/action-gh-release@v1
       with:
         draft: true
@@ -231,7 +223,6 @@ jobs:
         files: |
           enarx-x86_64-windows.exe
           enarx-x86_64-windows.msi
-          enarx-x86_64-apple-darwin
           enarx-x86_64-apple-darwin-oci
           enarx-x86_64-unknown-linux-musl
           enarx-x86_64-unknown-linux-musl-oci


### PR DESCRIPTION
- Fix windows artifact locations prior to release
- Remove platform specific darwin binaries in favor of universal binaries
- Remove unnecessary whitespace

Signed-off-by: Paul Pietkiewicz <paul@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
