### PR TITLE
feat: `enarx user key` subcommand for generating signing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
+ "base64ct",
  "crypto-bigint 0.4.8",
  "der 0.6.0",
  "digest 0.10.5",
@@ -1148,6 +1149,8 @@ dependencies = [
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1",
+ "serde_json",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1160,6 +1163,7 @@ dependencies = [
  "async-h1",
  "async-std",
  "atty",
+ "base64ct",
  "bitflags",
  "camino",
  "clap",
@@ -3112,6 +3116,7 @@ dependencies = [
  "der 0.6.0",
  "generic-array",
  "pkcs8 0.9.0",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -3249,6 +3254,16 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038fce1bf4d74b9b30ea7dcd59df75ba8ec669a5dcb3cc64fbfcef7334ced32c"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ disable-sgx-attestation = ["enarx-shim-sgx/disable-sgx-attestation"]
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 atty = { workspace = true }
+base64ct = { workspace = true }
 bitflags = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true }
@@ -39,6 +40,8 @@ tracing-subscriber = { workspace = true, features = ["ansi", "smallvec", "std", 
 oauth2 = { workspace = true }
 once_cell = { workspace = true, features = ["std"] }
 openidconnect = { workspace = true, features = ["ureq"] }
+p384 = { workspace = true }
+rand = { workspace = true }
 ring = { workspace = true }
 rsa = { workspace = true }
 rustls = { workspace = true }
@@ -61,11 +64,9 @@ kvm-ioctls = { workspace = true }
 lset = { workspace = true }
 mmarinus = { workspace = true }
 nbytes = { workspace = true }
-p384 = { workspace = true }
 pkcs8 = { workspace = true, features = ["std", "pem"] }
 primordial = { workspace = true, features = ["alloc"] }
 protobuf = { workspace = true }
-rand = { workspace = true }
 sallyport = { workspace = true }
 semver = { workspace = true }
 sgx = { workspace = true, features = ["rcrypto"] }
@@ -139,6 +140,7 @@ array-const-fn-init = { version = "0.1.0", default-features = false }
 async-h1 = { version = "2.3.3", default-features = false }
 async-std = { version = "1.11.0", default-features = false, features = ["attributes"] }
 atty = { version = "0.2.0", default-features = false }
+base64ct = { version = "1.5.2", default-features = false }
 bitflags = { version = "1.2.0", default-features = false }
 camino = { version = "1.0.9", default-features = false }
 clap = { version = "4.0", features = ["std", "derive", "env", "error-context", "help", "usage", "wrap_help"], default-features = false }
@@ -174,7 +176,7 @@ noted = { version = "1.0.0", default-features = false }
 oauth2 = { version = "4.2.2", default-features = false, features = ["ureq"] }
 once_cell = { version = "1.13.0", default-features = false }
 openidconnect = { version = "2.3.1", default-features = false }
-p384 = { version = "0.11.1", features = ["std", "pem", "ecdsa"], default-features = false }
+p384 = { version = "0.11.1", features = ["ecdsa", "jwk", "pem", "std"], default-features = false }
 pkcs8 = { version = "0.9.0" }
 primordial = { version = "0.5.0", default-features = false }
 process_control = { version = "3.3.0", default-features = false }

--- a/src/cli/user/key.rs
+++ b/src/cli/user/key.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::drawbridge::{generate_signing_key, get_signing_key, UserSpec};
+
+use std::ffi::OsString;
+
+use clap::Args;
+
+/// Generate and display keys used for signing uploaded packages
+#[derive(Args, Debug)]
+pub struct Options {
+    #[clap(long)]
+    generate: bool,
+    #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
+    credential_helper: Option<OsString>,
+    spec: UserSpec,
+}
+
+impl Options {
+    pub fn execute(self) -> anyhow::Result<()> {
+        if self.generate {
+            generate_signing_key(&self.spec, &self.credential_helper)?;
+        } else {
+            let public_key_jwk = get_signing_key(&self.spec, &self.credential_helper)?;
+            println!("{public_key_jwk}");
+        }
+
+        Ok(())
+    }
+}

--- a/src/cli/user/mod.rs
+++ b/src/cli/user/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod info;
+mod key;
 mod login;
 mod logout;
 mod register;
@@ -12,6 +13,7 @@ use clap::Subcommand;
 pub enum Subcommands {
     #[clap(hide = true)]
     Info(info::Options),
+    Key(key::Options),
     Login(login::Options),
     #[clap(hide = true)]
     Logout(logout::Options),
@@ -22,6 +24,7 @@ impl Subcommands {
     pub fn dispatch(self) -> anyhow::Result<()> {
         match self {
             Self::Info(cmd) => cmd.execute(),
+            Self::Key(cmd) => cmd.execute(),
             Self::Login(cmd) => cmd.execute(),
             Self::Logout(cmd) => cmd.execute(),
             Self::Register(cmd) => cmd.execute(),

--- a/src/cli/user/register.rs
+++ b/src/cli/user/register.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::drawbridge::{client, get_token, login, UserSpec};
+use crate::drawbridge::{client, get_auth_token, login, UserSpec};
 
 use std::ffi::OsString;
 
@@ -46,7 +46,7 @@ impl Options {
         } = self;
 
         // If we don't find a token saved locally, initiate an interactive login
-        let token = match get_token(oidc_domain, insecure_auth_token, credential_helper) {
+        let token = match get_auth_token(oidc_domain, insecure_auth_token, credential_helper) {
             Ok(token) => token,
             _ => login(oidc_domain, oidc_client_id.clone(), credential_helper)?,
         };


### PR DESCRIPTION
Part of #2167 .

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
