### PR TITLE
feat(sgx): complete the TCS page struct and add the flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "sallyport",
  "sgx",
  "spinning",
+ "testaso",
  "x86_64",
  "xsave",
 ]

--- a/crates/shim-sgx/Cargo.toml
+++ b/crates/shim-sgx/Cargo.toml
@@ -31,6 +31,9 @@ xsave = { workspace = true }
 gdbstub = { workspace = true, optional = true }
 gdbstub_arch = { workspace = true, optional = true }
 
+[dev-dependencies]
+testaso = { workspace = true }
+
 [[bin]]
 name = "enarx-shim-sgx"
 test = false


### PR DESCRIPTION
especially the AEXNOTIFY `TcsFlags`.

"Intel Architecture Instruction Set Extensions and Future Features - Version 45" is out[2].  There is a new chapter:

Asynchronous Enclave Exit Notify and the EDECCSSA User Leaf Function.

Enclaves exit can be either synchronous and consensual (EEXIT for instance) or asynchronous (on an interrupt or fault).  The asynchronous ones can evidently be exploited to single step enclaves[1], on top of which other naughty things can be built.

AEX Notify will be made available both on upcoming processors and on some older processors through microcode updates.

1. https://github.com/jovanbulck/sgx-step
2. https://cdrdv2.intel.com/v1/dl/getContent/671368?explicitVersion=true

Signed-off-by: Harald Hoyer <harald@profian.com>

Related: https://github.com/enarx/enarx/issues/2158

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
