### PR TITLE
fix(shim-kvm): correctly set XCR0 according to cpuid

### DIFF
--- a/crates/shim-kvm/src/sse.rs
+++ b/crates/shim-kvm/src/sse.rs
@@ -14,22 +14,28 @@ use x86_64::registers::{
 /// Setup and check SSE relevant stuff
 #[cfg_attr(coverage, no_coverage)]
 pub fn init_sse() {
+    let cpuid_1_0 = cpuid_count(1, 0);
+
     const XSAVE_SUPPORTED_BIT: u32 = 1 << 26;
-    let xsave_supported = (cpuid_count(1, 0).ecx & XSAVE_SUPPORTED_BIT) != 0;
+    let xsave_supported = (cpuid_1_0.ecx & XSAVE_SUPPORTED_BIT) != 0;
     assert!(xsave_supported);
 
-    let xsaveopt_supported = (cpuid_count(0xD, 1).eax & 1) == 1;
-    assert!(xsaveopt_supported);
+    let mut xcr0 = XCr0::read();
 
-    let sse_extended_supported = (cpuid_count(0xd, 0).eax & 0b111) == 0b111;
-
-    if sse_extended_supported {
-        let mut xcr0 = XCr0::read();
-        xcr0 |= XCr0Flags::AVX | XCr0Flags::SSE;
-        unsafe { XCr0::write(xcr0) };
-    } else {
-        let mut xcr0 = XCr0::read();
+    // check either SSE and SSE2 feature flags
+    if cpuid_1_0.edx & 0x6000000 != 0 {
         xcr0 |= XCr0Flags::SSE;
+
+        // check AVX feature flag
+        if cpuid_1_0.ecx & 0x10000000 == 0x10000000 {
+            xcr0 |= XCr0Flags::AVX;
+
+            // check for AVX512F feature flag
+            if cpuid_count(7, 0).ebx & 0x10000 == 0x10000 {
+                xcr0 |= XCr0Flags::OPMASK | XCr0Flags::ZMM_HI256 | XCr0Flags::HI16_ZMM;
+            }
+        }
+
         unsafe { XCr0::write(xcr0) };
     }
 


### PR DESCRIPTION
and patch the osxsave feature flag for cpuid.

Directly modifying the CPUID page did not have any effect (as if it was read-only).

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
