### PR TITLE
build: remove opt-level="s"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,10 +101,8 @@ http-types = { version = "2.12.0", default-features = false }
 openidconnect = { version = "2.3.1", default-features = false }
 
 [profile.release]
-incremental = false
 codegen-units = 1
 lto = true
-opt-level = "s"
 strip = true
 
 [profile.dev.package.rcrt1]


### PR DESCRIPTION
In my experiments, while `opt-level="s"` does indeed make the Enarx binary itself smaller, it actually makes the shims slightly *larger*, and in practice the shims are the only binaries whose sizes we actually care about. There's no reason to pay the performance penalty of `opt-level="s"` if it isn't giving us size benefits. We can re-evaluate this in the future, as compiler developments tend to cause these metrics to fluctuate over time.

Also, we remove the `incremental=false` line because that's already the default for the release profile.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
