### PR TITLE
docs: add link to quick installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ and for a more in-depth look please see our
 
 ## Using Enarx
 
-For instructions on installing the Enarx command-line tool,
+For instructions on installing the Enarx command-line tool from source,
 please see our [Installation Guide](https://enarx.dev/docs/Install).
+
+Alternatively, for instructions on installing pre-compiled Enarx binaries,
+please see our [Quick Installation Guide](https://enarx.dev/docs/Quickstart).
 
 For instructions on how to build an application that can be run within Enarx,
 please see our [WebAssembly Guide](https://enarx.dev/docs/WebAssembly/Introduction).


### PR DESCRIPTION
Add link to quick installation guide to address https://github.com/enarx/website/issues/76

Signed-off-by: Nick Vidal <nick@profian.com>