### PR TITLE
build: bump rust toolchain to 2022-08-10

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,11 +59,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-07-19 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-08-10 -y
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-07-19
+          toolchain: nightly-2022-08-10
           profile: minimal
           components: llvm-tools-preview
 

--- a/.github/workflows/sbom_manifest_action.yml
+++ b/.github/workflows/sbom_manifest_action.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-musl
-          toolchain: nightly-2022-07-19
+          toolchain: nightly-2022-08-10
           override: true
 
       - name: Install cargo-cyclonedx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-07-19 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-08-10 -y
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-07-19
+          toolchain: nightly-2022-08-10
           profile: minimal
 
       - uses: actions-rs/cargo@v1

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -213,20 +213,20 @@ $ cargo install --locked --bin enarx --path ./
 
 :::note
 
-Rust version nightly-2022-07-19 is required when installing Enarx 0.6.3 from crates.io.
+Rust version nightly-2022-08-10 is required when installing Enarx 0.6.3 from crates.io.
 
 :::
 
 For installing Enarx from crates.io on X86_64 Linux please run:
 ```sh:crates;
-$ rustup toolchain install nightly-2022-07-19 -t x86_64-unknown-linux-musl,x86_64-unknown-linux-gnu,x86_64-unknown-none
-$ CARGO_TARGET_X86_64_UNKNOWN_NONE_RUSTFLAGS="-C linker=gcc --cfg polyval_force_soft --cfg aes_force_soft" cargo +nightly-2022-07-19 -Z bindeps install --locked --bin enarx --version 0.6.3 -- enarx
+$ rustup toolchain install nightly-2022-08-10 -t x86_64-unknown-linux-musl,x86_64-unknown-linux-gnu,x86_64-unknown-none
+$ CARGO_TARGET_X86_64_UNKNOWN_NONE_RUSTFLAGS="-C linker=gcc --cfg polyval_force_soft --cfg aes_force_soft" cargo +nightly-2022-08-10 -Z bindeps install --locked --bin enarx --version 0.6.3 -- enarx
 ```
 
 For installing Enarx from crates.io on non-x86_64 Linux please run:
 ```console
-$ rustup toolchain install nightly-2022-07-19
-$ cargo +nightly-2022-07-19 -Z bindeps install --locked --bin enarx --version 0.6.3 -- enarx
+$ rustup toolchain install nightly-2022-08-10
+$ cargo +nightly-2022-08-10 -Z bindeps install --locked --bin enarx --version 0.6.3 -- enarx
 ```
 
 ### Install from Nix

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-07-19"
+channel = "nightly-2022-08-10"
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-unknown-none", "wasm32-wasi"]
 profile = "minimal"
 components = ["rustfmt", "clippy", "miri", "rust-src"]


### PR DESCRIPTION
Periodic regular bump in accordance with new stable Rust release.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
