### PR TITLE
feat: panic on integer overflow for keep crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,18 @@ opt-level = 3
 [profile.dev.package.num-bigint-dig]
 opt-level = 3
 
+[profile.release.package.enarx-exec-wasmtime]
+overflow-checks = true
+
+[profile.release.package.enarx-shim-kvm]
+overflow-checks = true
+
+[profile.release.package.enarx-shim-sgx]
+overflow-checks = true
+
+[profile.release.package.sallyport]
+overflow-checks = true
+
 [workspace]
 members = ["crates/*"]
 exclude = ["tests/crates"]


### PR DESCRIPTION
This is intended to mitigate theoretical attacks resulting from integer overflow. This mitigation only applies to the four crates specified, and not any of their dependents.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
