### PR TITLE
ci: update workflows to environment files

### DIFF
--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -27,7 +27,7 @@ jobs:
           git reset --hard origin/main
           for i in $(find . -name Cargo.toml); do cargo update --manifest-path=$i; done
           git diff --quiet && git diff --staged --quiet || git commit -am 'chore(deps): cargo update to update dependencies' && \
-            git push --force origin chore/cargo-update && echo "::set-output name=updated::0"
+            git push --force origin chore/cargo-update && echo "updated=0" >>$GITHUB_OUTPUT
         shell: bash
       - name: Create pull request
         if: steps.update_dependencies.outputs.updated == 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
       with:
         name: "enarx-x86_64-unknown-linux-musl-sig"
     - id: version
-      run: echo "::set-output name=version::$(cargo metadata --format-version=1 --no-deps | jq '.packages[] | select(.name == "enarx") | .version' --raw-output)"
+      run: echo "version=$(cargo metadata --format-version=1 --no-deps | jq '.packages[] | select(.name == "enarx") | .version' --raw-output)" >>$GITHUB_OUTPUT
     - run: |
         rpmbuild -bb release/linux/rpm/enarx.spec \
         --define "%source_binary `pwd`/enarx-${{ matrix.architecture }}-unknown-linux-musl" \
@@ -239,7 +239,7 @@ jobs:
       with:
         name: "enarx-x86_64-unknown-linux-musl-sig"
     - id: version
-      run: echo "::set-output name=version::$(cargo metadata --format-version=1 --no-deps | jq '.packages[] | select(.name == "enarx") | .version' --raw-output)"
+      run: echo "version=$(cargo metadata --format-version=1 --no-deps | jq '.packages[] | select(.name == "enarx") | .version' --raw-output)" >>$GITHUB_OUTPUT
     - run: |
         mkdir -p dpkg dpkg/DEBIAN dpkg/usr/bin
         cat release/linux/deb/control | sed -e 's/VERSION/${{ steps.version.outputs.version }}/' -e 's/ARCH/${{ matrix.architecture.debarch }}/' > dpkg/DEBIAN/control
@@ -314,7 +314,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: version
-      run: echo "::set-output name=version::$(cargo metadata --format-version=1 --no-deps | jq '.packages[] | select(.name == "enarx") | .version' --raw-output)"
+      run: echo "version=$(cargo metadata --format-version=1 --no-deps | jq '.packages[] | select(.name == "enarx") | .version' --raw-output)" >>$GITHUB_OUTPUT
     - uses: actions/download-artifact@v3
       with:
         name: enarx-x86_64-windows

--- a/.github/workflows/rust-toolchain-update.yml
+++ b/.github/workflows/rust-toolchain-update.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Generate rust toolchain snapshot version
         id: toolchain_version
-        run: echo "::set-output name=toolchain_version::nightly-$(date +%Y-%m-%d)"
+        run: echo "toolchain_version=nightly-$(date +%Y-%m-%d)" >>$GITHUB_OUTPUT
       - uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
@@ -31,7 +31,7 @@ jobs:
           sed -i "s/channel = .*/channel = \"${{ steps.toolchain_version.outputs.toolchain_version }}\"/" rust-toolchain.toml
           git diff --quiet && git diff --staged --quiet || git commit -am "chore(deps): bump rust toolchain to version ${{ steps.toolchain_version.outputs.toolchain_version }}" && \
             git push --force origin chore/update-rust-toolchain && \
-            echo "::set-output name=updated::0"
+            echo "updated=0" >>$GITHUB_OUTPUT
         shell: bash
       - name: Create pull request
         if: steps.update_rust_toolchain.outputs.updated == 0


### PR DESCRIPTION
GitHub is deprecating the set-output command[1], so let's update to the new environment file syntax.

[1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>