### PR TITLE
refactor(test): remove unused `token`

### DIFF
--- a/tests/client/token
+++ b/tests/client/token
@@ -1,1 +1,0 @@
-test-token


### PR DESCRIPTION
At first glance it looked like the file is misplaced and would have need to be put in `testdata` (or `data` in latest revision), but on closer inspection it turned out that it's not even used, hence remove
