### PR TITLE
build: bump Rust toolchain to 2022-11-04

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,11 +61,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-09-15 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-11-04 -y
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-09-15
+          toolchain: nightly-2022-11-04
           profile: minimal
           components: llvm-tools-preview
 

--- a/.github/workflows/sbom_manifest_action.yml
+++ b/.github/workflows/sbom_manifest_action.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-musl
-          toolchain: nightly-2022-09-15
+          toolchain: nightly-2022-11-04
           override: true
 
       - name: Install cargo-cyclonedx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-09-15 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-11-04 -y
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-09-15
+          toolchain: nightly-2022-11-04
           profile: minimal
 
       - uses: actions-rs/cargo@v1

--- a/crates/exec-wasmtime/src/runtime/net/tls.rs
+++ b/crates/exec-wasmtime/src/runtime/net/tls.rs
@@ -252,7 +252,7 @@ impl WasiFile for Stream {
         // TODO: Add support for peek and waitall
         // https://github.com/enarx/enarx/issues/2243
         let n = self.read_vectored(ri_data).await?;
-        Ok((n as u64, RoFlags::empty()))
+        Ok((n, RoFlags::empty()))
     }
 
     async fn sock_send<'a>(
@@ -265,7 +265,7 @@ impl WasiFile for Stream {
         }
 
         let n = self.write_vectored(si_data).await?;
-        Ok(n as u64)
+        Ok(n)
     }
 
     async fn sock_shutdown(&mut self, how: SdFlags) -> Result<(), Error> {

--- a/crates/sallyport/src/guest/handler.rs
+++ b/crates/sallyport/src/guest/handler.rs
@@ -293,7 +293,7 @@ pub trait Handler {
                     let mut timeout = *t;
                     timeout.tv_sec += cur_time.tv_sec;
                     timeout.tv_nsec += cur_time.tv_nsec;
-                    timeout.tv_sec += (timeout.tv_nsec / 1_000_000_000) as i64;
+                    timeout.tv_sec += timeout.tv_nsec / 1_000_000_000;
                     timeout.tv_nsec %= 1_000_000_000;
                     timeout
                 });

--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -11,7 +11,7 @@
 #![cfg_attr(not(test), no_std)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
-#![feature(asm_const, asm_sym, c_size_t, naked_functions)]
+#![feature(asm_const, c_size_t, naked_functions)]
 #![warn(rust_2018_idioms)]
 #![cfg_attr(coverage, feature(no_coverage))]
 

--- a/crates/shim-kvm/src/main.rs
+++ b/crates/shim-kvm/src/main.rs
@@ -8,7 +8,7 @@
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![no_main]
-#![feature(asm_const, asm_sym, naked_functions)]
+#![feature(asm_const, naked_functions)]
 #![cfg_attr(coverage, feature(no_coverage))]
 
 #[allow(unused_extern_crates)]

--- a/crates/shim-kvm/src/paging.rs
+++ b/crates/shim-kvm/src/paging.rs
@@ -23,7 +23,7 @@ pub struct EncPhysOffset {
 impl Default for EncPhysOffset {
     fn default() -> Self {
         EncPhysOffset {
-            offset: VirtAddr::new(SHIM_VIRT_OFFSET as u64),
+            offset: VirtAddr::new(SHIM_VIRT_OFFSET),
             c_bit_mask: get_cbit_mask(),
         }
     }

--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -133,7 +133,7 @@ impl<'a> Write for Handler<'a> {
         while written < len {
             written += self
                 .write(STDERR_FILENO, &buf[written..])
-                .map_err(|_| core::fmt::Error)? as usize;
+                .map_err(|_| core::fmt::Error)?;
         }
         Ok(())
     }

--- a/crates/shim-sgx/src/main.rs
+++ b/crates/shim-sgx/src/main.rs
@@ -6,7 +6,7 @@
 //! instructions) from the enclave code and proxies them to the host.
 
 #![no_std]
-#![feature(asm_const, asm_sym, naked_functions)]
+#![feature(asm_const, naked_functions)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-09-15"
+channel = "nightly-2022-11-04"
 targets = [
     "aarch64-apple-darwin",
     "aarch64-unknown-linux-musl",

--- a/src/backend/kvm/thread.rs
+++ b/src/backend/kvm/thread.rs
@@ -100,7 +100,7 @@ impl<P: KeepPersonality> Thread<P> {
                 ..
             } => {
                 *ret = match self.meminfo() {
-                    Ok(n) => n as usize,
+                    Ok(n) => n,
                     Err(e) => -e as usize,
                 };
                 Ok(None)
@@ -112,7 +112,7 @@ impl<P: KeepPersonality> Thread<P> {
                 ret,
             } => {
                 *ret = match self.balloon(*log2, *npgs, *addr) {
-                    Ok(n) => n as usize,
+                    Ok(n) => n,
                     Err(e) => -e as usize,
                 };
                 Ok(None)
@@ -138,8 +138,7 @@ impl<P: KeepPersonality> super::super::Thread for Thread<P> {
                 let block: Block = unsafe {
                     std::slice::from_raw_parts_mut(
                         block_virt.as_mut_ptr::<usize>(),
-                        self.keep.read().unwrap().sallyport_block_size as usize
-                            / size_of::<usize>(),
+                        self.keep.read().unwrap().sallyport_block_size / size_of::<usize>(),
                     )
                 }
                 .into();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -278,7 +278,7 @@ pub static BACKENDS: Lazy<Vec<Box<dyn Backend>>> = Lazy::new(|| {
         Box::new(kvm::Backend),
         #[cfg(not(enarx_with_shim))]
         Box::new(NotSupportedBackend("kvm")),
-        Box::new(nil::Backend::default()),
+        Box::<nil::Backend>::default(),
     ]
 });
 
@@ -328,7 +328,7 @@ pub(super) unsafe fn execute_gdb(
                 }
 
                 *ret = match res {
-                    Ok(n) => n as usize,
+                    Ok(n) => n,
                     Err(e) => -e as usize,
                 };
             } else {
@@ -400,7 +400,7 @@ pub(super) unsafe fn execute_gdb(
                 .map(|_| 0usize)
                 .map_err(|e| e.raw_os_error().unwrap_or(libc::EINVAL));
             *ret = match res {
-                Ok(n) => n as usize,
+                Ok(n) => n,
                 Err(e) => -e as usize,
             };
             Ok(())
@@ -420,7 +420,7 @@ pub(super) unsafe fn execute_gdb(
                 .map_err(|e| e.raw_os_error().unwrap_or(libc::EINVAL));
 
             *ret = match res {
-                Ok(n) => n as usize,
+                Ok(n) => n,
                 Err(e) => -e as usize,
             };
             Ok(())

--- a/src/backend/sev/snp/launch/linux.rs
+++ b/src/backend/sev/snp/launch/linux.rs
@@ -92,7 +92,7 @@ impl<'a, T: Id> Command<'a, T> {
     pub fn encapsulate(&self, err: std::io::Error) -> Indeterminate<Error> {
         match self.error {
             0 => Indeterminate::<Error>::from(err),
-            _ => Indeterminate::<Error>::from(self.error as u32),
+            _ => Indeterminate::<Error>::from(self.error),
         }
     }
 }

--- a/src/cli/unstable/exec.rs
+++ b/src/cli/unstable/exec.rs
@@ -56,7 +56,7 @@ impl Options {
         use mmarinus::{perms, Map, Private};
 
         let backend = backend.pick()?;
-        let binary = Map::load(&binpath, Private, perms::Read)?;
+        let binary = Map::load(binpath, Private, perms::Read)?;
 
         let signatures = if unsigned {
             None

--- a/tests/crates/enarx_syscall_tests/src/bin/bind.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/bind.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/clock_gettime.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/clock_gettime.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/close.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/close.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/exit_one.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/exit_one.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/exit_zero.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/exit_zero.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/get_att.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/get_att.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/getegid.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/getegid.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/geteuid.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/geteuid.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/getgid.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/getgid.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/getuid.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/getuid.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/listen.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/listen.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/read.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/read.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/read_udp.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/read_udp.rs
@@ -5,7 +5,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/readv.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/readv.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/sgx_get_att_quote.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/sgx_get_att_quote.rs
@@ -8,7 +8,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/socket.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/socket.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/uname.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/uname.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/write_emsgsize.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/write_emsgsize.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/write_stderr.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/write_stderr.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 

--- a/tests/crates/enarx_syscall_tests/src/bin/write_stdout.rs
+++ b/tests/crates/enarx_syscall_tests/src/bin/write_stdout.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_sym)]
+#![feature(naked_functions)]
 
 enarx_syscall_tests::startup!();
 


### PR DESCRIPTION
This also removes the now-unnecessary `asm_sym` feature flag and updates some code to account for new clippy lints.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
