### PR TITLE
fix(exec-wasmtime): lower TLS cert serial number length

### DIFF
--- a/crates/exec-wasmtime/src/loader/requested.rs
+++ b/crates/exec-wasmtime/src/loader/requested.rs
@@ -130,7 +130,9 @@ impl Loader<Requested> {
         }
         .to_vec()?;
 
-        let mut serial: [u8; 32] = [0u8; 32];
+        // Steward uses UUIDs as serial numbers, use 16-octet long serial number to loosely
+        // resemble format used by the Steward.
+        let mut serial = [0u8; 16];
         getrandom(&mut serial)?;
 
         // Create the certificate body.


### PR DESCRIPTION
TLS certificate serial numbers must be at most 20 octet long according to https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.2

Use 16 octets to loosely match format used by the Steward.

Closes https://github.com/enarx/enarx/issues/2164