### PR TITLE
feat: implement basic threading support for SGX

### DIFF
--- a/crates/sallyport/src/guest/call/enarxcall/park.rs
+++ b/crates/sallyport/src/guest/call/enarxcall/park.rs
@@ -10,14 +10,9 @@ use crate::{Result, NULL};
 use core::ffi::c_int;
 
 #[derive(Debug, Clone, Copy)]
-pub struct ParkTimeout {
-    pub timespec: timespec,
-    pub absolute: bool,
-}
-
 pub struct Park<'a> {
     pub expected_val: c_int,
-    pub timeout: Option<&'a ParkTimeout>,
+    pub timeout: Option<&'a timespec>,
 }
 
 impl<'a> Alloc<'a> for Park<'a> {
@@ -26,7 +21,7 @@ impl<'a> Alloc<'a> for Park<'a> {
     type Argv = Argv<2>;
     type Ret = c_int;
 
-    type Staged = Option<Input<'a, ParkTimeout, &'a ParkTimeout>>;
+    type Staged = Option<Input<'a, timespec, &'a timespec>>;
     type Committed = Option<()>;
     type Collected = Result<c_int>;
 

--- a/crates/sallyport/src/guest/call/enarxcall/types/result.rs
+++ b/crates/sallyport/src/guest/call/enarxcall/types/result.rs
@@ -43,3 +43,13 @@ impl From<Result<usize>> for crate::Result<usize> {
         }
     }
 }
+
+impl From<Result<c_int>> for crate::Result<c_int> {
+    #[inline]
+    fn from(res: Result<c_int>) -> Self {
+        match res.0 {
+            errno @ ERRNO_START.. => Err(-(errno as c_int)),
+            ret => Ok(ret as _),
+        }
+    }
+}

--- a/crates/sallyport/src/libc.rs
+++ b/crates/sallyport/src/libc.rs
@@ -175,6 +175,7 @@ pub struct utsname {
 }
 
 pub const AF_INET: c_int = 2;
+pub const CLOCK_MONOTONIC: clockid_t = 1;
 pub const CLONE_VM: c_uint = 0x00000100;
 pub const CLONE_FS: c_uint = 0x00000200;
 pub const CLONE_FILES: c_uint = 0x00000400;

--- a/crates/sallyport/tests/enarxcall/mod.rs
+++ b/crates/sallyport/tests/enarxcall/mod.rs
@@ -4,7 +4,6 @@ use super::run_test;
 
 use core::ptr::NonNull;
 use libc::ENOSYS;
-use sallyport::guest::enarxcall::ParkTimeout;
 use std::arch::x86_64::{CpuidResult, __cpuid_count};
 
 use sallyport::guest::Handler;
@@ -104,12 +103,9 @@ fn spawn() {
 #[test]
 fn park() {
     run_test(1, [0xff; 16], move |_, _, handler| {
-        let timeout = ParkTimeout {
-            timespec: timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            },
-            absolute: false,
+        let timeout = timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
         };
         assert_eq!(handler.park(0, Some(&timeout)), Err(ENOSYS));
     })

--- a/crates/sallyport/tests/enarxcall/mod.rs
+++ b/crates/sallyport/tests/enarxcall/mod.rs
@@ -111,7 +111,7 @@ fn park() {
             },
             absolute: false,
         };
-        assert_eq!(handler.park(Some(&timeout)), Err(ENOSYS));
+        assert_eq!(handler.park(0, Some(&timeout)), Err(ENOSYS));
     })
 }
 

--- a/crates/shim-sgx/layout.ld
+++ b/crates/shim-sgx/layout.ld
@@ -11,6 +11,14 @@ PHDRS {
     tcs0 PT_LOAD FLAGS(1 << 20); /* sallyport::elf::pf::sgx::TCS */
     ssa0 PT_LOAD;
 
+    stk1 PT_LOAD;
+    tcs1 PT_LOAD FLAGS(1 << 20); /* sallyport::elf::pf::sgx::TCS */
+    ssa1 PT_LOAD;
+
+    stk2 PT_LOAD;
+    tcs2 PT_LOAD FLAGS(1 << 20); /* sallyport::elf::pf::sgx::TCS */
+    ssa2 PT_LOAD;
+
     exec 0x63400000 FLAGS(0); /* sallyport::elf::pt::EXEC */
 }
 
@@ -60,6 +68,30 @@ SECTIONS {
         . = ALIGN(4K);
     } :tcs0 =0
     .enarx.ssa0 (NOLOAD) : { . += 4K * 3; } :ssa0 =0
+
+    . += 4K;                /* Guard Page */
+    .enarx.stk1 (NOLOAD) : { . += 2M - 4K * 5; } :stk1 =0
+    .enarx.tcs1 : {
+        . += 16;
+        QUAD(ADDR(.enarx.ssa1))   /* OSSA */
+        LONG(0)                   /* CSSA */
+        LONG(3)                   /* NSSA */
+        QUAD(_start)              /* OENTRY */
+        . = ALIGN(4K);
+    } :tcs1 =0
+    .enarx.ssa1 (NOLOAD) : { . += 4K * 3; } :ssa1 =0
+
+    . += 4K;                /* Guard Page */
+    .enarx.stk2 (NOLOAD) : { . += 2M - 4K * 5; } :stk2 =0
+    .enarx.tcs2 : {
+        . += 16;
+        QUAD(ADDR(.enarx.ssa2))   /* OSSA */
+        LONG(0)                   /* CSSA */
+        LONG(3)                   /* NSSA */
+        QUAD(_start)              /* OENTRY */
+        . = ALIGN(4K);
+    } :tcs2 =0
+    .enarx.ssa2 (NOLOAD) : { . += 4K * 3; } :ssa2 =0
 
     /* EXEC */
     . = ALIGN(1M);

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod entry;
 pub mod handler;
 pub mod heap;
+pub mod thread;
 
 use sgx::parameters::{Attributes, Features, MiscSelect, Xfrm};
 

--- a/crates/shim-sgx/src/thread.rs
+++ b/crates/shim-sgx/src/thread.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Thread handling
+
+use core::arch::asm;
+use core::sync::atomic::{AtomicI32, AtomicUsize};
+
+use sgx::ssa::GenPurposeRegs;
+use spinning::{Lazy, RwLock};
+
+/// A constant array to enqueue and dequeue from.
+#[derive(Clone, Debug)]
+pub struct ConstVecDequeue<const N: usize, T: Sized + Copy> {
+    records: [Option<T>; N],
+    start: usize,
+    count: usize,
+}
+
+impl<const N: usize, T: Sized + Copy> Default for ConstVecDequeue<N, T> {
+    fn default() -> Self {
+        Self {
+            records: [None; N],
+            start: 0,
+            count: 0,
+        }
+    }
+}
+
+impl<const N: usize, T: Sized + Copy> ConstVecDequeue<N, T> {
+    /// Push a record to the end of the queue.
+    pub fn push(&mut self, val: T) -> Result<(), T> {
+        if self.count >= N {
+            return Err(val); // full
+        }
+
+        let end = (self.start + self.count) % N;
+        self.records[end].replace(val);
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Pop a record from the front of the queue.
+    pub fn pop(&mut self) -> Option<T> {
+        if self.count == 0 {
+            return None;
+        }
+
+        let record = self.records[self.start].take();
+        self.start = (self.start + 1) % N;
+        self.count -= 1;
+
+        record
+    }
+}
+
+/// Describe the state of the new thread
+#[derive(Clone, Copy, Debug)]
+pub enum NewThread {
+    /// The main thread starting the payload
+    Main,
+    /// A new thread with the given registers
+    Thread((u32, GenPurposeRegs)),
+}
+
+/// Queue of new threads to be picked up
+pub static NEW_THREAD_QUEUE: Lazy<RwLock<ConstVecDequeue<10, NewThread>>> = Lazy::new(|| {
+    let mut queue = ConstVecDequeue::default();
+    queue.push(NewThread::Main).unwrap();
+    RwLock::new(queue)
+});
+
+/// Maximum number of threads
+pub const MAX_THREADS: usize = 3;
+
+/// actual thread ID
+pub static NUM_THREADS: AtomicI32 = AtomicI32::new(1);
+
+// this is only used in the initializer below
+#[allow(clippy::declare_interior_mutable_const)]
+const ZERO_ATOMIC_USIZE: AtomicUsize = AtomicUsize::new(0);
+
+/// Holds addresses of AtomicU32 to clear on exiting the thread
+pub static THREAD_CLEAR_TID: [AtomicUsize; MAX_THREADS] = [ZERO_ATOMIC_USIZE; MAX_THREADS];
+
+/// Holds the addresses of the thread SSA frames
+pub static THREAD_SSAS: [AtomicUsize; MAX_THREADS] = [ZERO_ATOMIC_USIZE; MAX_THREADS];
+
+/// Extend some trait with a method to load registers
+pub trait LoadRegsExt {
+    /// manually load the registers from the SSA
+    ///
+    /// # Safety
+    ///
+    /// The Caller has to ensure the integrity of the loaded registers.
+    unsafe fn load_registers(&self) -> !;
+}
+
+impl LoadRegsExt for GenPurposeRegs {
+    unsafe fn load_registers(&self) -> ! {
+        asm!(
+            "mov rsp, {rsp}",
+            "pop rax",                              // skip rax
+            "pop rcx",
+            "pop rdx",
+            "pop rbx",
+            "pop rax",                              // skip rsp
+            "pop rbp",
+            "pop rsi",
+            "pop rdi",
+            "pop r8",
+            "pop r9",
+            "pop r10",
+            "pop r11",
+            "pop r12",
+            "pop r13",
+            "pop r14",
+            "pop r15",
+            "popfq",                                // pop rflags
+            "mov rax, QWORD PTR [rsp + 168 - 136]", // fsbase
+            "wrfsbase rax",
+            "pop rax",                              // rip
+            "add rax, 2",                           // skip syscall
+            "mov rsp, QWORD PTR [rsp + 32 - 144]",  // rsp
+            "push rax",                             // push rip
+            "mov rax, 0",                           // clone child has 0 in ret
+            "ret",                                  // return to rip
+
+            rsp = in(reg) self as *const _ as u64,
+            options(noreturn)
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ConstVecDequeue;
+
+    #[test]
+    fn test_const_vec_dequeue() {
+        let mut queue = ConstVecDequeue::<3, u32>::default();
+
+        assert_eq!(queue.pop(), None);
+
+        queue.push(1).unwrap();
+        queue.push(2).unwrap();
+        queue.push(3).unwrap();
+        assert_eq!(queue.push(4).unwrap_err(), 4);
+
+        assert_eq!(queue.pop(), Some(1));
+        assert_eq!(queue.pop(), Some(2));
+        assert_eq!(queue.pop(), Some(3));
+        assert_eq!(queue.pop(), None);
+    }
+}

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -24,7 +24,7 @@ pub mod data;
 pub mod mem;
 pub mod thread;
 
-pub trait KeepPersonality {
+pub trait KeepPersonality: Send + Sync {
     fn map(_vm_fd: &mut VmFd, _region: &Region) -> std::io::Result<()> {
         Ok(())
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -207,7 +207,7 @@ pub trait Keep {
     fn spawn(self: Arc<Self>) -> Result<Option<Box<dyn Thread>>>;
 }
 
-pub trait Thread {
+pub trait Thread: Send {
     /// Enters the keep.
     fn enter(&mut self, gdblisten: &Option<String>) -> Result<Command>;
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -18,6 +18,9 @@ mod binary;
 mod probe;
 
 #[cfg(enarx_with_shim)]
+mod parking;
+
+#[cfg(enarx_with_shim)]
 use binary::{Binary, Loader, Mapper};
 
 use std::fs::File;

--- a/src/backend/parking.rs
+++ b/src/backend/parking.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+use std::ptr;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use libc::timespec;
+use tracing::{instrument, trace};
+
+pub(crate) static THREAD_PARK: Parking = Parking::const_default();
+
+#[derive(Debug)]
+pub(crate) struct Parking(AtomicU32);
+
+// Notes about memory ordering:
+//
+// Memory ordering is only relevant for the relative ordering of operations
+// between different variables. Even Ordering::Relaxed guarantees a
+// monotonic/consistent order when looking at just a single atomic variable.
+//
+// So, since this parker is just a single atomic variable, we only need to look
+// at the ordering guarantees we need to provide to the 'outside world'.
+//
+// The only memory ordering guarantee that parking and unparking provide, is
+// that things which happened before unpark() are visible on the thread
+// returning from park() afterwards. Otherwise, it was effectively unparked
+// before unpark() was called.
+//
+// In other words, unpark() needs to synchronize with the part of park() that
+// consumes the value and returns.
+//
+// This is done with a release-acquire synchronization, by using
+// Ordering::Release when increasing the value in unpark(), and using
+// Ordering::Acquire when checking for this value in park().
+impl Parking {
+    pub const fn const_default() -> Self {
+        Self(AtomicU32::new(0))
+    }
+
+    #[instrument(level = "trace")]
+    pub(crate) fn park(
+        &self,
+        expected: u32,
+        timespec: Option<&timespec>,
+    ) -> sallyport::Result<u32> {
+        let timespec = timespec.map_or(0, |t| t as *const _ as usize);
+        let futex_ptr = &self.0 as *const AtomicU32;
+
+        loop {
+            // No need to wait if the value already changed.
+            let val = self.0.load(Ordering::Acquire);
+            if val != expected {
+                trace!("futex value changed to {val}");
+                return Ok(val);
+            }
+
+            trace!("futex: FUTEX_WAIT_BITSET {futex_ptr:p} {expected} {timespec:#?}");
+            let r = unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    futex_ptr,
+                    libc::FUTEX_WAIT_BITSET | libc::FUTEX_PRIVATE_FLAG,
+                    expected,
+                    timespec,
+                    ptr::null::<u32>(), // This argument is unused for FUTEX_WAIT_BITSET.
+                    !0u32,              // Wait on all bits for FUTEX_WAIT_BITSET.
+                )
+            };
+
+            if r == 0 {
+                let val = self.0.load(Ordering::Acquire);
+                trace!("futex: FUTEX_WAIT_BITSET {futex_ptr:p} {expected} {timespec:#?} = 0 (val={val})");
+                return Ok(val);
+            }
+
+            let err = io::Error::last_os_error().raw_os_error().unwrap();
+            trace!("futex: FUTEX_WAIT_BITSET {futex_ptr:p} {expected} {timespec:#?} = -{err}");
+
+            match err {
+                libc::EINTR => continue,
+                e => return Err(e),
+            }
+        }
+    }
+
+    #[instrument(level = "trace")]
+    pub(crate) fn unpark(&self) {
+        self.0.fetch_add(1, Ordering::Release);
+
+        let futex_ptr = &self.0 as *const AtomicU32;
+        let op = libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG;
+        trace!("futex: {futex_ptr:p} FUTEX_WAKE");
+        unsafe {
+            libc::syscall(libc::SYS_futex, futex_ptr, op, i32::MAX);
+        }
+    }
+}

--- a/src/backend/sgx/builder.rs
+++ b/src/backend/sgx/builder.rs
@@ -25,7 +25,7 @@ pub struct Builder {
     hash: Hasher<S256Digest>,
     mmap: Map<perms::Unknown>,
     perm: Vec<(*const (), usize, SecInfo)>,
-    tcsp: Vec<*const super::Tcs>,
+    tcsp: Vec<super::Tcs>,
 }
 
 impl TryFrom<super::config::Config> for Builder {
@@ -119,7 +119,7 @@ impl super::super::Mapper for Builder {
         // Keep track of TCS pages.
         if with.0.class() == Class::Tcs {
             for chunk in pages.chunks(Page::SIZE) {
-                self.tcsp.push(addr as *const super::Tcs);
+                self.tcsp.push(addr);
                 addr += chunk.len();
             }
         }

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -20,12 +20,12 @@ use std::sync::{Arc, RwLock};
 
 pub const AESM_SOCKET: &str = "/var/run/aesmd/aesm.socket";
 
-struct Tcs;
+pub type Tcs = usize;
 
 struct Keep {
     sallyport_block_size: u64,
     mem: Map<perms::Unknown>,
-    tcs: RwLock<Vec<*const Tcs>>,
+    tcs: RwLock<Vec<Tcs>>,
     enclave: File,
 }
 

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -41,7 +41,11 @@ pub struct Thread {
 
 impl Drop for Thread {
     fn drop(&mut self) {
-        self.keep.tcs.write().unwrap().push(self.tcs)
+        trace!("Dropping thread");
+        // We can't simply enqueue the dropped thread into the array of available
+        // threads, because the old state is not cleared yet.
+        // FIXME: https://github.com/enarx/enarx/issues/2200
+        // self.keep.tcs.write().unwrap().push(self.tcs)
     }
 }
 

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -31,7 +31,7 @@ use vdso::Symbol;
 pub struct Thread {
     keep: Arc<super::Keep>,
     vdso: &'static Symbol,
-    tcs: *const super::Tcs,
+    tcs: super::Tcs,
     block: Vec<usize>,
     cssa: usize,
     how: usize,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,6 +22,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, bail};
 use clap::{Args, Parser, Subcommand};
 use tracing::info;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
 
 /// Tool to deploy WebAssembly into Enarx Keeps
@@ -171,8 +172,10 @@ impl LogOptions {
             .with_default_directive(self.verbosity_level().into())
             .parse_lossy(self.log_filter.as_ref().unwrap_or(&"".to_owned()));
 
+        let fmt_layer = fmt::layer().with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
+
         tracing_subscriber::registry()
-            .with(fmt::layer())
+            .with(fmt_layer)
             .with(env_filter)
             .init();
     }

--- a/tests/crates/enarx_exec_tests/src/bin/futex.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/futex.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use enarx_exec_tests::musl_fsbase_fix;
+
+use std::io;
+use std::sync::atomic::AtomicU32;
+use std::time;
+
+musl_fsbase_fix!();
+
+fn main() {
+    let futex = AtomicU32::new(0);
+    let futex_ptr = &futex as *const AtomicU32;
+    let timespec = libc::timespec {
+        tv_sec: 2,
+        tv_nsec: 0,
+    };
+
+    let now = time::Instant::now();
+    let r = unsafe {
+        libc::syscall(
+            libc::SYS_futex,
+            futex_ptr,
+            libc::FUTEX_WAIT | libc::FUTEX_PRIVATE_FLAG,
+            0,
+            &timespec as *const _,
+        )
+    };
+
+    assert_eq!(r, -1);
+    let err = io::Error::last_os_error().raw_os_error().unwrap();
+    assert_eq!(err, libc::ETIMEDOUT);
+
+    assert!(now.elapsed().as_secs() >= 2);
+}

--- a/tests/crates/enarx_exec_tests/src/bin/thread-channel.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/thread-channel.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use enarx_exec_tests::musl_fsbase_fix;
+
+musl_fsbase_fix!();
+
+fn main() {
+    println!("Start");
+
+    use std::sync::mpsc::channel;
+    use std::thread;
+
+    let (tx, rx) = channel();
+
+    let sender = thread::spawn(move || {
+        tx.send("Hello, thread".to_owned())
+            .expect("Unable to send on channel");
+    });
+
+    let receiver = thread::spawn(move || {
+        let value = rx.recv().expect("Unable to receive from channel");
+        println!("{value}");
+    });
+
+    sender.join().expect("The sender thread has panicked");
+    receiver.join().expect("The receiver thread has panicked");
+}

--- a/tests/crates/enarx_exec_tests/src/bin/thread-exit-group.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/thread-exit-group.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use enarx_exec_tests::musl_fsbase_fix;
+
+use std::thread;
+
+musl_fsbase_fix!();
+
+fn main() {
+    println!("Before Spawn");
+
+    let thread1 = thread::spawn(|| {
+        thread::sleep(std::time::Duration::from_secs(2));
+        println!("Hello from Thread 1!");
+    });
+    println!("After Spawn 1");
+
+    let thread2 = thread::spawn(|| {
+        thread::sleep(std::time::Duration::from_secs(1));
+        println!("Hello from Thread 2!");
+
+        std::process::exit(0);
+    });
+    println!("After Spawn 2");
+
+    thread1.join().unwrap();
+    println!("After Join 1");
+
+    thread2.join().unwrap();
+    println!("After Join 2");
+}

--- a/tests/crates/enarx_exec_tests/src/bin/thread.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/thread.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use enarx_exec_tests::musl_fsbase_fix;
+
+use std::thread;
+
+musl_fsbase_fix!();
+
+fn main() {
+    println!("Before Spawn");
+
+    let thread1 = thread::spawn(|| {
+        thread::sleep(std::time::Duration::from_secs(2));
+        println!("Hello from Thread 1!");
+    });
+    println!("After Spawn 1");
+
+    let thread2 = thread::spawn(|| {
+        thread::sleep(std::time::Duration::from_secs(1));
+        println!("Hello from Thread 2!");
+    });
+    println!("After Spawn 2");
+
+    thread1.join().unwrap();
+    println!("After Join 1");
+
+    thread2.join().unwrap();
+    println!("After Join 2");
+}

--- a/tests/exec/mod.rs
+++ b/tests/exec/mod.rs
@@ -16,6 +16,73 @@ use tempfile::Builder;
 
 #[test]
 #[serial]
+#[cfg_attr(not(host_can_test_sgx), ignore = "Backend does not support SGX")]
+fn futex() {
+    if let Ok(backend) = std::env::var("ENARX_BACKEND") {
+        if backend != "sgx" {
+            return;
+        }
+    }
+    let bin = env!("CARGO_BIN_FILE_ENARX_EXEC_TESTS_futex");
+
+    run_test(bin, 0, None, None, None);
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(host_can_test_sgx), ignore = "Backend does not support SGX")]
+fn thread() {
+    if let Ok(backend) = std::env::var("ENARX_BACKEND") {
+        if backend != "sgx" {
+            return;
+        }
+    }
+    let bin = env!("CARGO_BIN_FILE_ENARX_EXEC_TESTS_thread");
+    let output = r#"Before Spawn
+After Spawn 1
+After Spawn 2
+Hello from Thread 2!
+Hello from Thread 1!
+After Join 1
+After Join 2
+"#;
+    run_test(bin, 0, None, output.as_bytes(), None);
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(host_can_test_sgx), ignore = "Backend does not support SGX")]
+fn thread_exit_group() {
+    if let Ok(backend) = std::env::var("ENARX_BACKEND") {
+        if backend != "sgx" {
+            return;
+        }
+    }
+    let bin = env!("CARGO_BIN_FILE_ENARX_EXEC_TESTS_thread-exit-group");
+    let output = r#"Before Spawn
+After Spawn 1
+After Spawn 2
+Hello from Thread 2!
+"#;
+    run_test(bin, 0, None, output.as_bytes(), None);
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(host_can_test_sgx), ignore = "Backend does not support SGX")]
+fn thread_channel() {
+    if let Ok(backend) = std::env::var("ENARX_BACKEND") {
+        if backend != "sgx" {
+            return;
+        }
+    }
+    let bin = env!("CARGO_BIN_FILE_ENARX_EXEC_TESTS_thread-channel");
+    let output = "Start\nHello, thread\n";
+    run_test(bin, 0, None, output.as_bytes(), None);
+}
+
+#[test]
+#[serial]
 fn echo() {
     let mut input: Vec<u8> = Vec::with_capacity(2 * 1024 * 1024);
 


### PR DESCRIPTION
This patch series implements basic threading support for the SGX backend.

Currently only two additional threads can be started (and not restarted), because the TCS, SSA and stacks are statically allocated in the linker file. This will be turned into dynamic allocation in a followup PR.

Related https://github.com/enarx/enarx/issues/2160