### PR TITLE
feat: set `main.wasm` in `argv[0]`

### DIFF
--- a/crates/exec-wasmtime/src/loader/compiled/mod.rs
+++ b/crates/exec-wasmtime/src/loader/compiled/mod.rs
@@ -7,7 +7,7 @@ use null::Null;
 
 use super::{Compiled, Connected, Loader};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use cap_std::net::{TcpListener, TcpStream};
 use enarx_config::{File, Protocol};
 use wasi_common::{file::FileCaps, WasiFile};
@@ -25,8 +25,10 @@ impl Loader<Compiled> {
         }
 
         // Set up the arguments.
+        ctx.push_arg("main.wasm")
+            .context("failed to push argv[0]")?;
         for arg in self.0.config.args.iter() {
-            ctx.push_arg(arg)?;
+            ctx.push_arg(arg).context("failed to push argument")?;
         }
 
         // Set up the file descriptor environment variables.


### PR DESCRIPTION
Closes #2090 

Typical POSIX executables expect the executable name to be passed in as
the first argument. Without this, executables using command-line arguments are not portable.

Signed-off-by: Roman Volosatovs <roman@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
