### PR TITLE
feat(sgx): use CSSA level 0 EEXIT to return from `exit()` syscall

### DIFF
--- a/crates/sallyport/src/guest/handler.rs
+++ b/crates/sallyport/src/guest/handler.rs
@@ -810,7 +810,7 @@ pub trait Handler {
             (SYS_eventfd2, [initval, flags, ..]) => self
                 .eventfd2(initval as _, flags as _)
                 .map(|ret| [ret as _, 0]),
-            (SYS_exit, [status, ..]) => self.exit(status as _).map(|_| self.attacked()),
+            (SYS_exit, [status, ..]) => self.exit(status as _).map(|_| [0, 0]),
             (SYS_exit_group, [status, ..]) => self.exit_group(status as _).map(|_| self.attacked()),
             (SYS_fcntl, [fd, cmd, arg, ..]) => self
                 .fcntl(fd as _, cmd as _, arg as _)

--- a/tests/crates/enarx_exec_tests/src/bin/thread-exit-group.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/thread-exit-group.rs
@@ -2,6 +2,7 @@
 
 use enarx_exec_tests::musl_fsbase_fix;
 
+use std::io::Write;
 use std::thread;
 
 musl_fsbase_fix!();
@@ -18,10 +19,11 @@ fn main() {
     let thread2 = thread::spawn(|| {
         thread::sleep(std::time::Duration::from_secs(1));
         println!("Hello from Thread 2!");
-
+        std::io::stdout().flush().unwrap();
         std::process::exit(0);
     });
     println!("After Spawn 2");
+    std::io::stdout().flush().unwrap();
 
     thread1.join().unwrap();
     println!("After Join 1");

--- a/tests/crates/enarx_exec_tests/src/bin/thread-many.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/thread-many.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use enarx_exec_tests::musl_fsbase_fix;
+
+use std::thread;
+
+musl_fsbase_fix!();
+
+fn main() {
+    for _ in 0..100 {
+        let thread1 = thread::spawn(|| 0);
+
+        let thread2 = thread::spawn(|| 0);
+
+        let ret: i32 = thread1.join().unwrap();
+        assert_eq!(ret, 0);
+
+        let ret: i32 = thread2.join().unwrap();
+        assert_eq!(ret, 0);
+
+        // Wait for threads to be returned to the thread pool
+        thread::sleep(std::time::Duration::from_micros(100));
+    }
+}

--- a/tests/crates/enarx_exec_tests/src/bin/thread.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/thread.rs
@@ -7,23 +7,32 @@ use std::thread;
 musl_fsbase_fix!();
 
 fn main() {
-    println!("Before Spawn");
+    for _ in 0..2 {
+        println!("Before Spawn");
 
-    let thread1 = thread::spawn(|| {
-        thread::sleep(std::time::Duration::from_secs(2));
-        println!("Hello from Thread 1!");
-    });
-    println!("After Spawn 1");
+        let thread1 = thread::spawn(|| {
+            thread::sleep(std::time::Duration::from_secs(2));
+            println!("Hello from Thread 1!");
+            0
+        });
+        println!("After Spawn 1");
 
-    let thread2 = thread::spawn(|| {
+        let thread2 = thread::spawn(|| {
+            thread::sleep(std::time::Duration::from_secs(1));
+            println!("Hello from Thread 2!");
+            0
+        });
+        println!("After Spawn 2");
+
+        let ret: i32 = thread1.join().unwrap();
+        assert_eq!(ret, 0);
+        println!("After Join 1");
+
+        let ret: i32 = thread2.join().unwrap();
+        assert_eq!(ret, 0);
+        println!("After Join 2");
+
+        // Wait for threads to be returned to the thread pool
         thread::sleep(std::time::Duration::from_secs(1));
-        println!("Hello from Thread 2!");
-    });
-    println!("After Spawn 2");
-
-    thread1.join().unwrap();
-    println!("After Join 1");
-
-    thread2.join().unwrap();
-    println!("After Join 2");
+    }
 }

--- a/tests/exec/mod.rs
+++ b/tests/exec/mod.rs
@@ -45,8 +45,28 @@ Hello from Thread 2!
 Hello from Thread 1!
 After Join 1
 After Join 2
+Before Spawn
+After Spawn 1
+After Spawn 2
+Hello from Thread 2!
+Hello from Thread 1!
+After Join 1
+After Join 2
 "#;
     run_test(bin, 0, None, output.as_bytes(), None);
+}
+
+#[test]
+#[serial]
+#[cfg_attr(not(host_can_test_sgx), ignore = "Backend does not support SGX")]
+fn thread_many() {
+    if let Ok(backend) = std::env::var("ENARX_BACKEND") {
+        if backend != "sgx" {
+            return;
+        }
+    }
+    let bin = env!("CARGO_BIN_FILE_ENARX_EXEC_TESTS_thread-many");
+    run_test(bin, 0, None, None, None);
 }
 
 #[test]


### PR DESCRIPTION
This lets us reuse the SGX TCS after it's returned to the pool.
It also gets rid of global arrays for thread bookkeeping.
    
sallyport:
- don't be `attacked()` by return of `exit()`
  it is correctly handled by the shim
    
shim-sgx:
- add Task Control Block (Tcb)
- load_registers() with exit_status
- return with exit_status in r8, especially CSSA=0
- remove MAX_THREADS restriction from `clone()`
- use the state in Tcb to return from `exit()` syscall
  This will EEXIT CSSA=0 to the backend ready for re-use.
    
backend/sgx:
- requeue thread on CSSA=0 EEXIT
- panic on `exit()` syscall
- use exit status in r8 of CSSA=0 EEXIT

Related: https://github.com/enarx/enarx/issues/2160