### PR TITLE
refactor(config): avoid capitalizing file names

### DIFF
--- a/crates/enarx-config/Enarx_toml.md
+++ b/crates/enarx-config/Enarx_toml.md
@@ -119,14 +119,14 @@ kind = "stderr"
 
 # A listen socket
 [[files]]
-name = "LISTEN"
+name = "listen"
 kind = "listen"
 prot = "tls" # or prot = "tcp"
 port = 12345
 
 # An outgoing connected socket
 [[files]]
-name = "CONNECT"
+name = "connect"
 kind = "connect"
 prot = "tcp" # or prot = "tls"
 host = "127.0.0.1"
@@ -144,4 +144,4 @@ Additionally, five file descriptors are pre-opened:
 
 Additionally, the following environment variables are exported:
 - `FD_COUNT=5`
-- `FD_NAMES=null:stdout:stderr:LISTEN:CONNECT`
+- `FD_NAMES=null:stdout:stderr:listen:connect`

--- a/crates/enarx-config/src/lib.rs
+++ b/crates/enarx-config/src/lib.rs
@@ -43,14 +43,14 @@ kind = "stderr"
 
 ## A listen socket
 # [[files]]
-# name = "LISTEN"
+# name = "listen"
 # kind = "listen"
 # prot = "tls" # or prot = "tcp"
 # port = 12345
 
 ## An outgoing connected socket
 # [[files]]
-# name = "CONNECT"
+# name = "stream"
 # kind = "connect"
 # prot = "tls" # or prot = "tcp"
 # host = "127.0.0.1"
@@ -120,7 +120,7 @@ impl<'de> Deserialize<'de> for FileName {
 /// use enarx_config::Config;
 /// const CONFIG: &str = r#"
 /// [[files]]
-/// name = "LISTEN"
+/// name = "listen"
 /// kind = "listen"
 /// prot = "tls"
 /// port = 12345


### PR DESCRIPTION
Capitializing these does not really fit in with stdio names provided and does not reflect real-world use cases

Signed-off-by: Roman Volosatovs <roman@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
