### PR TITLE
test: fix tests when RUST_BACKTRACE is set

### DIFF
--- a/tests/client/util.rs
+++ b/tests/client/util.rs
@@ -52,6 +52,12 @@ macro_rules! cmd {
 pub fn enarx(args: String, expected_success: bool, expected_output: Output) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_enarx"));
 
+    // Disable RUST_BACKTRACE when running the tests so as not to cause spurious
+    // failures when comparing the actual output to the expected output.
+    // This is convenient for users who have RUST_BACKTRACE set by default
+    // in their development environment and want to run the tests.
+    cmd.env_remove("RUST_BACKTRACE");
+
     for arg in args.split_whitespace().skip(1) {
         cmd.arg(arg);
     }


### PR DESCRIPTION
Closes #2312.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
