### PR TITLE
docs: fix 50-sev.rules

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -52,7 +52,9 @@ $ sudo chown root:root /lib/firmware/amd/amd_sev_fam19h_model0xh.sbin
 - Set SEV device node permissions
 
 ```sh:snp;
-$ sudo bash -c "echo 'KERNEL=="sev", MODE="0666"' > /etc/udev/rules.d/50-sev.rules"
+$ sudo bash -c "cat > /etc/udev/rules.d/50-sev.rules" <<EOF
+KERNEL=="sev", MODE="0666"
+EOF
 ```
 - Increase the memlock limit for SEV keeps (need to pin a large number of pages)
 


### PR DESCRIPTION
Parentheses were not quoted resulting in:
```
KERNEL==sev, MODE=0666
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
