### PR TITLE
fix(test/exec::thread_exit_group): rely on exit code

### DIFF
--- a/tests/crates/enarx_exec_tests/src/bin/thread-exit-group.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/thread-exit-group.rs
@@ -11,8 +11,10 @@ fn main() {
     println!("Before Spawn");
 
     let thread1 = thread::spawn(|| {
-        thread::sleep(std::time::Duration::from_secs(2));
+        thread::sleep(std::time::Duration::from_secs(100));
         println!("Hello from Thread 1!");
+        std::io::stdout().flush().unwrap();
+        std::process::exit(2);
     });
     println!("After Spawn 1");
 
@@ -30,4 +32,6 @@ fn main() {
 
     thread2.join().unwrap();
     println!("After Join 2");
+
+    std::process::exit(1);
 }

--- a/tests/exec/mod.rs
+++ b/tests/exec/mod.rs
@@ -79,12 +79,8 @@ fn thread_exit_group() {
         }
     }
     let bin = env!("CARGO_BIN_FILE_ENARX_EXEC_TESTS_thread-exit-group");
-    let output = r#"Before Spawn
-After Spawn 1
-After Spawn 2
-Hello from Thread 2!
-"#;
-    run_test(bin, 0, None, output.as_bytes(), None);
+
+    run_test(bin, 0, None, None, None);
 }
 
 #[test]


### PR DESCRIPTION
rather than the output. Increase the sleep of Thread 2 "should" eliminate all race conditions.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
