### PR TITLE
fix(config): remove custom `Serialize` implementation

### DIFF
--- a/crates/enarx-config/src/lib.rs
+++ b/crates/enarx-config/src/lib.rs
@@ -10,8 +10,7 @@
 
 use std::{collections::HashMap, ops::Deref};
 
-use serde::ser::SerializeStruct;
-use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
 use url::Url;
 
 /// Configuration file template
@@ -128,11 +127,11 @@ impl<'de> Deserialize<'de> for FileName {
 ///
 /// let config: Config = toml::from_str(CONFIG).unwrap();
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
-    /// The environment variables to provide to the application
+    /// An optional Steward URL
     #[serde(default)]
-    pub env: HashMap<String, String>,
+    pub steward: Option<Url>,
 
     /// The arguments to provide to the application
     #[serde(default)]
@@ -142,32 +141,9 @@ pub struct Config {
     #[serde(default)]
     pub files: Vec<File>,
 
-    /// An optional Steward URL
+    /// The environment variables to provide to the application
     #[serde(default)]
-    pub steward: Option<Url>,
-}
-
-// TOML requires the `Vec`s to be serialized last, so manually implement `Serialize`
-impl Serialize for Config {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s = serializer.serialize_struct("Config", 4)?;
-        if !self.args.is_empty() {
-            s.serialize_field("args", &self.args).unwrap();
-        }
-        if self.steward.is_some() {
-            s.serialize_field("steward", &self.steward).unwrap();
-        }
-        if !self.env.is_empty() {
-            s.serialize_field("env", &self.env).unwrap();
-        }
-        if !self.files.is_empty() {
-            s.serialize_field("files", &self.files).unwrap();
-        }
-        s.end()
-    }
+    pub env: HashMap<String, String>,
 }
 
 impl Default for Config {


### PR DESCRIPTION
The only reason the custom implementation was necessary was because of the struct field ordering, reorder and remove the custom implementation

Signed-off-by: Roman Volosatovs <roman@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
