### PR TITLE
feat!: enforce OCI-like `owner/repo:tag` slug format

### DIFF
--- a/src/drawbridge.rs
+++ b/src/drawbridge.rs
@@ -80,7 +80,7 @@ impl FromStr for TagSpec {
 
 pub fn parse_tag(slug: &str) -> anyhow::Result<(String, &str, &str, &str)> {
     let (head, tag) = slug
-        .rsplit_once(&['/', ':'])
+        .rsplit_once(':')
         .with_context(|| format!("Missing `:` in tag specification: {slug}"))?;
     let (host, user, repo) = parse_repo(head)?;
     Ok((host, user, repo, tag))
@@ -88,7 +88,7 @@ pub fn parse_tag(slug: &str) -> anyhow::Result<(String, &str, &str, &str)> {
 
 fn parse_repo(slug: &str) -> anyhow::Result<(String, &str, &str)> {
     let (head, repo) = slug
-        .rsplit_once(&['/', ':'])
+        .rsplit_once('/')
         .with_context(|| format!("Missing `/` in repository specification: {slug}"))?;
     let (host, user) = parse_user(head);
     Ok((host, user, repo))


### PR DESCRIPTION
Closes https://github.com/enarx/enarx/issues/2111

`foo:bar` is a valid URL according to the spec:

https://url.spec.whatwg.org/#urls

Which means that there is no meaningful way to distinguish between a
colon-separated "slug" and a valid URL. To alleviate this, slugs now
have one, consistent, common OCI-like format: `owner/repo:tag`, which
means that the Enarx binary can unambiguously distinguish between a slug
and a URL.

Example:

```
$ enarx deploy examples/fibonacci-rust:0.2.0
Fibonacci sequence number at index 7 is 13
Fibonacci sequence number at index 21 is 10946
```

(Coming soon):
```
$ enarx deploy https://store.profian.com/api/v0.2.0/examples/fibonacci-rust/_tag/0.2.0
Fibonacci sequence number at index 7 is 13
Fibonacci sequence number at index 21 is 10946
```

```
$ enarx deploy https://store.profian.com/api/v0.2.0/examples/fibonacci-rust/_tag/0.2.0/tree
Fibonacci sequence number at index 7 is 13
Fibonacci sequence number at index 21 is 10946
```

```
$ enarx deploy https://store.profian.com/api/v0.2.0/examples/fibonacci-rust/_tag/0.2.0/tree/main.wasm
Enter a non-negative number:
25
Fibonacci sequence number at index 25 is 75025
```