### PR TITLE
fix: revert "test(wasm): avoid using `serial`"

### DIFF
--- a/tests/wasm/mod.rs
+++ b/tests/wasm/mod.rs
@@ -15,6 +15,7 @@ use process_control::Output;
 use rustls::client::{ServerCertVerified, ServerCertVerifier};
 use rustls::version::TLS13;
 use rustls::Certificate;
+use serial_test::serial;
 use tempfile::{tempdir, NamedTempFile};
 
 #[cfg(not(enarx_with_shim))]
@@ -141,6 +142,7 @@ fn compile(wasm: &str) -> PathBuf {
 }
 
 #[test]
+#[serial]
 fn return_1() {
     // This module does, in fact, return 1. But function return values
     // are separate from setting the process exit status code, so
@@ -150,6 +152,7 @@ fn return_1() {
 }
 
 #[test]
+#[serial]
 fn wasi_snapshot1() {
     // This module uses WASI to return the number of commandline args.
     // Since we don't currently do anything with the function return value,
@@ -159,6 +162,7 @@ fn wasi_snapshot1() {
 }
 
 #[test]
+#[serial]
 fn hello_wasi_snapshot1() {
     // This module just prints "Hello, world!" to stdout. Hooray!
     let wasm = compile("hello_wasi_snapshot1.wasm");
@@ -168,6 +172,7 @@ fn hello_wasi_snapshot1() {
 }
 
 #[test]
+#[serial]
 fn no_export() {
     // This module has no exported functions, so we get an error.
     let wasm = compile("no_export.wasm");
@@ -175,6 +180,7 @@ fn no_export() {
 }
 
 #[test]
+#[serial]
 fn echo() {
     let wasm = wasm_path(env!("CARGO_BIN_FILE_ENARX_WASM_TESTS_echo"));
 
@@ -187,18 +193,21 @@ fn echo() {
 }
 
 #[test]
+#[serial]
 fn memspike() {
     let wasm = wasm_path(env!("CARGO_BIN_FILE_ENARX_WASM_TESTS_memspike"));
     check_output(&enarx_run(&wasm, None, None), 0, None, None);
 }
 
 #[test]
+#[serial]
 fn memory_stress_test() {
     let wasm = wasm_path(env!("CARGO_BIN_FILE_ENARX_WASM_TESTS_memory_stress_test"));
     check_output(&enarx_run(&wasm, None, None), 0, None, None);
 }
 
 #[test]
+#[serial]
 fn zerooneone() -> anyhow::Result<()> {
     let wasm = wasm_path(env!("CARGO_BIN_FILE_ENARX_WASM_TESTS_zerooneone"));
     const INPUT: &[u8] = br#"Good morning, that's a nice tnetennba.
@@ -259,6 +268,7 @@ fn assert_stream<T: Read + Write>(mut stream: impl BorrowMut<T>) -> anyhow::Resu
 }
 
 #[test]
+#[serial]
 fn connect_tcp() -> anyhow::Result<()> {
     let wasm = wasm_path(env!("CARGO_BIN_FILE_ENARX_WASM_TESTS_connect"));
 
@@ -303,6 +313,7 @@ name = "stream""#,
 // TODO: Reenable once there's functionality to configure trust anchors in Enarx.toml
 // https://github.com/enarx/enarx/issues/2170 (which requires VFS)
 //#[test]
+//#[serial]
 //fn connect_tls() -> anyhow::Result<()> {
 //    let wasm = wasm_path(env!("CARGO_BIN_FILE_ENARX_WASM_TESTS_connect"));
 //
@@ -398,6 +409,7 @@ fn assert_connect<T: Read + Write>(connect: impl Fn() -> anyhow::Result<T>) -> a
 
 #[test]
 #[cfg_attr(windows, ignore = "listener tests hang on Windows")]
+#[serial]
 fn listen_tcp() -> anyhow::Result<()> {
     let wasm = wasm_path(env!("CARGO_BIN_FILE_ENARX_WASM_TESTS_listen"));
 
@@ -471,6 +483,7 @@ impl ServerCertVerifier for NoopCertVerifier {
 
 #[test]
 #[cfg_attr(windows, ignore = "listener tests hang on Windows")]
+#[serial]
 fn listen_tls() -> anyhow::Result<()> {
     let wasm = wasm_path(env!("CARGO_BIN_FILE_ENARX_WASM_TESTS_listen"));
 


### PR DESCRIPTION
This reverts commit accc56571d45c9dd05e3c98c8496cee259af5225.

It is causing sporadic failure, most likely about memory locking ulimits.

Fixes https://github.com/enarx/enarx/issues/2237

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
