### PR TITLE
feat(sgx): rename enarxcall `TrimSgxPages` to `ModifySgxPageType`

### DIFF
--- a/crates/sallyport/src/guest/call/enarxcall/passthrough.rs
+++ b/crates/sallyport/src/guest/call/enarxcall/passthrough.rs
@@ -173,22 +173,23 @@ impl PassthroughAlloc for Spawn {
 }
 
 /// Within an address range inside the enclave, ask host to set page type to
-/// 'trimmed'. Address and length must be page-aligned. Shim must validate
+/// the specified type. Address and length must be page-aligned. Shim must validate
 /// and acknowledge the changes with ENCLU[EACCEPT], in order for them to
 /// take effect.
-pub struct TrimSgxPages {
+pub struct ModifySgxPageType {
     pub addr: NonNull<c_void>,
     pub length: usize,
+    pub page_type: u8,
 }
 
-impl PassthroughAlloc for TrimSgxPages {
-    const NUM: Number = Number::TrimSgxPages;
+impl PassthroughAlloc for ModifySgxPageType {
+    const NUM: Number = Number::SgxModifyPageType;
 
-    type Argv = Argv<2>;
+    type Argv = Argv<3>;
     type Ret = ();
 
     fn stage(self) -> Self::Argv {
-        Argv([self.addr.as_ptr() as _, self.length])
+        Argv([self.addr.as_ptr() as _, self.length, self.page_type as _])
     }
 }
 

--- a/crates/sallyport/src/guest/handler.rs
+++ b/crates/sallyport/src/guest/handler.rs
@@ -1209,12 +1209,21 @@ pub trait Handler {
     }
 
     /// Within an address range inside the enclave, ask host to set page type to
-    /// 'trimmed'. Address and length must be page-aligned. Shim must validate
+    /// the specified type. Address and length must be page-aligned. Shim must validate
     /// and acknowledge the changes with ENCLU[EACCEPT], in order for them to
     /// take effect.
     #[inline]
-    fn trim_sgx_pages(&mut self, addr: NonNull<c_void>, length: usize) -> Result<()> {
-        self.execute(enarxcall::TrimSgxPages { addr, length })?
+    fn modify_sgx_page_type(
+        &mut self,
+        addr: NonNull<c_void>,
+        length: usize,
+        page_type: u8,
+    ) -> Result<()> {
+        self.execute(enarxcall::ModifySgxPageType {
+            addr,
+            length,
+            page_type,
+        })?
     }
 
     /// Unpark all parked threads

--- a/crates/sallyport/src/item/enarxcall/mod.rs
+++ b/crates/sallyport/src/item/enarxcall/mod.rs
@@ -73,7 +73,7 @@ pub enum Number {
     MunmapHost = 0x09,
 
     /// Trim SGX pages call number.
-    TrimSgxPages = 0x10,
+    SgxModifyPageType = 0x10,
 
     /// Park the current thread
     Park = 0x11,

--- a/crates/sallyport/tests/enarxcall/mod.rs
+++ b/crates/sallyport/tests/enarxcall/mod.rs
@@ -115,7 +115,7 @@ fn park() {
 fn trim_sgx_pages() {
     run_test(2, [0xff; 16], move |_, _, handler| {
         assert_eq!(
-            handler.trim_sgx_pages(NonNull::new(0x7f8af78eb000 as *mut _).unwrap(), 4096),
+            handler.modify_sgx_page_type(NonNull::new(0x7f8af78eb000 as *mut _).unwrap(), 4096, 1),
             Err(ENOSYS)
         );
     })

--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -721,7 +721,7 @@ impl<'a> Handler<'a> {
         // On the other hand, failing in any of these operations is expected to
         // crash the enclave because it is due either to a software bug, or a
         // malicious host.
-        self.trim_sgx_pages(addr_in, length.bytes())
+        self.modify_sgx_page_type(addr_in, length.bytes(), Class::Trimmed as _)
             .unwrap_or_else(|_| self.attacked());
 
         for i in 0..pages {

--- a/src/backend/sgx/enarxcall.rs
+++ b/src/backend/sgx/enarxcall.rs
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::backend::parking::THREAD_PARK;
+use crate::backend::sgx::attestation::{
+    get_attestation_key_id, get_key_size, get_quote, get_quote_size, get_target_info,
+};
+use crate::backend::sgx::ioctls::{
+    ModifyTypes, RemovePages, RestrictPermissions, ENCLAVE_MODIFY_TYPES, ENCLAVE_REMOVE_PAGES,
+    ENCLAVE_RESTRICT_PERMISSIONS,
+};
+use crate::backend::{Command, Keep};
+
+use std::arch::x86_64::CpuidResult;
+use std::io;
+use std::mem::{forget, size_of, MaybeUninit};
+use std::sync::Arc;
+
+use anyhow::Context;
+use libc::{timespec, EAGAIN, EINVAL, PROT_READ};
+use mmarinus::{perms, Map, Shared};
+use sallyport::host::{deref_aligned, deref_slice};
+use sallyport::item;
+use sallyport::item::enarxcall::sgx::{Report, TargetInfo};
+use sallyport::item::{enarxcall, Item};
+use tracing::{error, trace_span};
+
+pub(crate) fn sgx_enarxcall<'a>(
+    enarxcall: &'a mut enarxcall::Payload,
+    data: &'a mut [u8],
+    keep: Arc<super::Keep>,
+) -> anyhow::Result<Option<Item<'a>>> {
+    match enarxcall {
+        enarxcall::Payload {
+            num: item::enarxcall::Number::Spawn,
+            ret,
+            ..
+        } => {
+            *ret = if let Some(mut thread) = keep.spawn()? {
+                std::thread::spawn(move || {
+                    trace_span!(
+                        "Thread",
+                        id = ?std::thread::current().id()
+                    )
+                    .in_scope(|| loop {
+                        match thread.enter(&None)? {
+                            Command::Continue => (),
+                            Command::Exit(exit_code) => {
+                                drop(thread);
+                                return Ok::<i32, anyhow::Error>(exit_code);
+                            }
+                        }
+                    })
+                });
+                0
+            } else {
+                error!("no more SGX threads available");
+                -EAGAIN as usize
+            };
+
+            Ok(None)
+        }
+        item::Enarxcall {
+            num: item::enarxcall::Number::Park,
+            argv: [val, timeout, ..],
+            ret,
+            ..
+        } => {
+            let timeout = if *timeout != sallyport::NULL {
+                Some(unsafe {
+                    // Safety: `deref_aligned` gives us a pointer to an aligned `timespec` struct.
+                    // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
+                    // is a subslice of.
+                    (*deref_aligned::<MaybeUninit<timespec>>(data, *timeout, 1)
+                        .map_err(io::Error::from_raw_os_error)
+                        .context("sgx_enarxcall deref")?)
+                    .assume_init()
+                })
+            } else {
+                None
+            };
+
+            *ret = THREAD_PARK
+                .park(*val as _, timeout.as_ref())
+                .map(|v| v as usize)
+                .unwrap_or_else(|e| -e as usize);
+
+            Ok(None)
+        }
+        item::Enarxcall {
+            num: item::enarxcall::Number::UnPark,
+            ret,
+            ..
+        } => {
+            THREAD_PARK.unpark();
+            *ret = 0;
+            Ok(None)
+        }
+        item::Enarxcall {
+            num: item::enarxcall::Number::Cpuid,
+            argv: [leaf, subleaf, cpuid_offset, ..],
+            ret,
+        } => {
+            let cpuid_buf = unsafe {
+                // Safety: `deref_aligned` gives us a pointer to an aligned `CpuidResult` struct.
+                // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
+                // is a subslice of.
+                &mut *deref_aligned::<MaybeUninit<CpuidResult>>(data, *cpuid_offset, 1)
+                    .map_err(io::Error::from_raw_os_error)
+                    .context("sgx_enarxcall deref")?
+            };
+
+            // Safety: we know we are on an SGX machine, which can do cpuid
+            let cpuid_ret = unsafe { core::arch::x86_64::__cpuid_count(*leaf as _, *subleaf as _) };
+
+            cpuid_buf.write(cpuid_ret);
+            *ret = 0;
+            Ok(None)
+        }
+
+        item::Enarxcall {
+            num: item::enarxcall::Number::GetSgxTargetInfo,
+            argv: [target_info_offset, ..],
+            ret,
+        } => {
+            let out_buf = unsafe {
+                // Safety: `deref_slice` gives us a pointer to a byte slice, which does not have to be aligned.
+                // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
+                // is a subslice of.
+                &mut *deref_slice::<u8>(data, *target_info_offset, size_of::<TargetInfo>())
+                    .map_err(io::Error::from_raw_os_error)
+                    .context("sgx_enarxcall deref")?
+            };
+            let akid = get_attestation_key_id().context(
+                "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
+            )?;
+            let pkeysize = get_key_size(akid.clone()).context(
+                "Error obtaining key size. Check your aesmd / pccs service installation.",
+            )?;
+            *ret = get_target_info(akid, pkeysize, out_buf).context(
+                "Error getting target info. Check your aesmd / pccs service installation.",
+            )?;
+
+            Ok(None)
+        }
+
+        item::Enarxcall {
+            num: item::enarxcall::Number::GetSgxQuote,
+            argv: [report_offset, quote_offset, quote_len, ..],
+            ret,
+        } => {
+            let report_buf = unsafe {
+                // Safety: `deref_slice` gives us a pointer to a byte slice, which does not have to be aligned.
+                // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
+                // is a subslice of.
+                &mut *deref_slice::<u8>(data, *report_offset, size_of::<Report>())
+                    .map_err(io::Error::from_raw_os_error)
+                    .context("sgx_enarxcall deref")?
+            };
+
+            let quote_buf = unsafe {
+                // Safety: `deref_slice` gives us a pointer to a byte slice, which does not have to be aligned.
+                // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
+                // is a subslice of.
+                &mut *deref_slice::<u8>(data, *quote_offset, *quote_len)
+                    .map_err(io::Error::from_raw_os_error)
+                    .context("sgx_enarxcall deref")?
+            };
+
+            let akid = get_attestation_key_id().context(
+                "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
+            )?;
+            *ret = get_quote(report_buf, akid, quote_buf)
+                .context("Error getting quote. Check your aesmd / pccs service installation.")?;
+
+            Ok(None)
+        }
+
+        item::Enarxcall {
+            num: item::enarxcall::Number::GetSgxQuoteSize,
+            ret,
+            ..
+        } => {
+            let akid = get_attestation_key_id().context(
+                "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
+            )?;
+            *ret = get_quote_size(akid).context(
+                "Error getting quote size. Check your aesmd / pccs service installation.",
+            )?;
+
+            Ok(None)
+        }
+
+        item::Enarxcall {
+            num: item::enarxcall::Number::MmapHost,
+            argv: [addr, len, prot, ..],
+            ret,
+            ..
+        } => {
+            // Safety: an `mmap()` call is pointed to a file descriptor of the
+            // created enclave, and can therefore only affect the memory
+            // mappings within the address range given to ENCLAVE_CREATE.
+            match unsafe {
+                Map::bytes(*len)
+                    .onto(*addr)
+                    .from(&mut keep.enclave.try_clone().unwrap(), 0)
+                    .with_kind(Shared)
+                    .with(perms::Unknown(*prot as i32))
+            } {
+                Ok(map) => {
+                    // Skip `drop()`. The VMA's ownership has been moved to the shim.
+                    forget(map);
+                    *ret = 0;
+                }
+                Err(err) => {
+                    *ret = (-err.err.raw_os_error().unwrap()) as usize;
+                }
+            };
+            Ok(None)
+        }
+
+        item::Enarxcall {
+            num: item::enarxcall::Number::MprotectHost,
+            argv: [addr, len, prot, ..],
+            ret,
+            ..
+        } => {
+            let mem_end = keep.mem.addr() + keep.mem.size();
+            let end = *addr + *len;
+
+            // Check that the span is within the enclave address range:
+            if *addr < keep.mem.addr() || end > mem_end {
+                *ret = EINVAL as _;
+                return Ok(None);
+            }
+
+            // Safety: the parameters have been verified to be within the shim's
+            // address range.
+            if unsafe { libc::mprotect(*addr as _, *len, *prot as i32) } != 0 {
+                *ret = (-io::Error::last_os_error().raw_os_error().unwrap()) as _;
+                return Ok(None);
+            }
+
+            // TODO: https://github.com/enarx/enarx/issues/1892
+            let mut parameters =
+                RestrictPermissions::new(*addr - keep.mem.addr(), *len, PROT_READ as _);
+            ENCLAVE_RESTRICT_PERMISSIONS
+                .ioctl(&mut keep.enclave.try_clone().unwrap(), &mut parameters)
+                .context("ENCLAVE_RESTRICT_PERMISSIONS failed")?;
+
+            *ret = 0;
+            Ok(None)
+        }
+
+        item::Enarxcall {
+            num: item::enarxcall::Number::MunmapHost,
+            argv: [addr, len, ..],
+            ret,
+            ..
+        } => {
+            let mem_end = keep.mem.addr() + keep.mem.size();
+            let end = *addr + *len;
+
+            // Check that the span is within the enclave address range:
+            if *addr < keep.mem.addr() || end > mem_end {
+                panic!("munmap() is out of range");
+            }
+
+            // Safety: the parameters have been sanity checked before, that only
+            // enclave memory is unmapped.
+            unsafe {
+                libc::munmap(*addr as *mut _, *len);
+            }
+
+            let mut parameters = RemovePages::new(*addr - keep.mem.addr(), *len);
+            ENCLAVE_REMOVE_PAGES
+                .ioctl(&mut keep.enclave.try_clone().unwrap(), &mut parameters)
+                .context("ENCLAVE_REMOVE_PAGES failed")?;
+
+            *ret = 0;
+            Ok(None)
+        }
+
+        item::Enarxcall {
+            num: item::enarxcall::Number::TrimSgxPages,
+            argv: [addr, length, ..],
+            ret,
+            ..
+        } => {
+            let mut parameters = ModifyTypes::new(*addr - keep.mem.addr(), *length, 4);
+            ENCLAVE_MODIFY_TYPES
+                .ioctl(&mut keep.enclave.try_clone().unwrap(), &mut parameters)
+                .context("ENCLAVE_MODIFY_TYPES failed")?;
+            *ret = 0;
+            Ok(None)
+        }
+
+        _ => return Ok(Some(Item::Enarxcall(enarxcall, data))),
+    }
+}

--- a/src/backend/sgx/enarxcall.rs
+++ b/src/backend/sgx/enarxcall.rs
@@ -281,12 +281,12 @@ pub(crate) fn sgx_enarxcall<'a>(
         }
 
         item::Enarxcall {
-            num: item::enarxcall::Number::TrimSgxPages,
-            argv: [addr, length, ..],
+            num: item::enarxcall::Number::SgxModifyPageType,
+            argv: [addr, length, page_type, ..],
             ret,
             ..
         } => {
-            let mut parameters = ModifyTypes::new(*addr - keep.mem.addr(), *length, 4);
+            let mut parameters = ModifyTypes::new(*addr - keep.mem.addr(), *length, *page_type);
             ENCLAVE_MODIFY_TYPES
                 .ioctl(&mut keep.enclave.try_clone().unwrap(), &mut parameters)
                 .context("ENCLAVE_MODIFY_TYPES failed")?;

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -4,6 +4,7 @@ mod attestation;
 mod builder;
 mod config;
 mod data;
+mod enarxcall;
 mod hasher;
 mod ioctls;
 mod thread;
@@ -22,7 +23,7 @@ pub const AESM_SOCKET: &str = "/var/run/aesmd/aesm.socket";
 
 pub type Tcs = usize;
 
-struct Keep {
+pub(crate) struct Keep {
     sallyport_block_size: u64,
     mem: Map<perms::Unknown>,
     tcs: RwLock<Vec<Tcs>>,

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -1,32 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::attestation::{get_attestation_key_id, get_key_size, get_quote, get_target_info};
+use super::enarxcall::sgx_enarxcall;
 #[cfg(feature = "gdb")]
 use crate::backend::execute_gdb;
-use crate::backend::parking::THREAD_PARK;
-use crate::backend::sgx::attestation::get_quote_size;
-use crate::backend::sgx::ioctls::*;
-use crate::backend::{Command, Keep};
+use crate::backend::Command;
 
 use std::arch::asm;
-use std::arch::x86_64::CpuidResult;
 use std::io;
 use std::iter;
-use std::mem::{forget, size_of, MaybeUninit};
+use std::mem::{size_of, MaybeUninit};
 #[cfg(feature = "gdb")]
 use std::net::TcpStream;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use libc::{timespec, EAGAIN, EINVAL, PROT_READ};
-use mmarinus::{perms, Map, Shared};
-use sallyport::host::{deref_aligned, deref_slice};
 use sallyport::item;
-use sallyport::item::enarxcall::sgx::{Report, TargetInfo};
 use sallyport::item::{Block, Item};
 use sgx::enclu::{EENTER, EEXIT, ERESUME};
 use sgx::ssa::Vector;
-use tracing::{error, trace, trace_span};
+use tracing::{error, trace};
 use vdso::Symbol;
 
 pub struct Thread {
@@ -73,280 +65,6 @@ impl super::super::Keep for super::Keep {
             #[cfg(feature = "gdb")]
             gdb_fd: None,
         })))
-    }
-}
-
-fn sgx_enarxcall<'a>(
-    enarxcall: &'a mut item::Enarxcall,
-    data: &'a mut [u8],
-    keep: Arc<super::Keep>,
-) -> Result<Option<Item<'a>>> {
-    match enarxcall {
-        item::Enarxcall {
-            num: item::enarxcall::Number::Spawn,
-            ret,
-            ..
-        } => {
-            *ret = if let Some(mut thread) = keep.spawn()? {
-                std::thread::spawn(move || {
-                    trace_span!(
-                        "Thread",
-                        id = ?std::thread::current().id()
-                    )
-                    .in_scope(|| loop {
-                        match thread.enter(&None)? {
-                            Command::Continue => (),
-                            Command::Exit(exit_code) => {
-                                drop(thread);
-                                return Ok::<i32, anyhow::Error>(exit_code);
-                            }
-                        }
-                    })
-                });
-                0
-            } else {
-                error!("no more SGX threads available");
-                -EAGAIN as usize
-            };
-
-            Ok(None)
-        }
-        item::Enarxcall {
-            num: item::enarxcall::Number::Park,
-            argv: [val, timeout, ..],
-            ret,
-            ..
-        } => {
-            let timeout = if *timeout != sallyport::NULL {
-                Some(unsafe {
-                    // Safety: `deref_aligned` gives us a pointer to an aligned `timespec` struct.
-                    // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
-                    // is a subslice of.
-                    (*deref_aligned::<MaybeUninit<timespec>>(data, *timeout, 1)
-                        .map_err(io::Error::from_raw_os_error)
-                        .context("sgx_enarxcall deref")?)
-                    .assume_init()
-                })
-            } else {
-                None
-            };
-
-            *ret = THREAD_PARK
-                .park(*val as _, timeout.as_ref())
-                .map(|v| v as usize)
-                .unwrap_or_else(|e| -e as usize);
-
-            Ok(None)
-        }
-        item::Enarxcall {
-            num: item::enarxcall::Number::UnPark,
-            ret,
-            ..
-        } => {
-            THREAD_PARK.unpark();
-            *ret = 0;
-            Ok(None)
-        }
-        item::Enarxcall {
-            num: item::enarxcall::Number::Cpuid,
-            argv: [leaf, subleaf, cpuid_offset, ..],
-            ret,
-        } => {
-            let cpuid_buf = unsafe {
-                // Safety: `deref_aligned` gives us a pointer to an aligned `CpuidResult` struct.
-                // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
-                // is a subslice of.
-                &mut *deref_aligned::<MaybeUninit<CpuidResult>>(data, *cpuid_offset, 1)
-                    .map_err(io::Error::from_raw_os_error)
-                    .context("sgx_enarxcall deref")?
-            };
-
-            // Safety: we know we are on an SGX machine, which can do cpuid
-            let cpuid_ret = unsafe { core::arch::x86_64::__cpuid_count(*leaf as _, *subleaf as _) };
-
-            cpuid_buf.write(cpuid_ret);
-            *ret = 0;
-            Ok(None)
-        }
-
-        item::Enarxcall {
-            num: item::enarxcall::Number::GetSgxTargetInfo,
-            argv: [target_info_offset, ..],
-            ret,
-        } => {
-            let out_buf = unsafe {
-                // Safety: `deref_slice` gives us a pointer to a byte slice, which does not have to be aligned.
-                // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
-                // is a subslice of.
-                &mut *deref_slice::<u8>(data, *target_info_offset, size_of::<TargetInfo>())
-                    .map_err(io::Error::from_raw_os_error)
-                    .context("sgx_enarxcall deref")?
-            };
-            let akid = get_attestation_key_id().context(
-                "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
-            )?;
-            let pkeysize = get_key_size(akid.clone()).context(
-                "Error obtaining key size. Check your aesmd / pccs service installation.",
-            )?;
-            *ret = get_target_info(akid, pkeysize, out_buf).context(
-                "Error getting target info. Check your aesmd / pccs service installation.",
-            )?;
-
-            Ok(None)
-        }
-
-        item::Enarxcall {
-            num: item::enarxcall::Number::GetSgxQuote,
-            argv: [report_offset, quote_offset, quote_len, ..],
-            ret,
-        } => {
-            let report_buf = unsafe {
-                // Safety: `deref_slice` gives us a pointer to a byte slice, which does not have to be aligned.
-                // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
-                // is a subslice of.
-                &mut *deref_slice::<u8>(data, *report_offset, size_of::<Report>())
-                    .map_err(io::Error::from_raw_os_error)
-                    .context("sgx_enarxcall deref")?
-            };
-
-            let quote_buf = unsafe {
-                // Safety: `deref_slice` gives us a pointer to a byte slice, which does not have to be aligned.
-                // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
-                // is a subslice of.
-                &mut *deref_slice::<u8>(data, *quote_offset, *quote_len)
-                    .map_err(io::Error::from_raw_os_error)
-                    .context("sgx_enarxcall deref")?
-            };
-
-            let akid = get_attestation_key_id().context(
-                "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
-            )?;
-            *ret = get_quote(report_buf, akid, quote_buf)
-                .context("Error getting quote. Check your aesmd / pccs service installation.")?;
-
-            Ok(None)
-        }
-
-        item::Enarxcall {
-            num: item::enarxcall::Number::GetSgxQuoteSize,
-            ret,
-            ..
-        } => {
-            let akid = get_attestation_key_id().context(
-                "Error obtaining attestation key id. Check your aesmd / pccs service installation.",
-            )?;
-            *ret = get_quote_size(akid).context(
-                "Error getting quote size. Check your aesmd / pccs service installation.",
-            )?;
-
-            Ok(None)
-        }
-
-        item::Enarxcall {
-            num: item::enarxcall::Number::MmapHost,
-            argv: [addr, len, prot, ..],
-            ret,
-            ..
-        } => {
-            // Safety: an `mmap()` call is pointed to a file descriptor of the
-            // created enclave, and can therefore only affect the memory
-            // mappings within the address range given to ENCLAVE_CREATE.
-            match unsafe {
-                Map::bytes(*len)
-                    .onto(*addr)
-                    .from(&mut keep.enclave.try_clone().unwrap(), 0)
-                    .with_kind(Shared)
-                    .with(perms::Unknown(*prot as i32))
-            } {
-                Ok(map) => {
-                    // Skip `drop()`. The VMA's ownership has been moved to the shim.
-                    forget(map);
-                    *ret = 0;
-                }
-                Err(err) => {
-                    *ret = (-err.err.raw_os_error().unwrap()) as usize;
-                }
-            };
-            Ok(None)
-        }
-
-        item::Enarxcall {
-            num: item::enarxcall::Number::MprotectHost,
-            argv: [addr, len, prot, ..],
-            ret,
-            ..
-        } => {
-            let mem_end = keep.mem.addr() + keep.mem.size();
-            let end = *addr + *len;
-
-            // Check that the span is within the enclave address range:
-            if *addr < keep.mem.addr() || end > mem_end {
-                *ret = EINVAL as _;
-                return Ok(None);
-            }
-
-            // Safety: the parameters have been verified to be within the shim's
-            // address range.
-            if unsafe { libc::mprotect(*addr as _, *len, *prot as i32) } != 0 {
-                *ret = (-io::Error::last_os_error().raw_os_error().unwrap()) as _;
-                return Ok(None);
-            }
-
-            // TODO: https://github.com/enarx/enarx/issues/1892
-            let mut parameters =
-                RestrictPermissions::new(*addr - keep.mem.addr(), *len, PROT_READ as _);
-            ENCLAVE_RESTRICT_PERMISSIONS
-                .ioctl(&mut keep.enclave.try_clone().unwrap(), &mut parameters)
-                .context("ENCLAVE_RESTRICT_PERMISSIONS failed")?;
-
-            *ret = 0;
-            Ok(None)
-        }
-
-        item::Enarxcall {
-            num: item::enarxcall::Number::MunmapHost,
-            argv: [addr, len, ..],
-            ret,
-            ..
-        } => {
-            let mem_end = keep.mem.addr() + keep.mem.size();
-            let end = *addr + *len;
-
-            // Check that the span is within the enclave address range:
-            if *addr < keep.mem.addr() || end > mem_end {
-                panic!("munmap() is out of range");
-            }
-
-            // Safety: the parameters have been sanity checked before, that only
-            // enclave memory is unmapped.
-            unsafe {
-                libc::munmap(*addr as *mut _, *len);
-            }
-
-            let mut parameters = RemovePages::new(*addr - keep.mem.addr(), *len);
-            ENCLAVE_REMOVE_PAGES
-                .ioctl(&mut keep.enclave.try_clone().unwrap(), &mut parameters)
-                .context("ENCLAVE_REMOVE_PAGES failed")?;
-
-            *ret = 0;
-            Ok(None)
-        }
-
-        item::Enarxcall {
-            num: item::enarxcall::Number::TrimSgxPages,
-            argv: [addr, length, ..],
-            ret,
-            ..
-        } => {
-            let mut parameters = ModifyTypes::new(*addr - keep.mem.addr(), *length, 4);
-            ENCLAVE_MODIFY_TYPES
-                .ioctl(&mut keep.enclave.try_clone().unwrap(), &mut parameters)
-                .context("ENCLAVE_MODIFY_TYPES failed")?;
-            *ret = 0;
-            Ok(None)
-        }
-
-        _ => return Ok(Some(Item::Enarxcall(enarxcall, data))),
     }
 }
 


### PR DESCRIPTION
and introduce a new `page_type` parameter. Now, this function can be used in general to set a page type.

Also factor out the sgx enarxcalls into a separate file.