### PR TITLE
build(nix): unpin `nixify`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,15 +17,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1666145618,
-        "narHash": "sha256-JG5UNASFzfzFmU0OktCASVDTCm5p71rtMnUcATBD2Y8=",
+        "lastModified": 1667064003,
+        "narHash": "sha256-VuP+wzlUmuEqx43b8WOodjXJgFMlyQv/cNL4CdFcSqM=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "097afacc53a0a5fc23c212e5fe2a337ea53cdf0b",
+        "rev": "f48777a96601e8fa3f537f3cab22d7a858bcde19",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
+        "ref": "v0.9.0",
         "repo": "crane",
         "type": "github"
       }
@@ -48,26 +49,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -81,35 +67,30 @@
         "crane": "crane",
         "flake-utils": "flake-utils",
         "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-overlay": [
-          "rust-overlay"
-        ]
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1666207511,
-        "narHash": "sha256-PoRX6egul9xnDIGjwat0FCfCVW1/2m3vcG3TroGKhcg=",
+        "lastModified": 1668595154,
+        "narHash": "sha256-/fbBKrmTfbKvrj/vg2JSQdPuWm2R+CEtwtDMlZUhSME=",
         "owner": "rvolosatovs",
         "repo": "nixify",
-        "rev": "e87cbcb1ba3f43dbf99901312c70e6d566a21fb6",
+        "rev": "0825608f8aa19a66082aa8719d1d47fb52ada542",
         "type": "github"
       },
       "original": {
         "owner": "rvolosatovs",
         "repo": "nixify",
-        "rev": "e87cbcb1ba3f43dbf99901312c70e6d566a21fb6",
         "type": "github"
       }
     },
     "nixlib": {
       "locked": {
-        "lastModified": 1665882590,
-        "narHash": "sha256-+kIvUKZe7RCjwg4NX2pMhO4CN9VplGtTl/XK5XDR2Zo=",
+        "lastModified": 1668300937,
+        "narHash": "sha256-E9/ir9++M58btaHOqugyrE4lfVnM0gIq5M9QWhGX0aM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "07aca231dce1aa0a744bedca29dd3e702eb0343c",
+        "rev": "41386dc5b4915d0d5716e9d09dbf372ea3bd24f3",
         "type": "github"
       },
       "original": {
@@ -134,33 +115,21 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1665296151,
-        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "nixify": "nixify",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "nixify": "nixify"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "flake-utils": [
+          "nixify",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixify",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1668393806,

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,7 @@
 {
   description = "Tools for deploying WebAssembly into Enarx Keeps.";
 
-  # NOTE: https://github.com/rvolosatovs/nixify/commit/e714e8244d3736c6bd3168f4de87f519db4a507c following this commit
-  # introduced a bug, once that is fixed the dependency should be unpinned
-  inputs.nixify.url = github:rvolosatovs/nixify/e87cbcb1ba3f43dbf99901312c70e6d566a21fb6;
-
-  # Temporary override transitive `nixify` dependencies to benefit from updates.
-  inputs.nixify.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.nixify.inputs.rust-overlay.follows = "rust-overlay";
-  inputs.nixpkgs.url = github:nixos/nixpkgs/nixpkgs-22.05-darwin;
-  inputs.rust-overlay.url = github:oxalica/rust-overlay;
+  inputs.nixify.url = github:rvolosatovs/nixify;
 
   outputs = {nixify, ...}: let
   in
@@ -44,6 +36,8 @@
         clippy.allFeatures = true;
         clippy.allTargets = true;
         clippy.deny = ["warnings"];
+
+        targets.x86_64-unknown-none = false;
 
         buildOverrides = {
           pkgs,


### PR DESCRIPTION
The upstream bug regarding workspace handling is now fixed, unpin
Closes #2306 
Closes #2345 