### PR TITLE
chore(exec-wasmtime): bump x509-cert to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0-pre.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ed717eef39a802bcfbfefed277ffe0639c53ad7720753646d21d2bd6074fe1"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid 0.9.0",
  "der_derive",
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.6.0-pre.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45cd173346b7c0770907daa7d0b0c1f8e5ce67a853d7fa10f5ff77dc73d82b46"
+checksum = "180e0925824edd2cc2de26da32852c7cd30844011dbf4956c12c88ad2f42d910"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1167,7 +1167,7 @@ dependencies = [
  "io-extras 0.15.0",
  "io-lifetimes 0.7.2",
  "libc",
- "pkcs8 0.9.0-pre.1",
+ "pkcs8 0.9.0",
  "ring",
  "rustix 0.35.7",
  "rustls",
@@ -2469,12 +2469,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0-pre.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39eca6cd63c3c92cf3d7bec60872b6e7a7542dbd03c9a164559e13e22c2a708"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der 0.6.0-pre.3",
- "spki 0.6.0-pre.2",
+ "der 0.6.0",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -2933,12 +2933,11 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0-pre.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2a39b189e5764ec7067feb68646cced103360538af8a006616e387eb0d6e05"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "der 0.6.0-pre.3",
- "generic-array",
+ "der 0.6.0",
 ]
 
 [[package]]
@@ -3248,12 +3247,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0-pre.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093b274198792f2e7026c661f658c74fc4ab023212474878dff187eb98736db1"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der 0.6.0-pre.3",
+ "der 0.6.0",
 ]
 
 [[package]]
@@ -4161,14 +4160,14 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.0.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08fda23a1ea0b7f7d229f49b99b6635f3106b3630b8920e815a0009e6fc384e"
+checksum = "6bd27a832a85efcf56cad058e4e3256d1781b927e113a9e37d96916d639e4af7"
 dependencies = [
  "const-oid 0.9.0",
- "der 0.6.0-pre.3",
+ "der 0.6.0",
  "flagset",
- "spki 0.6.0-pre.2",
+ "spki 0.6.0",
 ]
 
 [[package]]

--- a/crates/exec-wasmtime/Cargo.toml
+++ b/crates/exec-wasmtime/Cargo.toml
@@ -24,7 +24,7 @@ toml = { version = "0.5.9", default-features = false }
 ureq = { version = "2.4.0", features = ["tls"], default-features = false }
 url = { version = "2.2.2", features = ["serde"], default-features = false }
 webpki-roots = { version = "0.22.2", default-features = false }
-x509-cert = { version = "0.0.2", features = ["std"], default-features = false }
+x509-cert = { version = "0.1.0", features = ["std"], default-features = false }
 zeroize = { version = "1.5.4", features = ["alloc"], default-features = false }
 
 # wasmtime and its pinned dependencies

--- a/crates/exec-wasmtime/src/loader/configured/mod.rs
+++ b/crates/exec-wasmtime/src/loader/configured/mod.rs
@@ -15,8 +15,8 @@ use const_oid::AssociatedOid;
 use pkcs8::PrivateKeyInfo;
 use sha2::{Digest, Sha256, Sha384};
 use x509_cert::attr::Attribute;
-use x509_cert::der::asn1::BitString;
-use x509_cert::der::{Any, Decodable, Encodable};
+use x509_cert::der::asn1::BitStringRef;
+use x509_cert::der::{AnyRef, Decode, Encode};
 use x509_cert::ext::Extension;
 use x509_cert::name::RdnSequence;
 use x509_cert::request::{CertReq, CertReqInfo, ExtensionReq};
@@ -27,7 +27,7 @@ impl Loader<Configured> {
         let req = ExtensionReq::from(exts).to_vec()?;
 
         // Embed the extension requests in an attribute.
-        let any = Any::from_der(&req)?;
+        let any = AnyRef::from_der(&req)?;
         let att = Attribute {
             oid: ExtensionReq::OID,
             values: vec![any].try_into()?,
@@ -46,7 +46,7 @@ impl Loader<Configured> {
         let req = CertReq {
             info: cri,
             algorithm: pki.signs_with()?,
-            signature: BitString::from_bytes(sig.as_ref())?,
+            signature: BitStringRef::from_bytes(sig.as_ref())?,
         };
 
         Ok(req.to_vec()?)

--- a/crates/exec-wasmtime/src/loader/pki.rs
+++ b/crates/exec-wasmtime/src/loader/pki.rs
@@ -6,7 +6,7 @@ use pkcs8::{AlgorithmIdentifier, ObjectIdentifier, PrivateKeyInfo, SubjectPublic
 use zeroize::Zeroizing;
 
 use sec1::EcPrivateKey;
-use x509_cert::der::{Decodable, Encodable};
+use x509_cert::der::{Decode, Encode};
 
 use const_oid::db::rfc5912::{
     ECDSA_WITH_SHA_256, ECDSA_WITH_SHA_384, ID_EC_PUBLIC_KEY as ECPK, SECP_256_R_1 as P256,

--- a/crates/exec-wasmtime/src/loader/requested.rs
+++ b/crates/exec-wasmtime/src/loader/requested.rs
@@ -23,8 +23,8 @@ use pkcs8::PrivateKeyInfo;
 use rustls::{cipher_suite::*, kx_group::*, version::TLS13, *};
 use ureq::Response;
 use url::Url;
-use x509_cert::der::asn1::{BitString, UIntBytes};
-use x509_cert::der::{Decodable, Encodable};
+use x509_cert::der::asn1::{BitStringRef, UIntRef};
+use x509_cert::der::{Decode, Encode};
 use x509_cert::ext::pkix::{BasicConstraints, ExtendedKeyUsage, KeyUsage, KeyUsages};
 use x509_cert::name::RdnSequence;
 use x509_cert::time::Validity;
@@ -97,7 +97,7 @@ impl Loader<Requested> {
 
         // Decode the certificate chain.
         let path = PkiPath::from_der(&body)?;
-        path.0.iter().rev().map(|c| Ok(c.to_vec()?)).collect()
+        path.iter().rev().map(|c| Ok(c.to_vec()?)).collect()
     }
 
     fn selfsigned(&self) -> Result<Vec<Vec<u8>>> {
@@ -121,7 +121,7 @@ impl Loader<Requested> {
         // Create the certificate body.
         let tbs = TbsCertificate {
             version: x509_cert::Version::V3,
-            serial_number: UIntBytes::new(&serial)?,
+            serial_number: UIntRef::new(&serial)?,
             signature: pki.signs_with()?,
             issuer: RdnSequence::from_der(&rdns)?,
             validity: Validity::from_now(Duration::from_secs(60 * 60 * 24 * 365))?,
@@ -154,7 +154,7 @@ impl Loader<Requested> {
         let crt = Certificate {
             tbs_certificate: tbs,
             signature_algorithm: alg,
-            signature: BitString::from_bytes(&sig)?,
+            signature: BitStringRef::from_bytes(&sig)?,
         };
 
         Ok(vec![crt.to_vec()?])


### PR DESCRIPTION
Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
