### PR TITLE
build: use crane

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v17
-    - run: nix flake check
+    - run: nix flake check -L
 
   fmt:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v17
-    - run: nix flake check --impure
+    - run: nix flake check
 
   fmt:
     runs-on: ubuntu-20.04
@@ -63,4 +63,4 @@ jobs:
       with:
         name: enarx
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix develop -L --ignore-environment --impure -c cargo test 'wasm::'
+    - run: nix develop -L --ignore-environment -c cargo test 'wasm::'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-x86_64:
+  build-nix:
     strategy:
       matrix:
         platform:
+        - host: macos-latest
+          target: aarch64-apple-darwin
+        - host: ubuntu-20.04
+          target: aarch64-unknown-linux-musl
         - host: macos-latest
           target: x86_64-apple-darwin
         - host: ubuntu-20.04
@@ -46,40 +50,6 @@ jobs:
       with:
         name: enarx-${{ matrix.platform.target }}-oci
         path: enarx-${{ matrix.platform.target }}-oci
-
-  build-aarch64:
-    strategy:
-      matrix:
-        platform:
-        - host: ARM64
-          target: aarch64-unknown-linux-musl
-        - host: aarch64-apple-darwin
-          target: aarch64-apple-darwin
-    runs-on: ${{ matrix.platform.host }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Get rust toolchain snapshot version
-        id: toolchain_version
-        run: echo "::set-output name=toolchain_version::$(grep channel  rust-toolchain.toml | cut -d\" -f 2)"
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ steps.toolchain_version.outputs.toolchain_version }}
-          target: ${{ matrix.platform.target }}
-          profile: minimal
-      - name: Setup Rust toolchain
-        run: >
-            rustup override unset || :
-            && rustup show
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target ${{ matrix.platform.target }}
-      - name: Rename artifact
-        run: mv target/${{ matrix.platform.target }}/release/enarx enarx-${{ matrix.platform.target }}
-      - uses: actions/upload-artifact@v3
-        with:
-          name: enarx-${{ matrix.platform.target }}
-          path: enarx-${{ matrix.platform.target }}
 
   build-windows:
     name: enarx Windows build
@@ -121,7 +91,7 @@ jobs:
           path: target\wix\enarx-x86_64-windows.msi
 
   sign-x86_64:
-    needs: [ build-x86_64 ]
+    needs: [ build-nix ]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/download-artifact@v3
@@ -155,8 +125,8 @@ jobs:
         name: enarx-x86_64-unknown-linux-musl-sig
         path: enarx-x86_64-unknown-linux-musl.sig
 
-  build-darwin-universal-binary:
-    needs: [ build-x86_64, build-aarch64 ]
+  build-lipo:
+    needs: [ build-nix ]
     runs-on: macos-latest
     steps:
     - uses: actions/download-artifact@v3
@@ -172,7 +142,7 @@ jobs:
         path: enarx-universal-darwin
 
   test-bin:
-    needs: [ build-x86_64, build-aarch64, build-darwin-universal-binary ]
+    needs: [ build-nix, build-lipo ]
     strategy:
       matrix:
         platform:
@@ -202,7 +172,7 @@ jobs:
     - run: .\enarx-x86_64-windows.exe platform info
 
   test-oci:
-    needs: build-x86_64
+    needs: build-nix
     strategy:
       matrix:
         platform:
@@ -227,7 +197,7 @@ jobs:
         architecture:
         - x86_64
         - aarch64
-    needs: [ build-x86_64, build-aarch64, sign-x86_64 ]
+    needs: [ build-nix, sign-x86_64 ]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -267,7 +237,7 @@ jobs:
           debarch: amd64
         - build: aarch64
           debarch: arm64
-    needs: [ build-x86_64, build-aarch64 , sign-x86_64]
+    needs: [ build-nix, sign-x86_64]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -307,7 +277,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
-    needs: [ build-x86_64, test-bin, test-oci, test-windows, build-rpm, build-deb ]
+    needs: [ build-nix, test-bin, test-oci, test-windows, build-rpm, build-deb ]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,8 @@ jobs:
         platform:
         - host: macos-latest
           target: x86_64-apple-darwin
-          nix: x86_64-darwin
         - host: ubuntu-20.04
           target: x86_64-unknown-linux-musl
-          nix: x86_64-linux
     runs-on: ${{ matrix.platform.host }}
     steps:
     - uses: actions/checkout@v3
@@ -34,17 +32,15 @@ jobs:
       with:
         name: enarx
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - name: Pre-build setup
-      run: ${{ matrix.platform.setup }}
 
-    - run: nix build -L ${{ matrix.platform.buildArgs }} '.#packages.${{ matrix.platform.nix }}.enarx-static'
+    - run: nix build -L ${{ matrix.platform.buildArgs }} '.#enarx-${{ matrix.platform.target }}'
     - run: nix run --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=ginstall -p ./result/bin/enarx "enarx-${{ matrix.platform.target }}"
     - uses: actions/upload-artifact@v3
       with:
         name: enarx-${{ matrix.platform.target }}
         path: enarx-${{ matrix.platform.target }}
 
-    - run: nix build -L ${{ matrix.platform.buildArgs }} '.#packages.${{ matrix.platform.nix }}.enarx-static-oci'
+    - run: nix build -L ${{ matrix.platform.buildArgs }} '.#enarx-${{ matrix.platform.target }}-oci'
     - run: nix run --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=ginstall -p ./result "enarx-${{ matrix.platform.target }}-oci"
     - uses: actions/upload-artifact@v3
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ enarx-shim-kvm = { version = "0.6.4", path = "crates/shim-kvm", artifact = "bin"
 enarx-shim-sgx = { version = "0.6.4", path = "crates/shim-sgx", artifact = "bin", target = "x86_64-unknown-none", default-features = false }
 
 [build-dependencies]
+once_cell = { version = "1.11.0", features = ["std"], default-features = false }
 protobuf-codegen-pure = { version = "2.27", default-features = false }
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use once_cell::sync::Lazy;
+use std::env::var;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Whether Enarx compilation target is x86_64 Linux or not.
+// NOTE: This may or may not correspond to `target_os` and `target_arch`, since `build.rs` is
+// compiled for the host triple and not the cargo compilation target
+static IS_X86_64_LINUX: Lazy<bool> = Lazy::new(|| {
+    var("CARGO_CFG_TARGET_OS").expect("missing CARGO_CFG_TARGET_OS") == "linux"
+        && var("CARGO_CFG_TARGET_ARCH").expect("missing CARGO_CFG_TARGET_ARCH") == "x86_64"
+});
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use std::os::unix::fs::FileTypeExt;
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 fn generate_protos() {
-    use std::path::{Path, PathBuf};
-
     fn create(path: &Path) {
-        match std::fs::create_dir(path) {
+        match fs::create_dir(path) {
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
             Err(e) => {
                 eprintln!("Can't create {:#?} : {:#?}", path, e);
@@ -18,7 +28,7 @@ fn generate_protos() {
         }
     }
 
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_dir = PathBuf::from(var("OUT_DIR").unwrap());
     let out_dir_proto = out_dir.join("protos");
     create(&out_dir_proto);
 
@@ -39,15 +49,17 @@ fn main() {
     // FIXME: this exists to work around https://github.com/rust-lang/cargo/issues/10527
     println!("cargo:rerun-if-changed=crates/");
 
-    #[cfg(all(target_os = "linux", target_arch = "x86_64",))]
-    println!("cargo:rustc-cfg=enarx_with_shim");
+    if *IS_X86_64_LINUX {
+        println!("cargo:rustc-cfg=enarx_with_shim");
+    }
+
+    if *IS_X86_64_LINUX {
+        generate_protos();
+    }
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    generate_protos();
-
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    if std::path::Path::new("/dev/sgx_enclave").exists()
-        && std::fs::metadata("/dev/sgx_enclave")
+    if Path::new("/dev/sgx_enclave").exists()
+        && fs::metadata("/dev/sgx_enclave")
             .unwrap()
             .file_type()
             .is_char_device()
@@ -57,20 +69,17 @@ fn main() {
         println!("cargo:rustc-cfg=host_can_test_sgx");
 
         if (!cfg!(feature = "disable-sgx-attestation"))
-            && std::path::Path::new(AESM_SOCKET).exists()
-            && std::fs::metadata(AESM_SOCKET)
-                .unwrap()
-                .file_type()
-                .is_socket()
+            && Path::new(AESM_SOCKET).exists()
+            && fs::metadata(AESM_SOCKET).unwrap().file_type().is_socket()
         {
             println!("cargo:rustc-cfg=host_can_test_attestation");
         }
     }
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    if std::path::Path::new("/dev/sev").exists() {
+    if Path::new("/dev/sev").exists() {
         // Not expected to fail, as the file exists.
-        let metadata = std::fs::metadata("/dev/sev").unwrap();
+        let metadata = fs::metadata("/dev/sev").unwrap();
         let file_type = metadata.file_type();
 
         if file_type.is_char_device() {

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,29 @@
 {
   "nodes": {
-    "fenix": {
+    "crane": {
       "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
+        ]
       },
       "locked": {
-        "lastModified": 1663570974,
-        "narHash": "sha256-ncUdRdY70VdJIX6Mi+820xeD7FutADd3NbQR0BKkFYA=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "02093d3aca186135da78b76ac28ec58031391076",
+        "lastModified": 1665490127,
+        "narHash": "sha256-ZQdaPEgnR8AZGSjQ5dUYz8+D+EsKG4GymmDenBBwT30=",
+        "owner": "rvolosatovs",
+        "repo": "crane",
+        "rev": "b8d5ca397faf748eb50387885d0242eada6b8a3f",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
+        "owner": "rvolosatovs",
+        "ref": "fix/no_std",
+        "repo": "crane",
         "type": "github"
       }
     },
@@ -69,26 +75,33 @@
     },
     "root": {
       "inputs": {
-        "fenix": "fenix",
+        "crane": "crane",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       }
     },
-    "rust-analyzer-src": {
-      "flake": false,
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1662896065,
-        "narHash": "sha256-1LkSsXzI1JTAmP/GMTz4fTJd8y/tw8R79l96q+h7mu8=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "2e9f1204ca01c3e20898d4a67c8b84899d394a88",
+        "lastModified": 1665111330,
+        "narHash": "sha256-bvL2xzSVOLBUlXQIklqHqn1M6z5aXrr3FKcqtSnGJ8I=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "fb8f4fa9c5514dbbc7d2a7c310d8ba874c519779",
         "type": "github"
       },
       "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,33 @@
 {
   description = "Tools for deploying WebAssembly into Enarx Keeps.";
 
-  inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.fenix.url = github:nix-community/fenix;
+  inputs.crane.inputs.flake-compat.follows = "flake-compat";
+  inputs.crane.inputs.flake-utils.follows = "flake-utils";
+  inputs.crane.inputs.nixpkgs.follows = "nixpkgs";
+  # TODO: Switch to upstream once https://github.com/ipetkov/crane/pull/126 is merged
+  inputs.crane.url = github:rvolosatovs/crane/fix/no_std;
   inputs.flake-compat.flake = false;
   inputs.flake-compat.url = github:edolstra/flake-compat;
   inputs.flake-utils.url = github:numtide/flake-utils;
   inputs.nixpkgs.url = github:profianinc/nixpkgs;
+  inputs.rust-overlay.inputs.flake-utils.follows = "flake-utils";
+  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.rust-overlay.url = github:oxalica/rust-overlay;
 
   outputs = {
     self,
-    nixpkgs,
-    fenix,
+    crane,
     flake-utils,
+    nixpkgs,
+    rust-overlay,
     ...
   }:
-    with flake-utils.lib.system;
-      flake-utils.lib.eachSystem [
-        aarch64-darwin
-        aarch64-linux
-        x86_64-darwin
-        x86_64-linux
-      ]
-      (
-        system: let
-          ignorePatterns = [
+    with flake-utils.lib.system; let
+      version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+
+      overlay = final: prev: let
+        src =
+          final.nix-gitignore.gitignoreRecursiveSource [
             "*.nix"
             "*.yml"
             "/.github"
@@ -35,166 +38,148 @@
             "flake.lock"
             "LICENSE"
             "rust-toolchain.toml"
-          ];
+          ]
+          ./.;
 
-          pkgs = nixpkgs.legacyPackages.${system};
+        rustToolchain = prev.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
-          cargo.toml = builtins.fromTOML (builtins.readFile "${self}/Cargo.toml");
+        craneLib = (crane.mkLib final).overrideToolchain rustToolchain;
 
-          buildPackage = targetPkgs: rustTargets: extraArgs: let
-            rust = with fenix.packages.${system};
-              combine (
-                [
-                  minimal.cargo
-                  minimal.rustc
-                ]
-                ++ map (target: targets.${target}.latest.rust-std) rustTargets
-              );
-          in
-            (targetPkgs.makeRustPlatform {
-              rustc = rust;
-              cargo = rust;
-            })
-            .buildRustPackage
-            (extraArgs
-              // {
-                inherit (cargo.toml.package) name version;
+        commonArgs = {
+          inherit
+            src
+            version
+            ;
+          pname = "enarx";
 
-                src = pkgs.nix-gitignore.gitignoreRecursiveSource ignorePatterns self;
+          buildInputs =
+            final.lib.optional final.stdenv.isDarwin
+            final.darwin.apple_sdk.frameworks.Security;
+        };
 
-                cargoLock.lockFileContents = builtins.readFile "${self}/Cargo.lock";
-                cargoLock.outputHashes."cranelift-bforest-0.89.0" = "sha256-ytUiONbe9pHceyNMtpjE2fRQF6SwO/rGXtDWQ3EkCK0="; # for Wasmtime 2.0.0 git rev
+        cargoArtifacts = craneLib.buildDepsOnly (commonArgs
+          // {
+            cargoExtraArgs = "-j $NIX_BUILD_CORES --all-features";
 
-                postPatch = ''
-                  patchShebangs ./helper
-                '';
+            # Remove binary dependency specification, since that breaks on generated "dummy source"
+            extraDummyScript = ''
+              sed -i '/^artifact = "bin"$/d' $out/Cargo.toml
+              sed -i '/^target = ".*"$/d' $out/Cargo.toml
+            '';
+          });
 
-                buildInputs =
-                  pkgs.lib.optional pkgs.stdenv.isDarwin
-                  pkgs.darwin.apple_sdk.frameworks.Security;
-              });
+        commonArtifactArgs = commonArgs // {inherit cargoArtifacts;};
 
-          dynamicBin =
-            buildPackage pkgs
-            ([
-                "wasm32-wasi" # required for tests
-              ]
-              ++ (
-                if system == aarch64-linux
-                then [
-                  "aarch64-unknown-linux-musl"
-                ]
-                else if system == x86_64-linux
-                then [
-                  "x86_64-unknown-linux-musl"
-                  "x86_64-unknown-none" # required for shims
-                ]
-                else []
-              ))
-            {
-              cargoTestFlags = ["wasm::"];
-            };
+        # TODO: Use `--workspace` once https://github.com/enarx/enarx/issues/2270 is resolved
+        #checks.clippy = craneLib.cargoClippy (commonArtifactArgs // {cargoClippyExtraArgs = "--all-targets --workspace -- --deny warnings";});
+        checks.clippy = craneLib.cargoClippy (commonArtifactArgs
+          // {
+            cargoExtraArgs = "-j $NIX_BUILD_CORES --all-features";
 
-          staticBin =
-            buildPackage pkgs.pkgsStatic
-            (
-              if system == aarch64-linux
-              then [
-                "aarch64-unknown-linux-musl"
-              ]
-              else if system == x86_64-linux
-              then [
-                "x86_64-unknown-linux-musl"
-                "x86_64-unknown-none" # required for shims
-              ]
-              else if (system == x86_64-darwin || system == aarch64-darwin)
-              then [
-                "wasm32-wasi" # required for tests
-              ]
-              else []
-            )
-            {
-              CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+          });
+        checks.fmt = craneLib.cargoFmt commonArgs;
 
-              depsBuildBuild = [
-                pkgs.stdenv.cc
-              ];
+        buildPackage = extraArgs:
+          craneLib.buildPackage (commonArtifactArgs
+            // {
+              cargoExtraArgs = "-j $NIX_BUILD_CORES";
+              cargoTestExtraArgs = "wasm::";
 
-              meta.mainProgram = cargo.toml.package.name;
-            };
+              installPhaseCommand = ''
+                mkdir -p $out/bin
+                cp target/''${CARGO_BUILD_TARGET:+''${CARGO_BUILD_TARGET}/}''${CARGO_PROFILE:-release}/enarx $out/bin/enarx
+              '';
+            }
+            // extraArgs);
 
-          aarch64DarwinBin =
-            if system == aarch64-darwin
-            then staticBin
-            else
-              # TODO: Support cross-compilation
-              throw "cross-compilation not supported, use QEMU";
+        nativeBin = buildPackage {};
+        aarch64DarwinBin = buildPackage {
+          CARGO_BUILD_TARGET = "aarch64-apple-darwin";
+          CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+        };
+        aarch64LinuxMuslBin = buildPackage {
+          CARGO_BUILD_TARGET = "aarch64-unknown-linux-musl";
+          CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+        };
+        x86_64DarwinBin = buildPackage {
+          CARGO_BUILD_TARGET = "x86_64-apple-darwin";
+          CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+        };
+        x86_64LinuxMuslBin = buildPackage {
+          CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+          CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+        };
 
-          aarch64LinuxMuslBin =
-            if system == aarch64-linux
-            then staticBin
-            else
-              # TODO: Support cross-compilation
-              throw "cross-compilation not supported, use QEMU";
+        buildImage = bin:
+          final.dockerTools.buildImage {
+            name = "enarx";
+            tag = version;
+            contents = [
+              bin
+            ];
+            config.Cmd = ["enarx"];
+            config.Env = ["PATH=${bin}/bin"];
+          };
+      in {
+        enarx = nativeBin;
+        enarx-aarch64-apple-darwin = aarch64DarwinBin;
+        enarx-aarch64-apple-darwin-oci = buildImage aarch64DarwinBin;
+        enarx-aarch64-unknown-linux-musl = aarch64LinuxMuslBin;
+        enarx-aarch64-unknown-linux-musl-oci = buildImage aarch64LinuxMuslBin;
+        enarx-x86_64-apple-darwin = x86_64DarwinBin;
+        enarx-x86_64-apple-darwin-oci = buildImage x86_64DarwinBin;
+        enarx-x86_64-unknown-linux-musl = x86_64LinuxMuslBin;
+        enarx-x86_64-unknown-linux-musl-oci = buildImage x86_64LinuxMuslBin;
 
-          x86_64DarwinBin =
-            if system == x86_64-darwin
-            then staticBin
-            else
-              # TODO: Support cross-compilation
-              throw "cross-compilation not supported, use QEMU";
-
-          x86_64LinuxMuslBin =
-            if system == x86_64-linux
-            then staticBin
-            else
-              # TODO: Support cross-compilation
-              throw "cross-compilation not supported, use QEMU";
-
-          buildImage = bin:
-            pkgs.dockerTools.buildImage {
-              inherit (cargo.toml.package) name;
-              tag = cargo.toml.package.version;
-              contents = [
-                bin
-              ];
-              config.Cmd = [cargo.toml.package.name];
-              config.Env = ["PATH=${bin}/bin"];
-            };
+        enarxChecks = checks;
+        enarxRustToolchain = rustToolchain;
+      };
+    in
+      {
+        overlays.default = overlay;
+      }
+      // flake-utils.lib.eachSystem [
+        aarch64-darwin
+        aarch64-linux
+        powerpc64le-linux
+        x86_64-darwin
+        x86_64-linux
+      ]
+      (
+        system: let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              # NOTE: Order is important
+              rust-overlay.overlays.default
+              overlay
+            ];
+          };
         in {
           formatter = pkgs.alejandra;
 
+          checks = pkgs.enarxChecks;
+
           packages =
             {
-              default = dynamicBin;
-
-              "${cargo.toml.package.name}" = dynamicBin;
-              "${cargo.toml.package.name}-static" = staticBin;
-              "${cargo.toml.package.name}-static-oci" = buildImage staticBin;
+              default = pkgs.enarx;
             }
-            // pkgs.lib.optionalAttrs (system == aarch64-darwin) {
-              "${cargo.toml.package.name}-aarch64-apple-darwin" = aarch64DarwinBin;
-              "${cargo.toml.package.name}-aarch64-apple-darwin-oci" = buildImage aarch64DarwinBin;
-            }
-            // pkgs.lib.optionalAttrs (system == aarch64-linux) {
-              "${cargo.toml.package.name}-aarch64-unknown-linux-musl" = aarch64LinuxMuslBin;
-              "${cargo.toml.package.name}-aarch64-unknown-linux-musl-oci" = buildImage aarch64LinuxMuslBin;
-            }
-            // pkgs.lib.optionalAttrs (system == x86_64-darwin) {
-              "${cargo.toml.package.name}-x86_64-apple-darwin" = x86_64DarwinBin;
-              "${cargo.toml.package.name}-x86_64-apple-darwin-oci" = buildImage x86_64DarwinBin;
-            }
-            // pkgs.lib.optionalAttrs (system == x86_64-linux) {
-              "${cargo.toml.package.name}-x86_64-unknown-linux-musl" = x86_64LinuxMuslBin;
-              "${cargo.toml.package.name}-x86_64-unknown-linux-musl-oci" = buildImage x86_64LinuxMuslBin;
-            };
+            // pkgs.lib.genAttrs [
+              "enarx"
+              "enarx-aarch64-apple-darwin"
+              "enarx-aarch64-apple-darwin-oci"
+              "enarx-aarch64-unknown-linux-musl"
+              "enarx-aarch64-unknown-linux-musl-oci"
+              "enarx-x86_64-apple-darwin"
+              "enarx-x86_64-apple-darwin-oci"
+              "enarx-x86_64-unknown-linux-musl"
+              "enarx-x86_64-unknown-linux-musl-oci"
+            ] (name: pkgs.${name});
 
           devShells.default = pkgs.mkShell {
             buildInputs = [
-              (fenix.packages.${system}.fromToolchainFile {
-                file = "${self}/rust-toolchain.toml";
-              })
-
+              pkgs.enarxRustToolchain
               pkgs.openssl
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -43,45 +43,57 @@
 
         rustToolchain = prev.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
-        craneLib = (crane.mkLib final).overrideToolchain rustToolchain;
+        # mkCraneLib constructs a crane library for specified `pkgs`.
+        mkCraneLib = pkgs: (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
-        commonArgs = {
+        # hostCraneLib is the crane library for the host native triple.
+        hostCraneLib = mkCraneLib final;
+
+        # commonArgs is a set of arguments that is common to all crane invocations.
+        commonArgs = with final.lib; {
           inherit
             src
             version
             ;
           pname = "enarx";
-
-          buildInputs =
-            final.lib.optional final.stdenv.isDarwin
-            final.darwin.apple_sdk.frameworks.Security;
         };
 
-        cargoArtifacts = craneLib.buildDepsOnly (commonArgs
-          // {
-            cargoExtraArgs = "-j $NIX_BUILD_CORES --all-features";
+        # buildDeps builds dependencies of the crate given `craneLib`.
+        # `extraArgs` are passed through to `craneLib.buildDepsOnly` verbatim.
+        buildDeps = craneLib: extraArgs:
+          craneLib.buildDepsOnly (commonArgs
+            // {
+              cargoExtraArgs = "-j $NIX_BUILD_CORES --all-features";
+              # Remove binary dependency specification, since that breaks on generated "dummy source"
+              extraDummyScript = ''
+                sed -i '/^artifact = "bin"$/d' $out/Cargo.toml
+                sed -i '/^target = ".*"$/d' $out/Cargo.toml
+              '';
+            }
+            // extraArgs);
 
-            # Remove binary dependency specification, since that breaks on generated "dummy source"
-            extraDummyScript = ''
-              sed -i '/^artifact = "bin"$/d' $out/Cargo.toml
-              sed -i '/^target = ".*"$/d' $out/Cargo.toml
-            '';
-          });
-
-        commonArtifactArgs = commonArgs // {inherit cargoArtifacts;};
+        # hostCargoArtifacts are the cargo artifacts built for the host native triple.
+        hostCargoArtifacts = buildDeps hostCraneLib {};
 
         # TODO: Use `--workspace` once https://github.com/enarx/enarx/issues/2270 is resolved
-        #checks.clippy = craneLib.cargoClippy (commonArtifactArgs // {cargoClippyExtraArgs = "--all-targets --workspace -- --deny warnings";});
-        checks.clippy = craneLib.cargoClippy (commonArtifactArgs
+        #checks.clippy = hostCraneLib.cargoClippy (hostArtifactCommonArgs // {cargoClippyExtraArgs = "--all-targets --workspace -- --deny warnings";});
+        checks.clippy = hostCraneLib.cargoClippy (commonArgs
           // {
-            cargoExtraArgs = "-j $NIX_BUILD_CORES --all-features";
-
+            cargoArtifacts = hostCargoArtifacts;
             cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+            cargoExtraArgs = "-j $NIX_BUILD_CORES --all-features";
           });
-        checks.fmt = craneLib.cargoFmt commonArgs;
+        checks.fmt = hostCraneLib.cargoFmt commonArgs;
+        checks.nextest = hostCraneLib.cargoNextest (commonArgs
+          // {
+            cargoArtifacts = hostCargoArtifacts;
+            cargoExtraArgs = "-j $NIX_BUILD_CORES";
+          });
 
-        buildPackage = extraArgs:
-          craneLib.buildPackage (commonArtifactArgs
+        # buildPackage builds using `craneLib`.
+        # `extraArgs` are passed through to `craneLib.buildPackage` verbatim.
+        buildPackage = craneLib: extraArgs:
+          craneLib.buildPackage (commonArgs
             // {
               cargoExtraArgs = "-j $NIX_BUILD_CORES";
               cargoTestExtraArgs = "wasm::";
@@ -93,21 +105,74 @@
             }
             // extraArgs);
 
-        nativeBin = buildPackage {};
-        aarch64DarwinBin = buildPackage {
-          CARGO_BUILD_TARGET = "aarch64-apple-darwin";
+        # hostBin is the binary built for host native triple.
+        hostBin = with final.lib;
+          buildPackage hostCraneLib {
+            buildInputs =
+              optional final.stdenv.isDarwin
+              final.darwin.apple_sdk.frameworks.Security;
+
+            cargoArtifacts = hostCargoArtifacts;
+            cargoExtraArgs = "-j $NIX_BUILD_CORES";
+          };
+
+        # pkgsFor constructs a package set for specified `crossSystem`.
+        pkgsFor = crossSystem: let
+          localSystem = final.hostPlatform.system;
+        in
+          if localSystem == crossSystem
+          then final
+          else if crossSystem == x86_64-darwin
+          then throw "cross compilation to x86_64-darwin not supported due to https://github.com/NixOS/nixpkgs/issues/180771"
+          else
+            import nixpkgs {
+              inherit
+                crossSystem
+                localSystem
+                ;
+            };
+
+        # buildPackageFor builds for `target` using `crossSystem` toolchain.
+        # `extraArgs` are passed through to `buildPackage` verbatim.
+        # NOTE: Upstream only provides binary caches for a subset of supported systems.
+        buildPackageFor = crossSystem: target: extraArgs:
+          with final.lib; let
+            pkgs = pkgsFor crossSystem;
+            cc = pkgs.stdenv.cc;
+            kebab2snake = replaceStrings ["-"] ["_"];
+            commonCrossArgs = {
+              depsBuildBuild = [
+                cc
+              ];
+
+              buildInputs =
+                optional pkgs.stdenv.isDarwin
+                pkgs.darwin.apple_sdk.frameworks.Security;
+
+              CARGO_BUILD_TARGET = target;
+              ${"CARGO_TARGET_${toUpper (kebab2snake target)}_LINKER"} = "${cc.targetPrefix}cc";
+            };
+            craneLib = mkCraneLib pkgs;
+          in
+            buildPackage craneLib (commonCrossArgs
+              // {
+                cargoArtifacts = buildDeps craneLib commonCrossArgs;
+              }
+              // extraArgs);
+
+        aarch64DarwinBin = buildPackageFor aarch64-darwin "aarch64-apple-darwin" {
           CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
         };
-        aarch64LinuxMuslBin = buildPackage {
-          CARGO_BUILD_TARGET = "aarch64-unknown-linux-musl";
+
+        aarch64LinuxMuslBin = buildPackageFor aarch64-linux "aarch64-unknown-linux-musl" {
           CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
         };
-        x86_64DarwinBin = buildPackage {
-          CARGO_BUILD_TARGET = "x86_64-apple-darwin";
+
+        x86_64DarwinBin = buildPackageFor x86_64-darwin "x86_64-apple-darwin" {
           CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
         };
-        x86_64LinuxMuslBin = buildPackage {
-          CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+
+        x86_64LinuxMuslBin = buildPackageFor x86_64-linux "x86_64-unknown-linux-musl" {
           CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
         };
 
@@ -122,7 +187,7 @@
             config.Env = ["PATH=${bin}/bin"];
           };
       in {
-        enarx = nativeBin;
+        enarx = hostBin;
         enarx-aarch64-apple-darwin = aarch64DarwinBin;
         enarx-aarch64-apple-darwin-oci = buildImage aarch64DarwinBin;
         enarx-aarch64-unknown-linux-musl = aarch64LinuxMuslBin;
@@ -161,21 +226,26 @@
 
           checks = pkgs.enarxChecks;
 
-          packages =
+          packages = with pkgs.lib;
             {
               default = pkgs.enarx;
             }
-            // pkgs.lib.genAttrs [
-              "enarx"
-              "enarx-aarch64-apple-darwin"
-              "enarx-aarch64-apple-darwin-oci"
-              "enarx-aarch64-unknown-linux-musl"
-              "enarx-aarch64-unknown-linux-musl-oci"
-              "enarx-x86_64-apple-darwin"
-              "enarx-x86_64-apple-darwin-oci"
-              "enarx-x86_64-unknown-linux-musl"
-              "enarx-x86_64-unknown-linux-musl-oci"
-            ] (name: pkgs.${name});
+            // genAttrs ([
+                "enarx"
+                "enarx-aarch64-unknown-linux-musl"
+                "enarx-aarch64-unknown-linux-musl-oci"
+                "enarx-x86_64-unknown-linux-musl"
+                "enarx-x86_64-unknown-linux-musl-oci"
+              ]
+              ++ optionals (system == aarch64-darwin || system == x86_64-darwin) [
+                "enarx-aarch64-apple-darwin"
+                "enarx-aarch64-apple-darwin-oci"
+              ]
+              ++ optionals (system == x86_64-darwin) [
+                # cross compilation to x86_64-darwin not supported due to https://github.com/NixOS/nixpkgs/issues/180771
+                "enarx-x86_64-apple-darwin"
+                "enarx-x86_64-apple-darwin-oci"
+              ]) (name: pkgs.${name});
 
           devShells.default = pkgs.mkShell {
             buildInputs = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,12 @@
 [toolchain]
 channel = "nightly-2022-09-15"
-targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-unknown-none", "wasm32-wasi"]
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-musl",
+    "wasm32-wasi",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-musl",
+    "x86_64-unknown-none"
+]
 profile = "minimal"
 components = ["rustfmt", "clippy", "miri", "rust-src"]

--- a/src/backend/sgx/attestation.rs
+++ b/src/backend/sgx/attestation.rs
@@ -444,7 +444,7 @@ mod tests {
         ignore = "CPU does not support SGX2 or attestation not possible"
     )]
     fn request_target_info() {
-        assert_eq!(std::path::Path::new(AESM_SOCKET).exists(), true);
+        assert!(std::path::Path::new(AESM_SOCKET).exists());
 
         let mut output = [1u8; SGX_TI_SIZE];
 

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -211,5 +211,5 @@ fn test_config_init() {
     env::set_current_dir(tmpdir.path()).unwrap();
     cmd!(succeed: "enarx config init");
     cmd!(fail: "enarx config init", text: r#"Error: "Enarx.toml" does already exist."#);
-    assert_eq!(Path::new("Enarx.toml").exists(), true);
+    assert!(Path::new("Enarx.toml").exists());
 }

--- a/tests/client/util.rs
+++ b/tests/client/util.rs
@@ -93,7 +93,7 @@ pub fn enarx(args: String, expected_success: bool, expected_output: Output) {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Output {
     Json(Value),
     Text(String),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -61,7 +61,7 @@ fn tee(r: impl Read, mut w: impl Write) -> io::Result<Vec<u8>> {
         .bytes()
         .map(|b| {
             let b = b?;
-            w.write(&[b])?;
+            w.write_all(&[b])?;
             Ok(b)
         })
         .collect()
@@ -71,7 +71,7 @@ fn enarx<'a>(
     cmd: impl FnOnce(&mut Command) -> &mut Command,
     input: impl Into<Option<&'a [u8]>>,
 ) -> Output {
-    let mut child = cmd(Command::new(&KEEP_BIN)
+    let mut child = cmd(Command::new(KEEP_BIN)
         .current_dir(CRATE)
         .env(
             "ENARX_TEST_SGX_KEY_FILE",

--- a/tests/wasm/mod.rs
+++ b/tests/wasm/mod.rs
@@ -305,7 +305,7 @@ name = "stream""#,
         let (stream, _) = listener.accept().expect("failed to accept connection");
         assert_stream(stream).expect("failed to assert stream");
     });
-    check_output(&enarx_run(&wasm, Some(&conf.path()), None), 0, None, None);
+    check_output(&enarx_run(&wasm, Some(conf.path()), None), 0, None, None);
     server.join().expect("failed to join server thread");
     Ok(())
 }
@@ -386,7 +386,7 @@ name = "stream""#,
 //        let tls = rustls::ServerConnection::new(tls).expect("failed to create TLS connection");
 //        assert_stream(rustls::StreamOwned::new(tls, stream)).expect("failed to assert stream");
 //    });
-//    check_output(&enarx_run(&wasm, Some(&conf.path()), None), 0, None, None);
+//    check_output(&enarx_run(&wasm, Some(conf.path()), None), 0, None, None);
 //    server.join().expect("failed to join server thread");
 //    Ok(())
 //}
@@ -460,7 +460,7 @@ name = "ping""#,
         })
         .expect("failed to assert TCP connection");
     });
-    check_output(&enarx_run(&wasm, Some(&conf.path()), None), 0, None, None);
+    check_output(&enarx_run(&wasm, Some(conf.path()), None), 0, None, None);
     client.join().expect("failed to join client thread");
     Ok(())
 }
@@ -548,7 +548,7 @@ name = "ping""#,
         })
         .expect("failed to assert TLS connection");
     });
-    check_output(&enarx_run(&wasm, Some(&conf.path()), None), 0, None, None);
+    check_output(&enarx_run(&wasm, Some(conf.path()), None), 0, None, None);
     client.join().expect("failed to join client thread");
     Ok(())
 }


### PR DESCRIPTION
- Git dependencies are now supported out-of-the-box
- The build is greatly simplified
- Caching performance should be improved
- `cargo clippy`, `cargo fmt` and `cargo nextest` are now run in release mode on `nix flake check`
- All binaries except for Windows are now cross-compiled via nix on Github default runners