### PR TITLE
feat(shim-kvm): update aes-gcm requirement from 0.9 to 0.10.1

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,9 @@
 [target.x86_64-unknown-none]
-rustflags = ["-C", "linker=gcc"]
+rustflags = [
+    "-C", "linker=gcc",
+    "--cfg", "polyval_force_soft",
+    "--cfg", "aes_force_soft",
+]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,10 +19,11 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "ae06cea71059b6b79d879afcdd237a33ac61afc052fdd605815e6f3916254abf"
 dependencies = [
+ "crypto-common",
  "generic-array",
 ]
 
@@ -33,20 +34,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
 ]
 
 [[package]]
-name = "aes-gcm"
-version = "0.9.4"
+name = "aes"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.4.3",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.1",
+ "cipher 0.4.3",
  "ctr",
  "ghash",
  "subtle",
@@ -389,7 +401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
 dependencies = [
  "block-padding",
- "cipher",
+ "cipher 0.3.0",
 ]
 
 [[package]]
@@ -586,6 +598,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -869,11 +891,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "0d14f329cfbaf5d0e06b5e87fff7e265d2673c5ea7d2c27691a2c107db1442a0"
 dependencies = [
- "cipher",
+ "cipher 0.4.3",
 ]
 
 [[package]]
@@ -1576,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -1812,6 +1834,15 @@ name = "infer"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "instant"
@@ -2498,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -2946,7 +2977,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1da5c423b8783185fd3fecd1c8796c267d2c089d894ce5a93c280a5d3f780a2"
 dependencies = [
- "aes",
+ "aes 0.7.5",
  "block-modes",
  "hkdf",
  "lazy_static",
@@ -3532,11 +3563,11 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
 dependencies = [
- "generic-array",
+ "crypto-common",
  "subtle",
 ]
 

--- a/crates/shim-kvm/Cargo.toml
+++ b/crates/shim-kvm/Cargo.toml
@@ -12,7 +12,7 @@ gdb = ["dep:gdbstub", "dep:gdbstub_arch", "dbg"]
 dbg = []
 
 [dependencies]
-aes-gcm = { version = "0.9", features = ["force-soft"], default-features = false }
+aes-gcm = { version = "0.10.1", features = ["aes"], default-features = false }
 array-const-fn-init = { version = "0.1", default-features = false }
 const-default = { version = "1.0", features = ["derive"], default-features = false }
 crt0stack = { version = "0.1", default-features = false }

--- a/crates/shim-kvm/src/snp/ghcb.rs
+++ b/crates/shim-kvm/src/snp/ghcb.rs
@@ -15,9 +15,7 @@ use core::arch::asm;
 use core::mem::size_of;
 use core::ptr;
 
-use aes_gcm::AeadInPlace;
-use aes_gcm::NewAead;
-use aes_gcm::{Aes256Gcm, Key, Nonce, Tag};
+use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce, Tag};
 use const_default::ConstDefault;
 use sallyport::libc::EINVAL;
 use spinning::Lazy;
@@ -668,8 +666,7 @@ impl GhcbExtHandle {
 
         let vmpck0 = SECRETS.get_vmpck0();
 
-        let key = Key::from_slice(&vmpck0);
-        let cipher = Aes256Gcm::new(key);
+        let cipher = Aes256Gcm::new_from_slice(&vmpck0).unwrap();
 
         let mut seqno_nonce = [0u8; 12];
         seqno_nonce[0..8].copy_from_slice(unsafe {
@@ -730,8 +727,7 @@ impl GhcbExtHandle {
         }
 
         let vmpck0 = SECRETS.get_vmpck0();
-        let key = Key::from_slice(&vmpck0);
-        let cipher = Aes256Gcm::new(key);
+        let cipher = Aes256Gcm::new_from_slice(&vmpck0).unwrap();
 
         let mut seqno_nonce = [0u8; 12];
         seqno_nonce[0..8].copy_from_slice(unsafe {
@@ -846,9 +842,8 @@ mod test {
 
     #[test]
     fn test_gcm() {
-        use aes_gcm::AeadInPlace;
-        use aes_gcm::NewAead;
-        use aes_gcm::{Aes256Gcm, Key, Nonce, Tag};
+        use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce, Tag};
+
         use std::mem::size_of;
 
         let mut request = <SnpGuestMsg as ConstDefault>::DEFAULT;
@@ -868,8 +863,7 @@ mod test {
             186, 126, 75, 217, 65, 119, 135, 183, 107, 152, 18, 248, 41,
         ];
 
-        let key = Key::from_slice(&vmpck0);
-        let cipher = Aes256Gcm::new(key);
+        let cipher = Aes256Gcm::new_from_slice(&vmpck0).unwrap();
 
         let mut seqno_nonce = [0u8; 12];
         let msg_seqno_ptr = &request.hdr.msg_seqno as *const _ as *const u8;


### PR DESCRIPTION
Requires
```
[target.x86_64-unknown-none]
rustflags = [
    "-C", "linker=gcc",
    "--cfg", "polyval_force_soft",
    "--cfg", "aes_force_soft",
]
```

otherwise it doesn't compile for the target and the build errors out with:

```
LLVM ERROR: Do not know how to split the result of this operator!
```

Signed-off-by: Harald Hoyer <harald@profian.com>
