### PR TITLE
chore: remove apt call on self-hosted runners

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,8 +52,10 @@ jobs:
             host: [ self-hosted, linux, x64 ]
 
     steps:
-      - run: sudo apt -o Acquire::Retries=3 update
-      - run: sudo apt -o Acquire::Retries=3 install -y musl-tools lcov
+      - if: matrix.crate.name == 'nil'
+        run: | 
+          sudo apt -o Acquire::Retries=3 update
+          sudo apt -o Acquire::Retries=3 install -y musl-tools lcov
       - name: Cleanup working directory
         run: rm -fr * $HOME/.cargo $HOME/.rustup
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
     env:
         ENARX_BACKEND: ${{ matrix.backend.name }}
     steps:
-      - run: sudo apt -o Acquire::Retries=3 update
-      - run: sudo apt -o Acquire::Retries=3 install -y musl-tools curl
       - name: Cleanup working directory
         run: rm -fr * $HOME/.cargo $HOME/.rustup
       - uses: actions/checkout@v2


### PR DESCRIPTION
Our self-hosted runners now have the tools installed, so apt is no longer required there.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>