### PR TITLE
feat(shim-sgx): add `deny(clippy::integer_arithmetic)`

### DIFF
--- a/crates/shim-sgx/src/entry.rs
+++ b/crates/shim-sgx/src/entry.rs
@@ -38,7 +38,7 @@ fn crt0setup<'a>(
     off: *const (),
 ) -> Result<Handle<'a>, OutOfSpace> {
     let rand = unsafe { core::mem::transmute([random(), random()]) };
-    let phdr = off as u64 + hdr.e_phoff;
+    let phdr = hdr.e_phoff.checked_add(off as u64).unwrap();
 
     // Set the arguments
     let mut builder = Builder::new(crt0);
@@ -102,7 +102,7 @@ pub unsafe fn entry(offset: *const ()) -> ! {
         Ok(handle) => handle,
     };
 
-    let entry = offset as u64 + hdr.e_entry;
+    let entry = hdr.e_entry.checked_add(offset as u64).unwrap();
 
     #[cfg(feature = "gdb")]
     crate::handler::gdb::set_bp(entry);

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -11,6 +11,7 @@
 #![cfg_attr(not(test), no_std)]
 #![feature(c_size_t)]
 #![deny(clippy::all)]
+#![cfg_attr(not(test), deny(clippy::integer_arithmetic))]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 


### PR DESCRIPTION
This should prevent some integer_arithmetic bug exploits.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
