### PR TITLE
feat(drawbridge): add client secrets login

### DIFF
--- a/src/cli/user/login.rs
+++ b/src/cli/user/login.rs
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::drawbridge::login;
+use crate::drawbridge::{login, LoginContext, LoginCredentials};
 
 use std::ffi::OsString;
 
-use clap::Args;
+use anyhow::Context;
+use clap::{Args, ValueEnum};
 use oauth2::url::Url;
 
+#[derive(Debug, Clone, ValueEnum)]
+enum LoginMethod {
+    ClientCredentials,
+    DeviceAuthorization,
+}
 /// Log in to an Enarx package host and save credentials locally.
 #[derive(Args, Debug)]
 pub struct Options {
@@ -14,6 +20,9 @@ pub struct Options {
     oidc_domain: Url,
     #[clap(long, default_value = "4NuaJxkQv8EZBeJKE56R57gKJbxrTLG2")]
     oidc_client_id: String,
+    #[clap(long)]
+    #[arg(value_enum)]
+    login_method: LoginMethod,
     #[clap(long, env = "ENARX_CREDENTIAL_HELPER")]
     credential_helper: Option<OsString>,
     #[clap(long, default_value = "store.profian.com")]
@@ -23,13 +32,30 @@ pub struct Options {
 impl Options {
     pub fn execute(self) -> anyhow::Result<()> {
         let Self {
-            ref oidc_domain,
+            oidc_domain,
             oidc_client_id,
-            ref credential_helper,
+            login_method,
+            credential_helper,
             store_host,
         } = self;
 
-        login(&store_host, oidc_domain, oidc_client_id, credential_helper)?;
+        let oidc_credentials = match login_method {
+            LoginMethod::ClientCredentials => LoginCredentials::ClientCredentials {
+                client_id: oidc_client_id,
+                client_secret: std::env::var("ENARX_OIDC_CLIENT_SECRET")
+                    .context("Error getting the ENARX_OIDC_CLIENT_SECRET value")?,
+            },
+            LoginMethod::DeviceAuthorization => LoginCredentials::DeviceAuthorization {
+                client_id: oidc_client_id,
+            },
+        };
+
+        login(LoginContext {
+            host: store_host,
+            oidc_domain,
+            credentials: oidc_credentials,
+            helper: credential_helper,
+        })?;
 
         println!("Login successful.");
 

--- a/src/cli/user/register.rs
+++ b/src/cli/user/register.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::drawbridge::{client, get_token, login, UserSpec};
+use crate::drawbridge::{client, get_token, login, LoginContext, LoginCredentials, UserSpec};
 
 use std::ffi::OsString;
 
@@ -53,12 +53,14 @@ impl Options {
             credential_helper,
         ) {
             Ok(token) => token,
-            _ => login(
-                &spec.host,
-                oidc_domain,
-                oidc_client_id.clone(),
-                credential_helper,
-            )?,
+            _ => login(LoginContext {
+                host: spec.host.clone(),
+                oidc_domain: oidc_domain.clone(),
+                credentials: LoginCredentials::DeviceAuthorization {
+                    client_id: oidc_client_id.clone(),
+                },
+                helper: credential_helper.clone(),
+            })?,
         };
 
         let cl = client(

--- a/src/drawbridge.rs
+++ b/src/drawbridge.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Borrow;
 use std::convert::TryInto;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{stderr, Write};
 use std::process::{Command, Stdio};
@@ -17,10 +17,18 @@ use drawbridge_client::Client;
 use oauth2::basic::BasicClient;
 use oauth2::devicecode::StandardDeviceAuthorizationResponse;
 use oauth2::url::Url;
-use oauth2::{AuthType, AuthUrl, ClientId, DeviceAuthorizationUrl, Scope, TokenResponse, TokenUrl};
+use oauth2::{
+    AuthType, AuthUrl, ClientId, ClientSecret, DeviceAuthorizationUrl, Scope, TokenResponse,
+    TokenUrl,
+};
 use rustls::{Certificate, RootCertStore};
 
 const DEFAULT_HOST: &str = "store.profian.com";
+const OAUTH_SCOPES: &[&str] = &[
+    "manage:drawbridge_users",
+    "manage:drawbridge_repositories",
+    "manage:drawbridge_tags",
+];
 
 #[derive(Clone, Debug)]
 pub struct UserSpec {
@@ -189,12 +197,11 @@ fn http_client(mut req: oauth2::HttpRequest) -> Result<oauth2::HttpResponse, oau
     oauth2::ureq::http_client(req)
 }
 
-pub fn login(
-    host: &str,
+fn get_oauth2_client(
     oidc_domain: &impl Borrow<Url>,
     oidc_client_id: String,
-    helper: &Option<impl AsRef<OsStr>>,
-) -> anyhow::Result<String> {
+    oidc_client_secret: Option<String>,
+) -> anyhow::Result<BasicClient> {
     let oidc_domain = oidc_domain.borrow();
     let dev_auth_url = DeviceAuthorizationUrl::new(format!("{oidc_domain}oauth/device/code"))
         .context("Failed to construct device authorization URL")?;
@@ -203,49 +210,28 @@ pub fn login(
     let token_url = TokenUrl::new(format!("{oidc_domain}oauth/token"))
         .context("Failed to construct token URL")?;
 
-    let client = BasicClient::new(
+    Ok(BasicClient::new(
         ClientId::new(oidc_client_id),
-        None,
+        oidc_client_secret.map(ClientSecret::new),
         auth_url,
         Some(token_url),
     )
     .set_auth_type(AuthType::RequestBody)
-    .set_device_authorization_url(dev_auth_url);
+    .set_device_authorization_url(dev_auth_url))
+}
 
-    let details: StandardDeviceAuthorizationResponse = client
-        .exchange_device_code()
-        .context("Failed to construct device authorization request")?
-        .add_scope(Scope::new("openid".into()))
-        .add_scope(Scope::new("profile".into()))
-        .add_scope(Scope::new("manage:drawbridge_users".into()))
-        .add_scope(Scope::new("manage:drawbridge_repositories".into()))
-        .add_scope(Scope::new("manage:drawbridge_tags".into()))
-        .add_extra_param("audience", format!("https://{}/", host))
-        .request(http_client)
-        .context("Failed to request device code")?;
-
-    println!(
-        "To continue, open the following link in your browser:\n\
-         \t{}\n\
-         At the prompt, enter the following one-time code:\n\
-         \t{}\n\
-         Once entered, please wait a few moments for authorization to complete.",
-        details.verification_uri().as_str(),
-        details.user_code().secret()
-    );
-
-    let res = client
-        .exchange_device_access_token(&details)
-        .request(http_client, poll_delay, None)
-        .context("Failed to exchange device code for a token")?;
-
-    // TODO: graceful timeout, so that users are not forced to Ctrl+C if the server errors
+fn store_retrieved_access_token(
+    host: &str,
+    oidc_domain: &impl Borrow<Url>,
+    helper: &Option<impl AsRef<OsStr>>,
+    secret: String,
+) -> anyhow::Result<String> {
     let oidc_domain = oidc_domain
         .borrow()
         .host_str()
         .ok_or_else(|| anyhow!("invalid OpenID Connect domain"))?;
     let oidc_token_id = format!("{}-{}", oidc_domain, host);
-    let secret = res.access_token().secret();
+
     if let Some(helper) = helper {
         let mut helper = Command::new(helper)
             .stdin(Stdio::piped())
@@ -274,12 +260,108 @@ pub fn login(
         }
     } else {
         keyring::Entry::new("enarx", &oidc_token_id)
-            .set_password(secret)
+            .set_password(&secret)
             .context("Failed to save user credentials")?;
     }
     println!("Credentials saved locally.");
 
-    Ok(secret.to_string())
+    Ok(secret)
+}
+
+fn login_device_authorization(
+    host: &str,
+    oidc_domain: &impl Borrow<Url>,
+    oidc_client_id: String,
+) -> anyhow::Result<String> {
+    let client = get_oauth2_client(oidc_domain, oidc_client_id, None)
+        .context("Failed to construct OIDC client")?;
+
+    let details: StandardDeviceAuthorizationResponse = client
+        .exchange_device_code()
+        .context("Failed to construct device authorization request")?
+        .add_scopes(OAUTH_SCOPES.iter().map(|s| Scope::new(s.to_string())))
+        .add_extra_param("audience", format!("https://{}/", host))
+        .request(http_client)
+        .context("Failed to request device code")?;
+
+    println!(
+        "To continue, open the following link in your browser:\n\
+         \t{}\n\
+         At the prompt, enter the following one-time code:\n\
+         \t{}\n\
+         Once entered, please wait a few moments for authorization to complete.",
+        details.verification_uri().as_str(),
+        details.user_code().secret()
+    );
+
+    // TODO: graceful timeout, so that users are not forced to Ctrl+C if the server errors
+
+    client
+        .exchange_device_access_token(&details)
+        .request(http_client, poll_delay, None)
+        .context("Failed to exchange device code for a token")
+        .map(|res| res.access_token().secret().clone())
+}
+
+fn login_client_credentials(
+    host: &str,
+    oidc_domain: &impl Borrow<Url>,
+    oidc_client_id: String,
+    oidc_client_secret: String,
+) -> anyhow::Result<String> {
+    let client = get_oauth2_client(oidc_domain, oidc_client_id, Some(oidc_client_secret))
+        .context("Failed to construct OIDC client")?;
+
+    client
+        .exchange_client_credentials()
+        .add_scopes(OAUTH_SCOPES.iter().map(|s| Scope::new(s.to_string())))
+        .add_extra_param("audience", format!("https://{}/", host))
+        .request(http_client)
+        .context("Failed to request access token")
+        .map(|res| res.access_token().secret().clone())
+}
+
+#[derive(Debug)]
+pub struct LoginContext {
+    pub host: String,
+    pub oidc_domain: Url,
+    pub credentials: LoginCredentials,
+    pub helper: Option<OsString>,
+}
+
+#[derive(Debug)]
+pub enum LoginCredentials {
+    DeviceAuthorization {
+        client_id: String,
+    },
+    ClientCredentials {
+        client_id: String,
+        client_secret: String,
+    },
+}
+
+pub fn login(
+    LoginContext {
+        host,
+        oidc_domain,
+        helper,
+        credentials,
+    }: LoginContext,
+) -> anyhow::Result<String> {
+    let access_token = match credentials {
+        LoginCredentials::DeviceAuthorization { client_id } => {
+            login_device_authorization(&host, &oidc_domain, client_id)
+                .context("Failed to log in with device authorization")?
+        }
+        LoginCredentials::ClientCredentials {
+            client_id,
+            client_secret,
+        } => login_client_credentials(&host, &oidc_domain, client_id, client_secret)
+            .context("Failed to log in with client credentials")?,
+    };
+
+    store_retrieved_access_token(&host, &oidc_domain, &helper, access_token)
+        .context("Failed to store access token")
 }
 
 const INTERVAL: Duration = Duration::from_secs(3);


### PR DESCRIPTION
This adds logging in with client credential grant for machine-2-machine interactions, like bots for uploading data to a Drawbridge instance.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>