### PR TITLE
fix(sev): check for the VCEK cache file

### DIFF
--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -23,6 +23,7 @@ use data::{
 use std::io;
 use std::sync::Arc;
 
+use crate::backend::sev::data::has_vcek_cache;
 use crate::backend::Signatures;
 use anyhow::{bail, Context, Result};
 use kvm_bindings::bindings::kvm_enc_region;
@@ -106,6 +107,7 @@ impl super::Backend for Backend {
             dev_sev_readable(),
             dev_sev_writable(),
             has_reasonable_memlock_rlimit(),
+            has_vcek_cache(),
         ]
     }
 


### PR DESCRIPTION
And also add an output for `platform info`:

```
  ✔ SEV-SNP VCEK key cache file: /var/cache/amd-sev/vcek-5cb260b9c24d8a9cbf1aab853d0eabae34dca787d876ae97f8d7a0e707d180ce07d4fdb2da7d6814b2f75b242a299dfd8181c157718c4b53a9ade79e82d24cbd-02-00-05-93
```

Signed-off-by: Harald Hoyer <harald@profian.com>

Related: https://github.com/enarx/enarx/issues/2142