### PR TITLE
fix(sgx): dynamically enable AVX and AVX512

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ sgx = { version = "0.5.0", features = ["rcrypto"], default-features = false }
 static_assertions = { version = "1.1.0", default-features = false }
 ureq = { version = "2.4.0", default-features = false }
 vdso = { version = "0.2", default-features = false }
-x86_64 = { version = "0.14.9", default-features = false }
+x86_64 = { version = "0.14.9", features = ["instructions"], default-features = false }
 
 # binary dependencies
 enarx-exec-wasmtime = { version = "0.6.3", path = "crates/exec-wasmtime", artifact = "bin", target = "x86_64-unknown-linux-musl", default-features = false }

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -27,7 +27,14 @@ pub const ENCL_SIZE_BITS: u8 = 32;
 /// FIXME: doc
 pub const ENCL_SIZE: usize = 1 << ENCL_SIZE_BITS;
 
-const XFRM: Xfrm = Xfrm::from_bits_truncate(Xfrm::X87.bits() | Xfrm::SSE.bits());
+const XFRM: Xfrm = Xfrm::from_bits_truncate(
+    Xfrm::X87.bits()
+        | Xfrm::SSE.bits()
+        | Xfrm::AVX.bits()
+        | Xfrm::OPMASK.bits()
+        | Xfrm::ZMM_HI256.bits()
+        | Xfrm::HI16_ZMM.bits(),
+);
 
 /// Default enclave CPU attributes
 pub const ATTR: Attributes = Attributes::new(Features::MODE64BIT, XFRM);


### PR DESCRIPTION
This reverts commit ed1f9b8bf28a92941b73500f6a260770aa05cd98.

Dynamically set the SGX features attributes according to the CPU
features.

Signed-off-by: Harald Hoyer <harald@profian.com>

Related: https://github.com/enarx/enarx/issues/2142

Works on the NUC, which has no AVX support.

```
[nix-shell:~/git/enarx/enarx]$ git show -s --pretty=oneline
046ae10a0a772f35b93b52b4f496aeaa9a4c7e87 (HEAD -> fix/sgx_avx_features, harald/fix/sgx_avx_features) fix(sgx): dynamically enable AVX and AVX512

[nix-shell:~/git/enarx/enarx]$ cargo run -- deploy examples/fibonacci-c:0.2.0 
[…]
Fibonacci sequence number at index 7 is 13
Fibonacci sequence number at index 21 is 10946

[nix-shell:~/git/enarx/enarx]$ cpuid -1 | fgrep AVX
      AVX: advanced vector extensions         = false
      AVX2: advanced vector extensions 2       = false
      AVX512F: AVX-512 foundation instructions = false
      AVX512DQ: double & quadword instructions = false
      AVX512IFMA: fused multiply add           = false
      AVX512PF: prefetch instructions          = false
      AVX512ER: exponent & reciprocal instrs   = false
      AVX512CD: conflict detection instrs      = false
      AVX512BW: byte & word instructions       = false
      AVX512VL: vector length                  = false
      AVX512VBMI: vector byte manipulation     = false
      AVX512_VBMI2: byte VPCOMPRESS, VPEXPAND  = false
      AVX512_VNNI: neural network instructions = false
      AVX512_BITALG: bit count/shiffle         = false
      AVX512: VPOPCNTDQ instruction            = false
      AVX512_4VNNIW: neural network instrs     = false
      AVX512_4FMAPS: multiply acc single prec  = false
      AVX512_VP2INTERSECT: intersect mask regs = false
      AVX512_FP16: fp16 support                = false
         XCR0 supported: AVX state            = false
         XCR0 supported: AVX-512 opmask       = false
         XCR0 supported: AVX-512 ZMM_Hi256    = false
         XCR0 supported: AVX-512 Hi16_ZMM     = false
         XCR0 supported: AVX state           = false
         XCR0 supported: AVX-512 opmask      = false
         XCR0 supported: AVX-512 ZMM_Hi256   = false
         XCR0 supported: AVX-512 Hi16_ZMM    = false

[nix-shell:~/git/enarx/enarx]$ cargo test
[…]
test result: ok. 37 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 386.88s
```