### PR TITLE
feat: add `get_key` syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,6 +1251,7 @@ dependencies = [
  "ring",
  "rustix 0.35.7",
  "rustls",
+ "sallyport",
  "sec1",
  "serde",
  "sha2 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
 name = "enarx-shim-sgx"
 version = "0.6.2"
 dependencies = [
+ "bitflags",
  "const-default",
  "crt0stack",
  "gdbstub 0.5.0",

--- a/crates/exec-wasmtime/Cargo.toml
+++ b/crates/exec-wasmtime/Cargo.toml
@@ -41,5 +41,8 @@ wiggle = { version = "0.39.1", default-features = false }
 [target.'cfg(windows)'.dependencies]
 io-extras = { version = "=0.15.0", default-features = false }
 
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
+sallyport = { version = "0.6.2", path = "../sallyport", default-features = false }
+
 [dev-dependencies]
 wat = { version = "1.0", default-features = false }

--- a/crates/exec-wasmtime/src/loader/configured/platform.rs
+++ b/crates/exec-wasmtime/src/loader/configured/platform.rs
@@ -28,16 +28,20 @@ impl From<Technology> for ObjectIdentifier {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct Platform(Technology, usize);
+pub struct Platform {
+    technology: Technology,
+    report_size: usize,
+    key_size: usize,
+}
 
 impl Platform {
     #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
-    fn get_att(_nonce: Option<&[u8]>, _buf: Option<&mut [u8]>) -> Result<Self> {
-        Ok(Self(Technology::Kvm, 0))
+    fn get_att(_nonce: Option<&[u8]>, _buf: Option<&mut [u8]>) -> Result<(Technology, usize)> {
+        Ok((Technology::Kvm, 0))
     }
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    fn get_att(nonce: Option<&[u8]>, mut buf: Option<&mut [u8]>) -> Result<Self> {
+    fn get_att(nonce: Option<&[u8]>, mut buf: Option<&mut [u8]>) -> Result<(Technology, usize)> {
         use sallyport::item::enarxcall::SYS_GETATT;
         use std::arch::asm;
         use std::ptr::{null, null_mut};
@@ -64,29 +68,85 @@ impl Platform {
         }
 
         match (rax, rdx) {
-            (ENOSYS | EPERM, ..) => Ok(Self(Technology::Kvm, 0)),
+            (ENOSYS | EPERM, ..) => Ok((Technology::Kvm, 0)),
             (n, ..) if n < 0 => Err(std::io::Error::from_raw_os_error(-n as i32)),
             (n, t) => match t {
-                0 => Ok(Self(Technology::Kvm, n as _)),
-                1 => Ok(Self(Technology::Snp, n as _)),
-                2 => Ok(Self(Technology::Sgx, n as _)),
+                0 => Ok((Technology::Kvm, n as _)),
+                1 => Ok((Technology::Snp, n as _)),
+                2 => Ok((Technology::Sgx, n as _)),
                 _ => Err(ErrorKind::Other.into()),
             },
         }
     }
 
+    #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+    fn get_key(_buf: Option<&mut [u8]>) -> Result<usize> {
+        Ok(0)
+    }
+
+    /// `get_key` syscall to the shim.
+    ///
+    /// See <https://github.com/enarx/enarx/issues/2110>
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    fn get_key(mut buf: Option<&mut [u8]>) -> Result<usize> {
+        use sallyport::item::enarxcall::SYS_GETKEY;
+        use std::arch::asm;
+        use std::ptr::null_mut;
+
+        const ENOSYS: isize = -(libc::ENOSYS as isize);
+        const EPERM: isize = -(libc::EPERM as isize);
+
+        let mut rax: isize;
+
+        unsafe {
+            asm!(
+            "syscall",
+            lateout("rax") rax,
+            in("rax") SYS_GETKEY,
+            in("rdi") buf.as_mut().map(|x| x.as_mut_ptr()).unwrap_or_else(null_mut),
+            in("rsi") buf.map(|x| x.len()).unwrap_or_default(),
+            lateout("rcx") _, // clobbered
+            lateout("r11") _, // clobbered
+            )
+        }
+
+        match rax {
+            ENOSYS | EPERM => Ok(0),
+            n if n < 0 => Err(std::io::Error::from_raw_os_error(-n as i32)),
+            n => Ok(n as _),
+        }
+    }
+
     pub fn get() -> Result<Self> {
-        Self::get_att(None, None)
+        let (technology, report_size) = Self::get_att(None, None)?;
+        let key_size = Self::get_key(None)?;
+
+        Ok(Self {
+            technology,
+            report_size,
+            key_size,
+        })
     }
 
-    pub fn technology(self) -> Technology {
-        self.0
+    pub fn technology(&self) -> Technology {
+        self.technology
     }
 
-    pub fn attest(self, nonce: &[u8]) -> Result<Vec<u8>> {
-        let mut buf = vec![0; self.1];
+    pub fn key(&self) -> Result<Vec<u8>> {
+        let mut buf = vec![0; self.key_size];
 
-        let Self(.., size) = Self::get_att(Some(nonce), Some(&mut buf))?;
+        let size = Self::get_key(Some(&mut buf))?;
+        if size > buf.len() {
+            return Err(ErrorKind::Other.into());
+        }
+
+        Ok(buf)
+    }
+
+    pub fn attest(&self, nonce: &[u8]) -> Result<Vec<u8>> {
+        let mut buf = vec![0; self.report_size];
+
+        let (_, size) = Self::get_att(Some(nonce), Some(&mut buf))?;
         if size > buf.len() {
             return Err(ErrorKind::Other.into());
         }
@@ -100,7 +160,8 @@ impl Platform {
 fn test() {
     let platform = Platform::get().unwrap();
     assert_eq!(platform.technology(), Technology::Kvm);
-    assert_eq!(platform.1, 0);
+    assert_eq!(platform.report_size, 0);
+    assert_eq!(platform.key_size, 0);
     let report = platform.attest(b"00000000").unwrap();
     assert!(report.is_empty());
 }

--- a/crates/exec-wasmtime/src/loader/configured/platform.rs
+++ b/crates/exec-wasmtime/src/loader/configured/platform.rs
@@ -31,8 +31,6 @@ impl From<Technology> for ObjectIdentifier {
 pub struct Platform(Technology, usize);
 
 impl Platform {
-    const SYS_GETATT: usize = 0xEA01;
-
     #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
     fn get_att(_nonce: Option<&[u8]>, _buf: Option<&mut [u8]>) -> Result<Self> {
         Ok(Self(Technology::Kvm, 0))
@@ -40,6 +38,7 @@ impl Platform {
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     fn get_att(nonce: Option<&[u8]>, mut buf: Option<&mut [u8]>) -> Result<Self> {
+        use sallyport::item::enarxcall::SYS_GETATT;
         use std::arch::asm;
         use std::ptr::{null, null_mut};
 
@@ -54,7 +53,7 @@ impl Platform {
                 "syscall",
                 lateout("rax") rax,
                 lateout("rdx") rdx,
-                in("rax") Self::SYS_GETATT,
+                in("rax") SYS_GETATT,
                 in("rdi") nonce.map(|x| x.as_ptr()).unwrap_or_else(null),
                 in("rsi") nonce.map(|x| x.len()).unwrap_or_default(),
                 in("rdx") buf.as_mut().map(|x| x.as_mut_ptr()).unwrap_or_else(null_mut),

--- a/crates/sallyport/src/item/enarxcall/mod.rs
+++ b/crates/sallyport/src/item/enarxcall/mod.rs
@@ -9,9 +9,15 @@ use core::mem::size_of;
 
 /// `get_attestation` syscall number used by the shim.
 ///
-/// See <https://github.com/enarx/enarx-keepldr/issues/31>
+/// See <https://github.com/enarx/enarx/issues/966>
 #[allow(dead_code)]
 pub const SYS_GETATT: i64 = 0xEA01;
+
+/// `get_key` syscall number used by the shim.
+///
+/// See <https://github.com/enarx/enarx/issues/2110>
+#[allow(dead_code)]
+pub const SYS_GETKEY: i64 = 0xEA02;
 
 /// Payload of an [`Item`](super::Item) of [`Kind::Enarxcall`](super::Kind::Enarxcall).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -10,7 +10,6 @@
 
 #![cfg_attr(not(test), no_std)]
 #![deny(clippy::all)]
-#![cfg_attr(not(test), deny(clippy::integer_arithmetic))]
 #![deny(missing_docs)]
 #![feature(asm_const, asm_sym, c_size_t, naked_functions)]
 #![warn(rust_2018_idioms)]

--- a/crates/shim-kvm/src/main.rs
+++ b/crates/shim-kvm/src/main.rs
@@ -5,7 +5,6 @@
 //! Contains the startup code and the main function.
 #![no_std]
 #![deny(clippy::all)]
-#![deny(clippy::integer_arithmetic)]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![no_main]

--- a/crates/shim-kvm/src/snp/attestation.rs
+++ b/crates/shim-kvm/src/snp/attestation.rs
@@ -2,16 +2,6 @@
 
 //! SNP attestation and ASN.1 helper functions
 
-/// Header of the SnpReport Response
-#[repr(C)]
-pub struct SnpReportResponseData {
-    /// 0 if valid
-    pub status: u32,
-    /// size
-    pub size: u32,
-    rsvd: [u8; 24],
-}
-
 /// wraps a chunk with a header returning the total length
 ///
 /// helper function for ASN.1 encoding

--- a/crates/shim-sgx/Cargo.toml
+++ b/crates/shim-sgx/Cargo.toml
@@ -13,6 +13,7 @@ dbg = []
 disable-sgx-attestation = []
 
 [dependencies]
+bitflags = { version = "1.2", default-features = false }
 const-default = { version = "1.0", default-features = false }
 crt0stack = { version = "0.1", default-features = false }
 goblin = { version = "0.5", features = ["elf64"], default-features = false }

--- a/crates/shim-sgx/src/handler/key.rs
+++ b/crates/shim-sgx/src/handler/key.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use core::arch::asm;
+use core::mem::MaybeUninit;
+
+use sgx::enclu::EGETKEY;
+
+/// SGX derived key length in bytes
+pub const SGX_KEY_LEN: usize = 16;
+
+/// SGX ENCLU[EGETKEY] response
+///
+/// has to be aligned to 16 bytes as per Intel CPU spec
+#[repr(C, align(16))]
+pub struct Response {
+    pub key: [u8; SGX_KEY_LEN],
+}
+
+/// SGX ENCLU[EGETKEY] request
+///
+/// has to be aligned to 512 bytes as per Intel CPU spec
+#[repr(C, align(512))]
+pub struct Request {
+    pub name: Names,
+    pub policy: Policy,
+    pub isvsvn: u16,
+    pub cet_attr_mask: u8,
+    pub rsvd: u8,
+    pub cpusvn: [u8; 16],
+    pub attribute_mask: [u8; 16],
+    pub keyid: [u8; 32],
+    pub misc_mask: [u8; 4],
+    pub config_svn: u16,
+    pub rsvd2: [u8; 434],
+}
+
+impl Default for Request {
+    fn default() -> Self {
+        Self {
+            name: Names::EinittokenKey,
+            policy: Policy::MRSIGNER,
+            isvsvn: 0,
+            cet_attr_mask: 0,
+            rsvd: 0,
+            cpusvn: [0; 16],
+            attribute_mask: [0; 16],
+            keyid: [0; 32],
+            misc_mask: [0; 4],
+            config_svn: 0,
+            rsvd2: [0; 434],
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[repr(u16)]
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
+pub enum Names {
+    /// EINIT_TOKEN key
+    EinittokenKey = 0,
+    /// Provisioning Key
+    ProvisionKey = 1,
+    /// Provisioning Seal Key
+    ProvisionSealKey = 2,
+    /// Report Key
+    ReportKey = 3,
+    /// Seal Key
+    SealKey = 4,
+}
+
+bitflags::bitflags! {
+    pub struct Policy: u16 {
+        const MRENCLAVE = 1 << 0;
+        const MRSIGNER = 1 << 1;
+        const NOISVPRODID = 1 << 2;
+        const CONFIGID = 1 << 3;
+        const ISVFAMILYID = 1 << 4;
+        const ISVEXTPRODID = 1 << 5;
+    }
+}
+
+impl Request {
+    /// Call SGX ENCLU[EGETKEY]
+    ///
+    /// This function calls `enclu` with
+    /// RAX: EGETKEY
+    /// RBX: pointer to request (self)
+    /// RCX: pointer to response
+    ///
+    /// Return value in RAX
+    /// 0: success
+    /// else: error number (not abstracted here, because not used in error reporting)
+    ///
+    /// TODO: detailed error reporting
+    #[inline]
+    pub fn enclu_egetkey(&self) -> Result<Response, u64> {
+        // Purposely make an uninitialized memory block for the struct, as it
+        // will be initialized by the CPU as the next step.
+        let mut key_response = MaybeUninit::<Response>::uninit();
+
+        let mut rax: u64 = EGETKEY as _;
+
+        // In Rust inline assembly rbx is not preserved by the compiler, even
+        // when part of the input list. It is one of the callee saved registers
+        // dictated by:
+        //
+        // https://github.com/hjl-tools/x86-psABI/wiki/x86-64-psABI-1.0.pdf
+        unsafe {
+            asm!(
+            "xchg       {RBX}, rbx",
+            "enclu",
+            "mov        rbx, {RBX}",
+
+            RBX = inout(reg) self => _,
+            inout("rax") rax,
+            in("rcx") key_response.as_mut_ptr(),
+            );
+        }
+
+        match rax {
+            0 => Ok(unsafe { key_response.assume_init() }),
+            _ => Err(rax),
+        }
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -107,6 +107,7 @@ pub unsafe trait ByteSized: Sized {
         Some(unsafe { (bytes.as_ptr() as *const _ as *const Self).read_unaligned() })
     }
 
+    /// Serialize Self to a byte slice.
     fn as_bytes(&self) -> &[u8] {
         // SAFETY: This is safe because we know that the pointer is non-null and the length is correct
         // and u8 does not need any alignment.


### PR DESCRIPTION
Fixes: #2110 

Derives a key from the security attributes and the signing key for the SGX and SEV-SNP keeps.

Signed-off-by: Harald Hoyer <harald@profian.com>
