### PR TITLE
feat: send CSR array to Steward

### DIFF
--- a/crates/exec-wasmtime/src/runtime/identity/mod.rs
+++ b/crates/exec-wasmtime/src/runtime/identity/mod.rs
@@ -59,7 +59,7 @@ fn csr(pki: &PrivateKeyInfo<'_>, exts: Vec<Extension<'_>>) -> anyhow::Result<Vec
         signature: BitStringRef::from_bytes(sig.as_ref())?,
     };
 
-    Ok(req.to_vec()?)
+    Ok(vec![req].to_vec()?)
 }
 
 /// Generates a new private key and corresponding CSR


### PR DESCRIPTION
Sends the CSR as an array to Steward to be compatible with https://github.com/profianinc/steward/pull/55.

It seems the `exec-wasmtime` already takes the response into `Vec<Certificate>`.

Signed-off-by: Richard Zak <richard@profian.com>
