### PR TITLE
docs: update `cargo install` docs

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -220,7 +220,7 @@ Rust version nightly-2022-07-19 is required when installing Enarx 0.6.2 from cra
 For installing Enarx from crates.io on X86_64 Linux please run:
 ```sh:crates;
 $ rustup toolchain install nightly-2022-07-19 -t x86_64-unknown-linux-musl,x86_64-unknown-linux-gnu,x86_64-unknown-none
-$ CARGO_TARGET_X86_64_UNKNOWN_NONE_RUSTFLAGS="-C linker=gcc" cargo +nightly-2022-07-19 -Z bindeps install --locked --bin enarx --version 0.6.2 -- enarx
+$ CARGO_TARGET_X86_64_UNKNOWN_NONE_RUSTFLAGS="-C linker=gcc --cfg polyval_force_soft --cfg aes_force_soft" cargo +nightly-2022-07-19 -Z bindeps install --locked --bin enarx --version 0.6.2 -- enarx
 ```
 
 For installing Enarx from crates.io on non-x86_64 Linux please run:


### PR DESCRIPTION
We're passing more rustflags via .cargo/config, so we need to make sure the docs pass the rustflags manually, since `cargo install` doesn't use .cargo/config.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
