### PR TITLE
feat(cli): support passing `enarx run` configuration via CLI

### DIFF
--- a/crates/enarx-config/Cargo.toml
+++ b/crates/enarx-config/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [".github/"]
 
 [dependencies]
 serde = { workspace = true }
+toml = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -74,6 +74,7 @@ impl<P: KeepPersonality> Keep<P> {
     }
 }
 
+#[derive(Debug)]
 pub struct Backend;
 
 impl crate::backend::Backend for Backend {

--- a/src/backend/nil.rs
+++ b/src/backend/nil.rs
@@ -5,15 +5,15 @@ use std::sync::{Arc, RwLock};
 use crate::backend::Signatures;
 use anyhow::{bail, Result};
 #[cfg(windows)]
-use enarx_exec_wasmtime::Args;
+use enarx_exec_wasmtime::Package;
 
 #[cfg(unix)]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Backend;
 
 #[cfg(windows)]
-#[derive(Default)]
-pub struct Backend(RwLock<Option<Args>>);
+#[derive(Debug, Default)]
+pub struct Backend(RwLock<Option<Package>>);
 
 impl crate::backend::Backend for Backend {
     #[inline]
@@ -83,7 +83,7 @@ impl crate::backend::Backend for Backend {
     }
 
     #[cfg(windows)]
-    fn set_args(&self, args: Args) {
+    fn set_args(&self, args: Package) {
         self.0.write().unwrap().replace(args);
     }
 }
@@ -100,7 +100,7 @@ impl super::Keep for RwLock<Keep> {
 struct Thread;
 
 #[cfg(windows)]
-struct Thread(Option<Args>);
+struct Thread(Option<Package>);
 
 impl super::Thread for Thread {
     fn enter(&mut self, _gdblisten: &Option<String>) -> Result<super::Command> {

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -78,6 +78,7 @@ impl KeepPersonality for SnpKeepPersonality {
     }
 }
 
+#[derive(Debug)]
 pub struct Backend;
 
 impl super::Backend for Backend {

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -36,6 +36,7 @@ impl Keep {
     }
 }
 
+#[derive(Debug)]
 pub struct Backend;
 
 impl crate::backend::Backend for Backend {

--- a/src/cli/unstable/exec.rs
+++ b/src/cli/unstable/exec.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cli::BackendOptions;
+use crate::backend::Backend;
 
 use camino::Utf8PathBuf;
 use clap::Args;
@@ -17,8 +17,8 @@ use clap::Args;
 /// development and integration tests.
 #[derive(Args, Debug)]
 pub struct Options {
-    #[clap(flatten)]
-    pub backend: BackendOptions,
+    #[clap(long, env = "ENARX_BACKEND")]
+    pub backend: Option<&'static dyn Backend>,
 
     /// Binary to load and run inside the keep
     #[clap(value_name = "BINARY")]
@@ -55,7 +55,7 @@ impl Options {
         use crate::exec::keep_exec;
         use mmarinus::{perms, Map, Private};
 
-        let backend = backend.pick()?;
+        let backend = backend.unwrap_or_default();
         let binary = Map::load(binpath, Private, perms::Read)?;
 
         let signatures = if unsigned {


### PR DESCRIPTION
`enarx deploy` isn't modified because the plan is to merge `enarx deploy` into `enarx run` in the near future.

Closes #2281.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
