### PR TITLE
feat: don't strip debug enarx binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,6 @@ futures = { version = "0.3.21", default-features = false }
 http-types = { version = "2.12.0", default-features = false }
 openidconnect = { version = "2.3.1", default-features = false }
 
-[profile.dev]
-strip = true
-
 [profile.release]
 incremental = false
 codegen-units = 1


### PR DESCRIPTION
The debug sections of the shims and exec are not loaded in the keep anyway.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
