### PR TITLE
feat(sgx): implement dynamic thread allocation

### DIFF
--- a/crates/sallyport/src/guest/call/enarxcall/passthrough.rs
+++ b/crates/sallyport/src/guest/call/enarxcall/passthrough.rs
@@ -159,16 +159,20 @@ impl PassthroughAlloc for MunmapHost {
 
 /// Spawn a new thread
 #[repr(transparent)]
-pub struct Spawn;
+pub struct Spawn {
+    /// An address suitable to start a new thread with the keep's technology.
+    /// 0 is a valid value, and indicates that the keep should reuse a thread from the pool.
+    pub addr: usize,
+}
 
 impl PassthroughAlloc for Spawn {
     const NUM: Number = Number::Spawn;
 
-    type Argv = Argv<0>;
+    type Argv = Argv<1>;
     type Ret = ();
 
     fn stage(self) -> Self::Argv {
-        Argv([])
+        Argv([self.addr as _])
     }
 }
 

--- a/crates/sallyport/src/guest/handler.rs
+++ b/crates/sallyport/src/guest/handler.rs
@@ -1204,8 +1204,8 @@ pub trait Handler {
 
     /// Spawn a new thread
     #[inline]
-    fn spawn(&mut self) -> Result<()> {
-        self.execute(enarxcall::Spawn)?
+    fn spawn(&mut self, addr: usize) -> Result<()> {
+        self.execute(enarxcall::Spawn { addr })?
     }
 
     /// Within an address range inside the enclave, ask host to set page type to

--- a/crates/sallyport/tests/enarxcall/mod.rs
+++ b/crates/sallyport/tests/enarxcall/mod.rs
@@ -96,7 +96,7 @@ fn munmap_host() {
 #[test]
 fn spawn() {
     run_test(1, [0xff; 16], move |_, _, handler| {
-        assert_eq!(handler.spawn(), Err(ENOSYS));
+        assert_eq!(handler.spawn(0), Err(ENOSYS));
     })
 }
 

--- a/crates/shim-sgx/layout.ld
+++ b/crates/shim-sgx/layout.ld
@@ -1,8 +1,8 @@
 ENTRY(_start)
 
 /* change CSSA_0_STACK_SIZE in lib.rs if you change this */
-CSSA_0_STACK_SIZE = 0x200000;
-CSSA_1_plus_STACK_SIZE = 0x200000;
+CSSA_0_STACK_SIZE = 0x800000;
+CSSA_1_plus_STACK_SIZE = 0x800000;
 
 PHDRS {
     rodata PT_LOAD FILEHDR PHDRS;
@@ -66,7 +66,7 @@ SECTIONS {
         QUAD(_start)              /* OENTRY */
         . = ALIGN(4K);
     } :tcs =0
-    .enarx.ssa (NOLOAD) : { . += 4K * 3; } :ssa =0
+    .enarx.ssa (NOLOAD) : { . += 4K * 4; } :ssa =0
 
     /* EXEC */
     . = ALIGN(1M);

--- a/crates/shim-sgx/layout.ld
+++ b/crates/shim-sgx/layout.ld
@@ -11,20 +11,10 @@ PHDRS {
     dynamic PT_DYNAMIC;
     note PT_NOTE;
 
-    stk01 PT_LOAD;
-    stk00 PT_LOAD;
-    tcs0 PT_LOAD FLAGS(1 << 20); /* sallyport::elf::pf::sgx::TCS */
-    ssa0 PT_LOAD;
-
-    stk11 PT_LOAD;
-    stk10 PT_LOAD;
-    tcs1 PT_LOAD FLAGS(1 << 20); /* sallyport::elf::pf::sgx::TCS */
-    ssa1 PT_LOAD;
-
-    stk21 PT_LOAD;
-    stk20 PT_LOAD;
-    tcs2 PT_LOAD FLAGS(1 << 20); /* sallyport::elf::pf::sgx::TCS */
-    ssa2 PT_LOAD;
+    stk1 PT_LOAD;
+    stk0 PT_LOAD;
+    tcs PT_LOAD FLAGS(1 << 20); /* sallyport::elf::pf::sgx::TCS */
+    ssa PT_LOAD;
 
     exec 0x63400000 FLAGS(0); /* sallyport::elf::pt::EXEC */
 }
@@ -65,46 +55,18 @@ SECTIONS {
     /* THREAD */
     . = ALIGN(2M);
     . += 4K;                /* Guard Page */
-    .enarx.stk01 (NOLOAD) : { . += CSSA_1_plus_STACK_SIZE - 4K * 5; } :stk01 =0
+    .enarx.stk1 (NOLOAD) : { . += CSSA_1_plus_STACK_SIZE - 4K * 5; } :stk1 =0
     . += 4K;                /* Guard Page */
-    .enarx.stk00 (NOLOAD) : { . += CSSA_0_STACK_SIZE - 4K; } :stk00 =0
-    .enarx.tcs0 : {
+    .enarx.stk0 (NOLOAD) : { . += CSSA_0_STACK_SIZE - 4K; } :stk0 =0
+    .enarx.tcs : {
         . += 16;
-        QUAD(ADDR(.enarx.ssa0))   /* OSSA */
+        QUAD(ADDR(.enarx.ssa))   /* OSSA */
         LONG(0)                   /* CSSA */
         LONG(3)                   /* NSSA */
         QUAD(_start)              /* OENTRY */
         . = ALIGN(4K);
-    } :tcs0 =0
-    .enarx.ssa0 (NOLOAD) : { . += 4K * 3; } :ssa0 =0
-
-    . += 4K;                /* Guard Page */
-    .enarx.stk11 (NOLOAD) : { . += CSSA_1_plus_STACK_SIZE - 4K * 5; } :stk11 =0
-    . += 4K;                /* Guard Page */
-    .enarx.stk10 (NOLOAD) : { . += CSSA_0_STACK_SIZE - 4K; } :stk10 =0
-    .enarx.tcs1 : {
-        . += 16;
-        QUAD(ADDR(.enarx.ssa1))   /* OSSA */
-        LONG(0)                   /* CSSA */
-        LONG(3)                   /* NSSA */
-        QUAD(_start)              /* OENTRY */
-        . = ALIGN(4K);
-    } :tcs1 =0
-    .enarx.ssa1 (NOLOAD) : { . += 4K * 3; } :ssa1 =0
-
-    . += 4K;                /* Guard Page */
-    .enarx.stk21 (NOLOAD) : { . += CSSA_1_plus_STACK_SIZE - 4K * 5; } :stk21 =0
-    . += 4K;                /* Guard Page */
-    .enarx.stk20 (NOLOAD) : { . += CSSA_0_STACK_SIZE - 4K; } :stk20 =0
-    .enarx.tcs2 : {
-        . += 16;
-        QUAD(ADDR(.enarx.ssa2))   /* OSSA */
-        LONG(0)                   /* CSSA */
-        LONG(3)                   /* NSSA */
-        QUAD(_start)              /* OENTRY */
-        . = ALIGN(4K);
-    } :tcs2 =0
-    .enarx.ssa2 (NOLOAD) : { . += 4K * 3; } :ssa2 =0
+    } :tcs =0
+    .enarx.ssa (NOLOAD) : { . += 4K * 3; } :ssa =0
 
     /* EXEC */
     . = ALIGN(1M);

--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod usermem;
 
 use crate::handler::usermem::UserMemScope;
 use crate::heap::Heap;
-use crate::thread::{NewThread, NewThreadFromRegisters, Tcb, NEW_THREAD_QUEUE, NUM_THREADS};
+use crate::thread::{NewThread, NewThreadFromRegisters, Tcb, NEW_THREAD_QUEUE, THREAD_ID_CNT};
 use crate::{shim_address, DEBUG, ENARX_EXEC_END, ENARX_EXEC_START, ENCL_SIZE};
 use core::arch::asm;
 use core::arch::x86_64::CpuidResult;
@@ -229,7 +229,7 @@ impl guest::Handler for Handler<'_> {
             tls = tls.as_ptr()
         );
 
-        let tid = NUM_THREADS.fetch_add(1, Ordering::SeqCst);
+        let tid = THREAD_ID_CNT.fetch_add(1, Ordering::SeqCst);
 
         let mut regs = self.ssa.gpr;
         regs.rsp = stack.as_ptr() as _;

--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -246,7 +246,7 @@ impl guest::Handler for Handler<'_> {
 
         ptid.store(tid as _, Ordering::Relaxed);
 
-        let ret = self.spawn();
+        let ret = self.spawn(0);
         debugln!(self, "spawn() = {ret:#?}");
         ret?;
 

--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -417,7 +417,7 @@ impl<'a> Handler<'a> {
     }
 
     /// Finish handling an exception
-    pub fn finish(ssa: &'a mut StateSaveArea) {
+    pub fn finish(ssa: &'a mut StateSaveArea, block: &'a mut [usize], tcb: &'a mut Tcb) {
         if let Some(Vector::InvalidOpcode) = ssa.vector() {
             if let OP_SYSCALL | OP_CPUID = unsafe { read_unaligned(ssa.gpr.rip as _) } {
                 // Skip the instruction.
@@ -425,6 +425,9 @@ impl<'a> Handler<'a> {
                 return;
             }
         }
+
+        let mut h = Self::new(ssa, block, tcb, 0);
+        h.print_ssa_stack_trace();
 
         unsafe { asm!("ud2", options(noreturn)) };
     }

--- a/crates/shim-sgx/src/heap.rs
+++ b/crates/shim-sgx/src/heap.rs
@@ -11,7 +11,9 @@ pub struct Heap {
     end: Address<usize, Page>,
     brk: Address<usize, Page>,
     brk_max: Address<usize, Page>,
-    ledger: Ledger<4094>,
+    // FIXME: use a dynamic Ledger
+    // https://github.com/enarx/enarx/issues/2264
+    ledger: Ledger<8188>,
 }
 
 impl Heap {

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -26,16 +26,16 @@ use sgx::ssa::StateSaveArea;
 const DEBUG: bool = cfg!(feature = "dbg");
 
 /// Number of available slots for SSA frames.
-pub const NUM_SSA: usize = 3;
+pub const NUM_SSA: usize = 4;
 
 /// Stack size of the CSSA = 0
 /// as defined in the linker script `layout.ld`
-pub const CSSA_0_STACK_SIZE: usize = 0x200000 - Page::SIZE; // 2MB - TCB
+pub const CSSA_0_STACK_SIZE: usize = 0x800000 - Page::SIZE; // 8MB - TCB
 
 /// Stack size of the CSSA > 0
 /// as defined in the linker script `layout.ld`
 pub const CSSA_1_PLUS_STACK_SIZE: usize =
-    0x200000 - Page::SIZE - NUM_SSA * core::mem::size_of::<StateSaveArea>(); // 2MB - TCS - SSA
+    0x800000 - Page::SIZE - NUM_SSA * core::mem::size_of::<StateSaveArea>(); // 8MB - TCS - SSA
 
 /// FIXME: doc
 pub const ENCL_SIZE_BITS: u8 = 32;

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -19,13 +19,23 @@ pub mod handler;
 pub mod heap;
 pub mod thread;
 
+use primordial::Page;
 use sgx::parameters::{Attributes, Features, MiscSelect, Xfrm};
+use sgx::ssa::StateSaveArea;
 
 const DEBUG: bool = cfg!(feature = "dbg");
 
+/// Number of available slots for SSA frames.
+pub const NUM_SSA: usize = 3;
+
 /// Stack size of the CSSA = 0
 /// as defined in the linker script `layout.ld`
-pub const CSSA_0_STACK_SIZE: u64 = 0x200000;
+pub const CSSA_0_STACK_SIZE: usize = 0x200000 - Page::SIZE; // 2MB - TCB
+
+/// Stack size of the CSSA > 0
+/// as defined in the linker script `layout.ld`
+pub const CSSA_1_PLUS_STACK_SIZE: usize =
+    0x200000 - Page::SIZE - NUM_SSA * core::mem::size_of::<StateSaveArea>(); // 2MB - TCS - SSA
 
 /// FIXME: doc
 pub const ENCL_SIZE_BITS: u8 = 32;

--- a/crates/shim-sgx/src/main.rs
+++ b/crates/shim-sgx/src/main.rs
@@ -337,7 +337,10 @@ unsafe extern "C" fn main(
                 _start as usize as _,
             )
         }
-        n => handler::Handler::finish(&mut ssas[n - 1]),
+        n => {
+            let tcb = tcb.assume_init_mut();
+            handler::Handler::finish(&mut ssas[n - 1], block.as_mut_slice(), tcb)
+        }
     }
 
     // Disable exceptions:

--- a/crates/shim-sgx/src/main.rs
+++ b/crates/shim-sgx/src/main.rs
@@ -37,6 +37,7 @@ fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
 // ============== REAL CODE HERE ===============
 
 use noted::noted;
+use primordial::Page;
 use sallyport::{elf::note, REQUIRES};
 use sgx::parameters::{Attributes, MiscSelect};
 use sgx::ssa::{GenPurposeRegs, StateSaveArea};
@@ -211,10 +212,10 @@ pub unsafe extern "sysv64" fn _start() -> ! {
         "je     2b                          ",  // ... loop forever.
 
         // Find stack pointer for CSSA == 1
-        "cmp    rax,    1                   ",  // If CSSA > 0
+        "cmp    rax,    1                   ",  // If CSSA > 1
         "jne    3f                          ",  // ... jump to the next section
-        "mov    r10,    rcx                 ",  // r10 = stack pointer CSSA == 0
-        "sub    r10,    {CSSA_0_STK_TCS_SZ} ",  // r10 = stack pointer - 2MB
+        "mov    r10,    rcx                 ",  // r10 = stack pointer CSSA == 1
+        "sub    r10,    {CSSA_0_STK_TCS_SZ} ",  // r10 = stack pointer - CSSA_0_STK_TCS_SZ
         "jmp    4f                          ",  // Jump to stack setup
 
         // Find stack pointer for CSSA > 1
@@ -262,7 +263,7 @@ pub unsafe extern "sysv64" fn _start() -> ! {
         RELOC = sym relocate,
         ENTRY = sym main,
         EEXIT = const sgx::enclu::EEXIT,
-        CSSA_0_STK_TCS_SZ = const CSSA_0_STACK_SIZE + 4096,
+        CSSA_0_STK_TCS_SZ = const CSSA_0_STACK_SIZE + Page::SIZE,
         options(noreturn)
     )
 }

--- a/crates/shim-sgx/src/thread.rs
+++ b/crates/shim-sgx/src/thread.rs
@@ -114,8 +114,8 @@ pub struct Tcb {
     pub tls: ThreadLocalStorage,
 }
 
-/// actual thread ID
-pub static NUM_THREADS: AtomicI32 = AtomicI32::new(1);
+/// actual thread ID to be used for the next thread
+pub static THREAD_ID_CNT: AtomicI32 = AtomicI32::new(1);
 
 /// Extend some trait with a method to load registers
 pub trait LoadRegsExt {

--- a/src/backend/sgx/builder.rs
+++ b/src/backend/sgx/builder.rs
@@ -6,7 +6,7 @@ use super::ioctls::*;
 use std::convert::TryFrom;
 use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use anyhow::{anyhow, Context, Error, Result};
 use mmarinus::{perms, Map, Shared};
@@ -210,7 +210,7 @@ impl TryFrom<Builder> for Arc<dyn super::super::Keep> {
             sallyport_block_size: builder.cnfg.sallyport_block_size,
             mem: builder.mmap,
             tcs: RwLock::new(builder.tcsp),
-            enclave: builder.file.try_clone().unwrap(),
+            enclave: Mutex::new(builder.file.try_clone().unwrap()),
         }))
     }
 }

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -30,6 +30,12 @@ pub(crate) struct Keep {
     enclave: File,
 }
 
+impl Keep {
+    fn push_tcs(&self, tcs: Tcs) {
+        self.tcs.write().unwrap().push(tcs)
+    }
+}
+
 pub struct Backend;
 
 impl crate::backend::Backend for Backend {

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -17,7 +17,7 @@ use mmarinus::{perms, Map};
 use crate::backend::Signatures;
 use std::arch::x86_64::__cpuid_count;
 use std::fs::File;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 pub const AESM_SOCKET: &str = "/var/run/aesmd/aesm.socket";
 
@@ -27,7 +27,7 @@ pub(crate) struct Keep {
     sallyport_block_size: u64,
     mem: Map<perms::Unknown>,
     tcs: RwLock<Vec<Tcs>>,
-    enclave: File,
+    enclave: Mutex<File>,
 }
 
 impl Keep {

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -138,9 +138,6 @@ impl super::super::Thread for Thread {
                         "Unexpected {:?}: address = {:>#016x}, error code = {:>#016b} cssa={}",
                         run.vector, run.exception_addr, run.exception_error_code, self.cssa
                     );
-                    if self.cssa > 4 {
-                        std::process::exit(1);
-                    }
                     EENTER
                 } else {
                     panic!(
@@ -159,6 +156,11 @@ impl super::super::Thread for Thread {
                 _ => self.cssa -= 1,
             },
             _ => unreachable!(),
+        }
+
+        if self.cssa > 3 {
+            error!("CSSA overflow");
+            std::process::exit(1);
         }
 
         // If we have handled an InvalidOpcode error, evaluate the sallyport.

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -35,7 +35,7 @@ pub struct Thread {
 impl Drop for Thread {
     fn drop(&mut self) {
         trace!("Dropping thread");
-        self.keep.tcs.write().unwrap().push(self.tcs)
+        self.keep.push_tcs(self.tcs)
     }
 }
 


### PR DESCRIPTION
The SGX keep allocates memory and sets up the TCS for new threads, if the existing thread pool is drained.

The thread pool is not shrinked though. See https://github.com/enarx/enarx/issues/2251

Fixes: https://github.com/enarx/enarx/issues/2160