### PR TITLE
test: check output during CLI integration tests

### DIFF
--- a/src/cli/user/register.rs
+++ b/src/cli/user/register.rs
@@ -23,7 +23,11 @@ pub struct Options {
     insecure_auth_token: Option<String>,
     #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
     credential_helper: Option<OsString>,
-    #[clap(long, default_value = "https://auth.profian.com/")]
+    #[clap(
+        long,
+        env = "ENARX_OIDC_DOMAIN",
+        default_value = "https://auth.profian.com/"
+    )]
     oidc_domain: Url,
     #[clap(long, default_value = "4NuaJxkQv8EZBeJKE56R57gKJbxrTLG2")]
     oidc_client_id: String,


### PR DESCRIPTION
This also:

* makes the OIDC mock server return 401 on unauthorized, rather than panicking, so we can test the authorization failure mode
* makes the mock OIDC server use our hardcoded OIDC client key, rather than a dummy token
* allows setting an option to `enarx user register` via an env var
* improves the integration test helper, by making it easier to use and read, and making the error output more useful and readable

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
