### PR TITLE
ci: consolidate deny checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,11 +77,6 @@ jobs:
       matrix:
         crate:
           - {name: enarx, path: ./Cargo.toml}
-          - {name: shim-sgx, path: crates/shim-sgx/Cargo.toml}
-          - {name: shim-kvm, path: crates/shim-kvm/Cargo.toml}
-          - {name: enarx-config, path: crates/enarx-config/Cargo.toml}
-          - {name: exec-wasmtime, path: crates/exec-wasmtime/Cargo.toml}
-          - {name: sallyport, path: crates/sallyport/Cargo.toml}
 
   check-spdx-headers:
     runs-on: ubuntu-latest


### PR DESCRIPTION
All crates in the workspace use the same lockfile, so there should be no need to check each crate individually.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
