### PR TITLE
feat(drawbridge): specify OIDC scopes and audience

### DIFF
--- a/src/cli/user/login.rs
+++ b/src/cli/user/login.rs
@@ -16,6 +16,8 @@ pub struct Options {
     oidc_client_id: String,
     #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
     credential_helper: Option<OsString>,
+    #[clap(long, default_value = "store.profian.com")]
+    store_host: String,
 }
 
 impl Options {
@@ -24,9 +26,10 @@ impl Options {
             ref oidc_domain,
             oidc_client_id,
             ref credential_helper,
+            store_host,
         } = self;
 
-        login(oidc_domain, oidc_client_id, credential_helper)?;
+        login(&store_host, oidc_domain, oidc_client_id, credential_helper)?;
 
         println!("Login successful.");
 

--- a/src/cli/user/register.rs
+++ b/src/cli/user/register.rs
@@ -46,9 +46,19 @@ impl Options {
         } = self;
 
         // If we don't find a token saved locally, initiate an interactive login
-        let token = match get_token(oidc_domain, insecure_auth_token, credential_helper) {
+        let token = match get_token(
+            &spec.host,
+            oidc_domain,
+            insecure_auth_token,
+            credential_helper,
+        ) {
             Ok(token) => token,
-            _ => login(oidc_domain, oidc_client_id.clone(), credential_helper)?,
+            _ => login(
+                &spec.host,
+                oidc_domain,
+                oidc_client_id.clone(),
+                credential_helper,
+            )?,
         };
 
         let cl = client(


### PR DESCRIPTION
Specify OpenID Connect audience and scopes, so the tokens are properly restricted to the environment/API they are intended for.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>