### PR TITLE
fix(shim-sgx): set HWCAP2 and clear fsbase

### DIFF
--- a/crates/shim-sgx/src/entry.rs
+++ b/crates/shim-sgx/src/entry.rs
@@ -73,7 +73,7 @@ fn crt0setup<'a>(
     builder.push(&Entry::ClockTick(100))?;
     builder.push(&Entry::Flags(0))?; // TODO: https://github.com/enarx/enarx/issues/386
     builder.push(&Entry::HwCap(0))?; // TODO: https://github.com/enarx/enarx/issues/386
-    builder.push(&Entry::HwCap2(0))?; // TODO: https://github.com/enarx/enarx/issues/386
+    builder.push(&Entry::HwCap2(2))?; // FSGSBASE flag is 1 << 1
     builder.push(&Entry::PHdr(phdr as _))?;
     builder.push(&Entry::PHent(hdr.e_phentsize as _))?;
     builder.push(&Entry::PHnum(hdr.e_phnum as _))?;
@@ -109,6 +109,8 @@ pub unsafe fn entry(offset: *const ()) -> ! {
 
     asm!(
         "mov rsp, {SP}",
+        "mov rax, 0",
+        "wrfsbase rax",
         "jmp {START}",
         SP = in(reg) &*handle,
         START = in(reg) entry,


### PR DESCRIPTION
We already rely on the linux kernel to grant us to set fsbase. Reflect that in HWCAP2 to the executable and give it a cleared fsbase to work with.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
