### PR TITLE
fix(shim-sgx): don't output dbg for SYS_clock_gettime

### DIFF
--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -489,6 +489,7 @@ impl super::super::Thread for Thread {
                                     libc::SYS_write | libc::SYS_read,
                                     libc::STDIN_FILENO | libc::STDOUT_FILENO | libc::STDERR_FILENO,
                                 ) => {}
+                                (libc::SYS_clock_gettime, _) => {}
                                 _ => {
                                     dbg!(&_syscall);
                                 }


### PR DESCRIPTION
it's just too much

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
