### PR TITLE
fix(shim-sgx): filter cpuid and turn off AVX2

### DIFF
--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -605,6 +605,9 @@ impl<'a> Handler<'a> {
             self.ssa.gpr.rcx.clone(),
         );
 
+        let leaf = self.ssa.gpr.rax;
+        let subleaf = self.ssa.gpr.rcx;
+
         self.cpuid(
             self.ssa.gpr.rax as _,
             self.ssa.gpr.rcx as _,
@@ -616,6 +619,14 @@ impl<'a> Handler<'a> {
         self.ssa.gpr.rbx = cpuid_result.ebx.into();
         self.ssa.gpr.rcx = cpuid_result.ecx.into();
         self.ssa.gpr.rdx = cpuid_result.edx.into();
+
+        match (leaf, subleaf) {
+            (7, 0) => {
+                // NO AVX2
+                self.ssa.gpr.rbx &= !(1u64 << 5);
+            }
+            _ => {}
+        }
 
         debugln!(
             self,


### PR DESCRIPTION
Since we don't allow AVX2 in the keep with
commit ed1f9b8bf28a92941b73500f6a260770aa05cd98
filter cpuid return values and turn off the AVX2 feature flag.

This caused
```
cpuid(00000001, 00000000) = (000706e5, 06100800, 6ffafbbf, bfebfbff)
cpuid(00000007, 00000000) = (00000000, f2bf27ef, 40405f5e, bc000410)
unsupported opcode: 0xf9c5
```

called from e.g. `sha2::sha512::x86::sha512_compress_x86_64_avx2`

Signed-off-by: Harald Hoyer <harald@profian.com>

Related: https://github.com/enarx/enarx/issues/2142