### PR TITLE
fix(config): use a domain name in TLS connect

### DIFF
--- a/crates/enarx-config/src/lib.rs
+++ b/crates/enarx-config/src/lib.rs
@@ -53,7 +53,7 @@ kind = "stderr"
 # name = "CONNECT"
 # kind = "connect"
 # prot = "tls" # or prot = "tcp"
-# host = "127.0.0.1"
+# host = "localhost"
 # port = 23456
 "#;
 


### PR DESCRIPTION
TLS connections to raw IPs always fail (at least now)

#2187 

Signed-off-by: Roman Volosatovs <roman@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
