### PR TITLE
chore(wasmtime): bump wasmtime related dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,23 +450,23 @@ checksum = "88c2fabb6b63843ea4839a27bbfb2e6a33eff8ed6337651975d11d3d43b605b4"
 dependencies = [
  "async-std",
  "camino",
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
+ "cap-primitives 0.24.4",
+ "io-extras 0.13.2",
+ "io-lifetimes 0.5.3",
  "ipnet",
- "rustix",
+ "rustix 0.33.7",
 ]
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.24.4"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54b86398b5852ddd45784b1d9b196b98beb39171821bad4b8b44534a1e87927"
+checksum = "04e142bbbe9d5d6a2dd0387f887a000b41f4c82fb1226316dfb4cc8dbc3b1a29"
 dependencies = [
- "cap-primitives",
+ "cap-primitives 0.25.2",
  "cap-std",
- "io-lifetimes",
- "winapi",
+ "io-lifetimes 0.7.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -477,22 +477,41 @@ checksum = "fb8fca3e81fae1d91a36e9784ca22a39ef623702b5f7904d89dc31f10184a178"
 dependencies = [
  "ambient-authority",
  "errno",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
+ "fs-set-times 0.15.0",
+ "io-extras 0.13.2",
+ "io-lifetimes 0.5.3",
  "ipnet",
  "maybe-owned",
- "rustix",
+ "rustix 0.33.7",
  "winapi",
  "winapi-util",
- "winx",
+ "winx 0.31.0",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f22f4975282dd4f2330ee004f001c4e22f420da9fb474ea600e9af330f1e548"
+dependencies = [
+ "ambient-authority",
+ "errno",
+ "fs-set-times 0.17.1",
+ "io-extras 0.15.0",
+ "io-lifetimes 0.7.2",
+ "ipnet",
+ "maybe-owned",
+ "rustix 0.35.7",
+ "winapi-util",
+ "windows-sys",
+ "winx 0.33.0",
 ]
 
 [[package]]
 name = "cap-rand"
-version = "0.24.4"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3b27294116983d706f4c8168f6d10c84f9f5daed0c28bc7d0296cf16bcf971"
+checksum = "ef643f8defef7061c395bb3721b6a80d39c1baaa8ee2e42edf2917fa05584e7f"
 dependencies = [
  "ambient-authority",
  "rand 0.8.5",
@@ -500,27 +519,27 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.24.3"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d684df5773e4af5c343c466f47151db7e7a4366daab609b4a6bb7a75aecf732"
+checksum = "95624bb0abba6b6ff6fad2e02a7d3945d093d064ac5a3477a308c29fbe3bfd49"
 dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
+ "cap-primitives 0.25.2",
+ "io-extras 0.15.0",
+ "io-lifetimes 0.7.2",
  "ipnet",
- "rustix",
+ "rustix 0.35.7",
 ]
 
 [[package]]
 name = "cap-time-ext"
-version = "0.24.4"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50472b6ebc302af0401fa3fb939694cd8ff00e0d4c9182001e434fc822ab83a"
+checksum = "46a2d284862edf6e431e9ad4e109c02855157904cebaceae6f042b124a1a21e2"
 dependencies = [
- "cap-primitives",
+ "cap-primitives 0.25.2",
  "once_cell",
- "rustix",
- "winx",
+ "rustix 0.35.7",
+ "winx 0.33.0",
 ]
 
 [[package]]
@@ -689,18 +708,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.85.1"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7901fbba05decc537080b07cb3f1cadf53be7b7602ca8255786288a8692ae29a"
+checksum = "0457b287eaa01086632f14ff4b5e5ec4bf97f639b981473f43df4056a15f2253"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.85.1"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ba1b45d243a4a28e12d26cd5f2507da74e77c45927d40de8b6ffbf088b46b5"
+checksum = "5a710dcf0bb5e037b822e82bf1988b87d2692cf39e940107c3cac613d1ca10bd"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -716,33 +735,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.85.1"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cc30032171bf230ce22b99c07c3a1de1221cb5375bd6dbe6dbe77d0eed743c"
+checksum = "bc6799d0c2afcb24000336bba69d356b1aac4097a975306bfe5309f588aeacf1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.85.1"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23f2672426d2bb4c9c3ef53e023076cfc4d8922f0eeaebaf372c92fae8b5c69"
+checksum = "6f5a9d4a05b1161e30e1adbea9ffb2ca0059424607db2b92cd268d9582996f04"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.85.1"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886c59a5e0de1f06dbb7da80db149c75de10d5e2caca07cdd9fef8a5918a6336"
+checksum = "bfcb460dd2df6a3f8aa722effcc5b5cd2df4f4c05a70a5cebd0686cf0710bd54"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.85.1"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace74eeca11c439a9d4ed1a5cb9df31a54cd0f7fbddf82c8ce4ea8e9ad2a8fe0"
+checksum = "ed6535b47baf007b597a64d82108d08a5dff2292babe65050a5635f24812729d"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -752,15 +771,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.85.1"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db1ae52a5cc2cad0d86fdd3dcb16b7217d2f1e65ab4f5814aa4f014ad335fa43"
+checksum = "377a7a63425d602cdc14e025e8c790153d68435284dc6902451e5016e648a93d"
 
 [[package]]
 name = "cranelift-native"
-version = "0.85.1"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dadcfb7852900780d37102bce5698bcd401736403f07b52e714ff7a180e0e22f"
+checksum = "2ab92b46bd65423ca6b3714a6f0b58edfeea293f804c2e4762601e0e514a3cce"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -769,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.85.1"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84e3410960389110b88f97776f39f6d2c8becdaa4cd59e390e6b76d9d0e7190"
+checksum = "b262a93bee8a9331e8ea24ddefc5ca63e793f449c0b442b86a5cfff54b6295f6"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1145,12 +1164,12 @@ dependencies = [
  "enarx-config",
  "env_logger",
  "getrandom 0.2.7",
- "io-extras",
- "io-lifetimes",
+ "io-extras 0.15.0",
+ "io-lifetimes 0.7.2",
  "libc",
  "pkcs8 0.9.0-pre.1",
  "ring",
- "rustix",
+ "rustix 0.35.7",
  "rustls",
  "sec1",
  "serde",
@@ -1344,9 +1363,20 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df62ee66ee2d532ea8d567b5a3f0d03ecd64636b98bad5be1e93dcc918b92aa"
 dependencies = [
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 0.5.3",
+ "rustix 0.33.7",
  "winapi",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a267b6a9304912e018610d53fe07115d8b530b160e85db4d2d3a59f3ddde1aec"
+dependencies = [
+ "io-lifetimes 0.7.2",
+ "rustix 0.35.7",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1799,8 +1829,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c937cc9891c12eaa8c63ad347e4a288364b1328b924886970b47a14ab8f8f8"
 dependencies = [
  "async-std",
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "winapi",
+]
+
+[[package]]
+name = "io-extras"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5d8c2ab5becd8720e30fd25f8fa5500d8dc3fceadd8378f05859bd7b46fc49"
+dependencies = [
+ "io-lifetimes 0.7.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1810,8 +1850,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 dependencies = [
  "async-std",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
+dependencies = [
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1828,14 +1876,14 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "is-terminal"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c89a757e762896bdbdfadf2860d0f8b0cea5e363d8cf3e7bdfeb63d1d976352"
+checksum = "0d508111813f9af3afd2f92758f77e4ed2cc9371b642112c6a48d22eb73105c5"
 dependencies = [
  "hermit-abi 0.2.3",
- "io-lifetimes",
- "rustix",
- "winapi",
+ "io-lifetimes 0.7.2",
+ "rustix 0.35.7",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1941,6 +1989,12 @@ name = "linux-raw-sys"
 version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -2678,9 +2732,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8d23b35d7177df3b9d31ed8a9ab4bf625c668be77a319d4f5efd4a5257701c"
+checksum = "76ff2e57a7d050308b3fde0f707aa240b491b190e3855f212860f11bb3af4205"
 dependencies = [
  "fxhash",
  "log",
@@ -2758,12 +2812,28 @@ checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "itoa",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.42",
  "once_cell",
  "winapi",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.7.2",
+ "itoa",
+ "libc",
+ "linux-raw-sys 0.0.46",
+ "once_cell",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3223,18 +3293,18 @@ checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "system-interface"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e09bb3fb4e02ec4b87e182ea9718fadbc0fa3e50085b40a9af9690572b67f9e"
+checksum = "2e3e98c4cf2f43a7e3b3a943b63fd192559b8a98ddcbef260580f29f0f4b9d1b"
 dependencies = [
  "atty",
  "bitflags",
  "cap-fs-ext",
  "cap-std",
- "io-lifetimes",
- "rustix",
- "winapi",
- "winx",
+ "io-lifetimes 0.7.2",
+ "rustix 0.35.7",
+ "windows-sys",
+ "winx 0.33.0",
 ]
 
 [[package]]
@@ -3592,9 +3662,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c4e73ed64b92ae87b416f4274b3c827180b02b67f835f66a86fc4267b77349"
+checksum = "37c545f679cd7f53c679b392634b4bcddadba1cec661f938de9feff5855c2d46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3602,34 +3672,34 @@ dependencies = [
  "cap-rand",
  "cap-std",
  "cap-time-ext",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
+ "fs-set-times 0.17.1",
+ "io-extras 0.15.0",
+ "io-lifetimes 0.7.2",
  "is-terminal",
  "lazy_static",
- "rustix",
+ "rustix 0.35.7",
  "system-interface",
  "tracing",
  "wasi-common",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "wasi-common"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc983eb93607a61f64152ec8728bf453f4dfdf22e7ab1784faac3297fe9a035e"
+checksum = "196ad34069d2a54d931752243dd09a41c81e50577e2e00feef7dc9eaffa806cf"
 dependencies = [
  "anyhow",
  "bitflags",
  "cap-rand",
  "cap-std",
- "io-extras",
- "rustix",
+ "io-extras 0.15.0",
+ "rustix 0.35.7",
  "thiserror",
  "tracing",
  "wiggle",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3709,18 +3779,18 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.85.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570460c58b21e9150d2df0eaaedbb7816c34bcec009ae0dcc976e40ba81463e7"
+checksum = "4bcbfe95447da2aa7ff171857fc8427513eb57c75a729bb190e974dc695e8f5c"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e76e2b2833bb0ece666ccdbed7b71b617d447da11f1bb61f4f2bab2648f745ee"
+checksum = "cff030cf8d798cdfc733cb22dd0a75ae543665fabcb8d9e4785e4fd52830eec4"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3742,14 +3812,14 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc0f80afa1ce97083a7168e6b6948d015d6237369e9f4a511d38c9c4ac8fbb9"
+checksum = "04eac45616085ceb25ad9281400055e9132a960039e27ac475a6b3ba333a007c"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3769,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0816d9365196f1f447060087e0f87239ccded830bd54970a1168b0c9c8e824c9"
+checksum = "2dcc3d3675626f2994d060c4b8b0a2ff8be43c18717c81dba90046b70b65b9a8"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3789,9 +3859,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c687f33cfa0f89ec1646929d0ff102087052cf9f0d15533de56526b0da0d1b3"
+checksum = "3f39bfa316a52dbe5de0b2ef2e9111f52148259675e75d888c3ea75b8ac37292"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3803,29 +3873,29 @@ dependencies = [
  "object 0.28.4",
  "region",
  "rustc-demangle",
- "rustix",
+ "rustix 0.35.7",
  "serde",
  "target-lexicon",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-runtime",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b252d1d025f94f3954ba2111f12f3a22826a0764a11c150c2d46623115a69e27"
+checksum = "ea6ac08cd4cd3e9c682dbd3f905be923bbe5e3272ea1088a0eca59593749ef17"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace251693103c9facbbd7df87a29a75e68016e48bc83c09133f2fda6b575e0ab"
+checksum = "2fd789d7e23742aef2d17f9ea3a7ad60c0ba63725bfb570363b1e8677b308302"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3839,18 +3909,18 @@ dependencies = [
  "more-asserts",
  "rand 0.8.5",
  "region",
- "rustix",
+ "rustix 0.35.7",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-jit-debug",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d129b0487a95986692af8708ffde9c50b0568dcefd79200941d475713b4f40bb"
+checksum = "3d32edb292aa37391a12f61abdc05f1877ae9520ede3a6ccb6cd54c0c9d11e26"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3860,9 +3930,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb49791530b3a3375897a6d5a8bfa9914101ef8a672d01c951e70b46fd953c15"
+checksum = "8b366d9830b9a44809b1dd1523d9e18a11a976389aeddbc8b738b01a578f5f0f"
 dependencies = [
  "anyhow",
  "wasi-cap-std-sync",
@@ -3941,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c38020359fabec5e5ce5a3f667af72e9a203bc6fe8caeb8931d3a870754d9d"
+checksum = "e16816e59865749c9ce018c251d2df06731a29f02d6e2e9331821fe72e5e0b35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3956,9 +4026,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e4420b496b04920ae3e41424029aba95c15a5e2e2b4012d14ec83770a3ef"
+checksum = "42b06353cc4f6f449322e469a1f3b765ac9f8bae55e827f2a8a2885540e5bfca"
 dependencies = [
  "anyhow",
  "heck",
@@ -3971,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e541a0be1f2c4d53471d8a9df81c2d8725a3f023d8259f555c65b03d515aaab"
+checksum = "3bb033ae85463bf9457efe4799307c4e98e856d62cd366561ce6bedbb2d51b94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4062,8 +4132,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d5973cb8cd94a77d03ad7e23bbe14889cb29805da1cec0e4aff75e21aebded"
 dependencies = [
  "bitflags",
- "io-lifetimes",
+ "io-lifetimes 0.5.3",
  "winapi",
+]
+
+[[package]]
+name = "winx"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b01e010390eb263a4518c8cebf86cb67469d1511c00b749a47b64c39e8054d"
+dependencies = [
+ "bitflags",
+ "io-lifetimes 0.7.2",
+ "windows-sys",
 ]
 
 [[package]]

--- a/crates/exec-wasmtime/Cargo.toml
+++ b/crates/exec-wasmtime/Cargo.toml
@@ -31,17 +31,17 @@ zeroize = { version = "1.5.4", features = ["alloc"], default-features = false }
 # The dependencies are pinned, because:
 # - traits and types must fit the ones used in wasmtime
 # - we don't want to be notified by dependabot, if there is no new version of wasmtime
-wasmtime = { version = "0.38.1", features = ["cranelift", "pooling-allocator"], default-features = false }
-cap-std = { version = "=0.24.3", default-features = false }
-io-lifetimes = { version = "=0.5.3", default-features = false }
-rustix = { version = "=0.33.7", features = ["std"], default-features = false }
-system-interface = { version = "=0.20.0", default-features = false }
-wasi-common = { version = "=0.38.1", default-features = false }
-wasmtime-wasi = { version = "=0.38.1", features = ["sync"], default-features = false }
-wiggle = { version = "=0.38.1", default-features = false }
+wasmtime = { version = "0.39.0", features = ["cranelift", "pooling-allocator"], default-features = false }
+cap-std = { version = "=0.25.2", default-features = false }
+io-lifetimes = { version = "=0.7.2", default-features = false }
+rustix = { version = "=0.35.7", features = ["std"], default-features = false }
+system-interface = { version = "=0.21.0", default-features = false }
+wasi-common = { version = "=0.39.0", default-features = false }
+wasmtime-wasi = { version = "=0.39.0", features = ["sync"], default-features = false }
+wiggle = { version = "=0.39.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
-io-extras = { version = "=0.13.2", default-features = false }
+io-extras = { version = "=0.15.0", default-features = false }
 
 [dev-dependencies]
 wat = { version = "1.0", default-features = false }


### PR DESCRIPTION
- bump wasmtime to 0.39.0
Signed-off-by: Paul Pietkiewicz <paul@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
