### PR TITLE
fix(shim): replace unicode chars

### DIFF
--- a/crates/shim-kvm/src/hostcall.rs
+++ b/crates/shim-kvm/src/hostcall.rs
@@ -357,7 +357,7 @@ impl Handler for HostCall<'_> {
         let mut brk_line = BRK_LINE.write();
         let brk_end_u64 = brk_line.end.as_u64();
 
-        eprintln!("SC> brk({:#?}) …", addr);
+        eprintln!("SC> brk({:#?}) ...", addr);
 
         match addr.map(|a| a.as_ptr() as u64) {
             None => {
@@ -456,7 +456,7 @@ impl Handler for HostCall<'_> {
         offset: off_t,
     ) -> sallyport::Result<NonNull<c_void>> {
         const PA: i32 = MAP_PRIVATE | MAP_ANONYMOUS;
-        eprintln!("SC> mmap({:#?}, {}, …)", addr, length);
+        eprintln!("SC> mmap({:#?}, {}, ...)", addr, length);
 
         match (addr, length, prot, flags, fd, offset) {
             (None, _, _, PA, -1, 0) => {
@@ -484,17 +484,17 @@ impl Handler for HostCall<'_> {
                             | PageTableFlags::USER_ACCESSIBLE,
                     )
                     .map_err(|_| {
-                        eprintln!("SC> mmap(0, {}, …) = ENOMEM", length);
+                        eprintln!("SC> mmap(0, {}, ...) = ENOMEM", length);
                         ENOMEM
                     })?;
 
-                eprintln!("SC> mmap(0, {}, …) = {:#?}", length, mem_slice.as_ptr());
+                eprintln!("SC> mmap(0, {}, ...) = {:#?}", length, mem_slice.as_ptr());
 
                 *NEXT_MMAP_RWLOCK.write().deref_mut() = virt_addr + (len_aligned as u64);
                 Ok(NonNull::new(mem_slice.as_mut_ptr() as *mut c_void).unwrap())
             }
             (addr, ..) => {
-                eprintln!("SC> mmap({:#?}, {}, …)", addr, length);
+                eprintln!("SC> mmap({:#?}, {}, ...)", addr, length);
                 unimplemented!()
             }
         }
@@ -535,7 +535,7 @@ impl Handler for HostCall<'_> {
                 Ok(flush) => flush.ignore(),
                 Err(e) => {
                     eprintln!(
-                        "SC> mprotect({:#?}, {}, {}, …) = EINVAL ({:#?})",
+                        "SC> mprotect({:#?}, {}, {}, ...) = EINVAL ({:#?})",
                         addr, len, prot, e
                     );
                     return Err(EINVAL);
@@ -545,7 +545,7 @@ impl Handler for HostCall<'_> {
 
         flush_all();
 
-        eprintln!("SC> mprotect({:#?}, {}, {}, …) = 0", addr, len, prot);
+        eprintln!("SC> mprotect({:#?}, {}, {}, ...) = 0", addr, len, prot);
 
         Ok(())
     }

--- a/crates/shim-kvm/src/syscall.rs
+++ b/crates/shim-kvm/src/syscall.rs
@@ -126,7 +126,7 @@ extern "sysv64" fn syscall_rust(
 
     #[cfg(feature = "dbg")]
     if !(nr == SYS_write as usize && (a == STDERR_FILENO as usize || a == STDOUT_FILENO as usize)) {
-        eprintln!("syscall {} …", nr)
+        eprintln!("syscall {} ...", nr)
     }
 
     let mut tls = THREAD_TLS.lock();

--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -501,7 +501,7 @@ impl<'a> Handler<'a> {
         let nr = self.ssa.gpr.rax as usize;
 
         let tid = self.get_tid();
-        debugln!(self, "[{tid}] syscall {nr} …");
+        debugln!(self, "[{tid}] syscall {nr} ...");
 
         let usermemscope = UserMemScope;
 


### PR DESCRIPTION
Don't print out unicode chars in debug mode. Multiple processes outputting stuff, can scramble the console easily.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
