### PR TITLE
feat(sgx): add a page fault handler to do lazy mmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,10 +2271,10 @@ dependencies = [
 [[package]]
 name = "mmledger"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e897144402a49ebd210db4b367029e69fdad0db6f38ad97289dc9d5af10023"
+source = "git+https://github.com/enarx/mmledger?rev=79bbef3ef90dc33bfd8a188ea4bc79db57fe91a0#79bbef3ef90dc33bfd8a188ea4bc79db57fe91a0"
 dependencies = [
  "bitflags",
+ "const-default",
  "lset",
  "primordial",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ libc = { version = "0.2.137", default-features = false }
 linked_list_allocator = { version = "0.10.1", default-features = false }
 lset = { version = "0.3.0", default-features = false }
 mmarinus = { version = "0.4.0", default-features = false }
-mmledger = { version = "0.3.0", default-features = false }
+mmledger = { git = "https://github.com/enarx/mmledger", rev="79bbef3ef90dc33bfd8a188ea4bc79db57fe91a0", default-features = false }
 nbytes = { version = "0.1.0", default-features = false }
 noted = { version = "1.0.0", default-features = false }
 oauth2 = { version = "4.2.2", default-features = false, features = ["ureq"] }

--- a/crates/shim-sgx/layout.ld
+++ b/crates/shim-sgx/layout.ld
@@ -62,7 +62,7 @@ SECTIONS {
         . += 16;
         QUAD(ADDR(.enarx.ssa))   /* OSSA */
         LONG(0)                   /* CSSA */
-        LONG(3)                   /* NSSA */
+        LONG(4)                   /* NSSA */
         QUAD(_start)              /* OENTRY */
         . = ALIGN(4K);
     } :tcs =0

--- a/crates/shim-sgx/src/handler/gdb.rs
+++ b/crates/shim-sgx/src/handler/gdb.rs
@@ -8,7 +8,9 @@ use core::mem::size_of;
 use core::ops::Range;
 
 use crate::handler::HEAP;
+use crate::heap::Access;
 use crate::{shim_address, BLOCK_SIZE, ENARX_EXEC_START};
+
 use gdbstub::arch::Arch;
 use gdbstub::target::ext::base::singlethread::SingleThreadOps;
 use gdbstub::target::ext::base::singlethread::{GdbInterrupt, ResumeAction, StopReason};
@@ -16,7 +18,6 @@ use gdbstub::target::ext::base::BaseOps;
 use gdbstub::target::{Target, TargetError, TargetResult};
 use gdbstub::Connection;
 use gdbstub_arch::x86::reg::X86_64CoreRegs;
-use mmledger::Access;
 use primordial::{Address, Offset, Page};
 use sallyport::guest::Handler;
 use sgx::ssa::StateSaveArea;

--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -28,7 +28,7 @@ pub(crate) mod key;
 pub(crate) mod usermem;
 
 use crate::handler::usermem::UserMemScope;
-use crate::heap::Heap;
+use crate::heap::{Access, Heap};
 use crate::thread::{
     NewThread, NewThreadFromRegisters, Tcb, Tcs, ThreadMem, NEW_THREAD_QUEUE, THREADS_FREE,
     THREAD_ID_CNT,
@@ -37,16 +37,18 @@ use crate::{
     shim_address, CSSA_0_STACK_SIZE, CSSA_1_PLUS_STACK_SIZE, DEBUG, ENARX_EXEC_END,
     ENARX_EXEC_START, ENCL_SIZE, NUM_SSA,
 };
+
 use core::arch::asm;
 use core::arch::x86_64::CpuidResult;
 use core::ffi::{c_int, c_size_t, c_ulong, c_void};
 use core::fmt::Write;
 use core::mem::size_of;
+use core::ops::Deref;
 use core::ptr::read_unaligned;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU32, Ordering};
 
-use mmledger::Access;
+use mmledger::{Record, Region};
 use primordial::{Address, Offset, Page};
 use sallyport::guest::{self, Handler as _, Platform, ThreadLocalStorage};
 use sallyport::item::enarxcall::sgx::{Report, ReportData, TargetInfo, TECH};
@@ -55,11 +57,13 @@ use sallyport::libc::{
     off_t, pid_t, CloneFlags, SYS_clock_gettime, EACCES, EAGAIN, EINVAL, EIO, EMSGSIZE, ENOMEM,
     ENOSYS, ENOTSUP, MAP_ANONYMOUS, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE, STDERR_FILENO,
 };
+use sallyport::Error;
 use sgx::page::{Class, Flags};
 use sgx::ssa::StateSaveArea;
 use sgx::ssa::Vector;
 use spinning::{Lazy, RwLock};
 use x86_64::addr::VirtAddr;
+use x86_64::structures::idt::PageFaultErrorCode;
 use x86_64::structures::paging::Page as PageAddr;
 
 // Opcode constants, details in Volume 2 of the Intel 64 and IA-32 Architectures Software
@@ -71,7 +75,10 @@ const OP_CPUID: u16 = 0xa20f;
 pub static HEAP: Lazy<RwLock<Heap>> = Lazy::new(|| {
     let start = unsafe { &ENARX_EXEC_END as *const _ } as usize;
     let end = shim_address() + ENCL_SIZE;
-    RwLock::new(Heap::new(Address::new(start), Address::new(end)))
+    RwLock::new(Heap::new(
+        Address::new(start),
+        Address::new(end) - Address::new(start),
+    ))
 });
 
 // For `Handler::mmap_guest()`
@@ -79,6 +86,42 @@ static ZERO: Page = Page::zeroed();
 
 fn is_prot_allowed(prot: c_int) -> bool {
     prot == PROT_READ || prot == (PROT_READ | PROT_WRITE) || prot == (PROT_READ | PROT_EXEC)
+}
+
+fn flags_from_access(access: Access) -> Flags {
+    let mut flags = Flags::empty();
+
+    if access.contains(Access::READ) {
+        flags |= Flags::READ;
+    }
+
+    if access.contains(Access::WRITE) {
+        flags |= Flags::WRITE;
+    }
+
+    if access.contains(Access::EXECUTE) {
+        flags |= Flags::EXECUTE;
+    }
+
+    flags
+}
+
+fn libc_from_access(access: Access) -> c_int {
+    let mut flags = 0;
+
+    if access.contains(Access::READ) {
+        flags |= PROT_READ;
+    }
+
+    if access.contains(Access::WRITE) {
+        flags |= PROT_WRITE;
+    }
+
+    if access.contains(Access::EXECUTE) {
+        flags |= PROT_EXEC;
+    }
+
+    flags
 }
 
 fn flags_from_libc(prot: c_int) -> Flags {
@@ -115,6 +158,14 @@ fn access_from_libc(prot: c_int) -> Access {
     }
 
     access
+}
+
+#[derive(PartialEq)]
+enum MMapStrategy {
+    /// Memory should be mmap'ed directly
+    Direct,
+    /// Memory should be mmap'ed, when used
+    Lazy,
 }
 
 /// Thread local storage for the current thread
@@ -327,8 +378,6 @@ impl guest::Handler for Handler<'_> {
         fd: c_int,
         offset: off_t,
     ) -> sallyport::Result<NonNull<c_void>> {
-        let tid = self.tcb.tid;
-
         let addr = addr.map(|v| v.as_ptr() as usize).unwrap_or(0);
         // TODO: https://github.com/enarx/enarx/issues/1892
         let prot = prot | PROT_READ;
@@ -342,46 +391,7 @@ impl guest::Handler for Handler<'_> {
             return Err(EACCES);
         }
 
-        let length = Offset::from_items((len + Page::SIZE - 1) / Page::SIZE);
-        let access = access_from_libc(prot);
-        let mut heap = HEAP.write();
-
-        if let Some(addr) = heap.mmap(None, length, access) {
-            let ret = NonNull::new(addr.raw() as *mut c_void).unwrap();
-
-            if let Err(e) = self.mmap_host(
-                NonNull::new(addr.raw() as *mut _).unwrap(),
-                length.bytes(),
-                PROT_READ | PROT_WRITE,
-            ) {
-                debugln!(self, "[{tid}] ERROR mmap_host() = {e:#?}");
-                // undo the mmap
-                heap.munmap(addr, length).unwrap_or_else(|e| {
-                    panic!(
-                        "[{tid}] ERROR heap.munmap({addr:#x}, {length:#x}) = {e:#?}",
-                        addr = addr.raw(),
-                        length = length.bytes(),
-                    )
-                });
-                return Err(e);
-            }
-
-            self.mmap_guest(addr, length, flags_from_libc(prot));
-
-            // If the previous operations succeeded, the virtual memory area
-            // (VMA) is already RW.
-            if prot != PROT_READ | PROT_WRITE {
-                self.mprotect_unlocked(&mut heap, ret, length.bytes() as c_size_t, prot)
-                    .or_else(|e| {
-                        self.munmap_unlocked(&mut heap, ret, length.bytes())
-                            .and(Err(e))
-                    })?;
-            }
-            Ok(ret)
-        } else {
-            debugln!(self, "[{tid}] ERROR heap.mmap() failed!!!!");
-            Err(ENOMEM)
-        }
+        self.do_mmap(prot, len, MMapStrategy::Lazy)
     }
 
     fn mprotect(
@@ -436,19 +446,30 @@ impl<'a> Handler<'a> {
     }
 
     /// Finish handling an exception
-    pub fn finish(ssa: &'a mut StateSaveArea, block: &'a mut [usize], tcb: &'a mut Tcb) {
-        if let Some(Vector::InvalidOpcode) = ssa.vector() {
-            if let OP_SYSCALL | OP_CPUID = unsafe { read_unaligned(ssa.gpr.rip as _) } {
-                // Skip the instruction.
-                ssa.gpr.rip += 2;
-                return;
+    pub fn finish(ssa: &'a mut StateSaveArea, block: Option<&'a mut [usize]>, tcb: &'a mut Tcb) {
+        match ssa.vector() {
+            Some(Vector::InvalidOpcode) => {
+                if let OP_SYSCALL | OP_CPUID = unsafe { read_unaligned(ssa.gpr.rip as _) } {
+                    // Skip the instruction.
+                    ssa.gpr.rip += 2;
+                    return;
+                }
             }
+            Some(Vector::Page) => {
+                if let Some(block) = block {
+                    let mut h = Self::new(ssa, block, tcb, 0);
+                    let error_code =
+                        PageFaultErrorCode::from_bits_truncate(h.ssa.misc.exinfo.errcd as u64);
+                    let addr = h.ssa.misc.exinfo.maddr as usize;
+                    if h.handle_page_fault(addr, error_code).is_ok() {
+                        return;
+                    }
+                }
+            }
+            _ => {}
         }
 
-        let mut h = Self::new(ssa, block, tcb, 0);
-        h.print_ssa_stack_trace();
-
-        unsafe { asm!("ud2", options(noreturn)) };
+        panic!();
     }
 
     /// Handle an exception
@@ -492,15 +513,30 @@ impl<'a> Handler<'a> {
                 }
             },
 
-            #[cfg(feature = "gdb")]
             Some(Vector::Page) => {
-                h.print_ssa_stack_trace();
-                h.gdb_session();
-                let _ = h.exit_group(1);
-                unreachable!()
+                let error_code =
+                    PageFaultErrorCode::from_bits_truncate(h.ssa.misc.exinfo.errcd as u64);
+                if h.handle_page_fault(h.ssa.misc.exinfo.maddr as usize, error_code)
+                    .is_ok()
+                {
+                    return;
+                }
+
+                #[cfg(feature = "gdb")]
+                {
+                    h.print_ssa_stack_trace();
+                    h.gdb_session();
+                    let _ = h.exit_group(1);
+                }
+
+                #[cfg(not(feature = "gdb"))]
+                h.attacked()
             }
 
             _ => {
+                debugln!(h, "unhandled exception: {:#?}", h.ssa.vector());
+                debugln!(h, "Exinfo: {:#?}", h.ssa.misc.exinfo.clone());
+
                 if cfg!(feature = "dbg") {
                     h.print_ssa_stack_trace();
                 }
@@ -710,6 +746,68 @@ impl<'a> Handler<'a> {
         self.ssa.gpr.rip += 2;
     }
 
+    fn do_mmap(
+        &mut self,
+        prot: c_int,
+        len: usize,
+        lazy: MMapStrategy,
+    ) -> Result<NonNull<c_void>, Error> {
+        if len == 0 {
+            return Err(EINVAL);
+        }
+
+        let length = Offset::from_items((len + Page::SIZE - 1) / Page::SIZE);
+        let access = access_from_libc(prot);
+        let mut heap = HEAP.write();
+        if let Some(addr) = heap.mmap(None, length, access) {
+            let ret = NonNull::new(addr.raw() as *mut c_void).unwrap();
+            debugln!(
+                self,
+                "mmap({:#?})",
+                Record {
+                    region: Region::new(addr, addr + length),
+                    access: access | Access::MMAPPED
+                }
+            );
+
+            if lazy == MMapStrategy::Lazy {
+                // Allocate all paged on-demand.
+                return Ok(ret);
+            }
+
+            if heap.mmap(Some(addr), length, access | Access::MMAPPED) != Some(addr) {
+                debugln!(self, "MMAPPED heap is inconsistent");
+                self.attacked()
+            }
+
+            if let Err(e) = self.mmap_host(
+                NonNull::new(addr.raw() as *mut _).unwrap(),
+                length.bytes(),
+                PROT_READ | PROT_WRITE,
+            ) {
+                debugln!(self, "ERROR mmap_host() = {e:#?}");
+                self.attacked()
+            }
+
+            self.mmap_guest(addr, length, flags_from_libc(prot));
+
+            // If the previous operations succeeded, the virtual memory area
+            // (VMA) is already RW.
+            if prot != PROT_READ | PROT_WRITE {
+                if let Err(e) =
+                    self.mprotect_unlocked(&mut heap, ret, length.bytes() as c_size_t, prot)
+                {
+                    debugln!(self, "ERROR mprotect_unlocked() = {e:#?}");
+                    self.attacked()
+                }
+            }
+            Ok(ret)
+        } else {
+            debugln!(self, "ERROR heap.mmap() failed!!!!");
+            Err(ENOMEM)
+        }
+    }
+
     /// Acknowledge pages committed by the host with ENCLS[EAUG].
     fn mmap_guest(
         &mut self,
@@ -758,31 +856,88 @@ impl<'a> Handler<'a> {
 
         let addr = Address::new(addr);
         let length = Offset::from_items(pages);
-
-        if heap.contains(addr, length).is_none() {
-            return Err(ENOMEM);
-        }
-
-        self.mprotect_host(addr_in, length.bytes(), prot)?;
-
-        for i in 0..pages {
-            let virt_addr = VirtAddr::new((addr.raw() + i * Page::SIZE) as u64);
-            // Safety: The address is guaranteed to be page aligned, because
-            // `addr` was checked to be page aligned and only a multiple of
-            // pages was added.
-            let page_addr = unsafe { PageAddr::from_start_address_unchecked(virt_addr) };
-
-            // TODO: https://github.com/enarx/enarx/issues/1892
-            Class::Regular
-                .info(Flags::READ | Flags::RESTRICTED)
-                .accept(page_addr)
-                .unwrap_or_else(|_| self.attacked());
-
-            Class::Regular.info(flags_from_libc(prot)).extend(page_addr);
-        }
-
         let access = access_from_libc(prot);
-        heap.mmap(Some(addr), length, access);
+
+        debugln!(self, "heap = {heap:#?}", heap = heap.deref());
+        debugln!(
+            self,
+            "mprotect({:#?}, {:?})",
+            &Region {
+                start: addr,
+                end: addr + length
+            },
+            access
+        );
+
+        match heap.contains(addr, length) {
+            None => return Err(ENOMEM),
+            Some(access) => {
+                if access == Access::empty() {
+                    debugln!(
+                        self,
+                        "mprotect_unlocked previous access ({:#?}",
+                        Record {
+                            region: Region::new(addr, addr + length),
+                            access
+                        }
+                    );
+                    self.attacked();
+                }
+            }
+        }
+
+        heap.protect_with(addr, length, |record| {
+            debugln!(self, "mprotect_unlocked working on ({record:#?})");
+            if record.access.contains(Access::MMAPPED) {
+                if access != record.access {
+                    let region = &record.region;
+                    let addr = NonNull::new(region.start.as_mut_ptr() as *mut c_void).unwrap();
+                    let length = (region.end - region.start).bytes();
+                    let pages = (region.end - region.start).items();
+
+                    self.mprotect_host(addr, length, prot)
+                        .unwrap_or_else(|err| {
+                            debugln!(
+                                self,
+                                "mprotect_unlocked mprotect_host failed access={access:#?} record.access={raccess:#?} ({record:#?}) = {err:#?}",
+                                raccess=record.access,
+                            );
+                            self.attacked();
+                        });
+
+                    for i in 0..pages {
+                        let virt_addr =
+                            VirtAddr::new((region.start + Offset::from_items(i)).as_ptr() as u64);
+                        // Safety: The address is guaranteed to be page aligned, because
+                        // `addr` was checked to be page aligned and only a multiple of
+                        // pages was added.
+                        let page_addr =
+                            unsafe { PageAddr::from_start_address_unchecked(virt_addr) };
+
+                        // TODO: https://github.com/enarx/enarx/issues/1892
+                        Class::Regular
+                            .info(Flags::READ | Flags::RESTRICTED)
+                            .accept(page_addr)
+                            .unwrap_or_else(|_| self.attacked());
+
+                        Class::Regular.info(flags_from_libc(prot)).extend(page_addr);
+                    }
+                }
+                access | Access::MMAPPED
+            } else {
+                access
+            }
+        }).unwrap();
+
+        debugln!(self, "heap = {heap:#?}", heap = heap.deref());
+        debugln!(
+            self,
+            "ready mprotect_unlocked({:#?}",
+            Record {
+                region: Region::new(addr, addr + length),
+                access: access | Access::MMAPPED
+            }
+        );
 
         Ok(())
     }
@@ -810,37 +965,48 @@ impl<'a> Handler<'a> {
 
         // Process the ledger first, before doing anything else, because it can
         // legitly fail when running out of resources.
-        if let Err(e) = heap.munmap(addr, length) {
-            debugln!(self, "[{tid}] ERROR munmap: heap.munmap FAILED !!! {e:?}");
-            return Err(ENOMEM);
-        }
+        heap.munmap_with(addr, length, move |record: &Record<Access>| {
+            debugln!(self, "[{tid}] sgx_unmap({:#?}", record);
 
-        // On the other hand, failing in any of these operations is expected to
-        // crash the enclave because it is due either to a software bug, or a
-        // malicious host.
-        if let Err(e) = self.modify_sgx_page_type(addr_in, length.bytes(), Class::Trimmed as _) {
-            debugln!(
-                self,
-                "[{tid}] ERROR munmap: modify_sgx_page_type FAILED !!! {e:?}"
-            );
-            self.attacked();
-        }
+            if !record.access.contains(Access::MMAPPED) {
+                // if not MMAPPED, we don't have to do anything
+                return;
+            }
 
-        for i in 0..pages {
-            let virt_addr = VirtAddr::new((addr.raw() + i * Page::SIZE) as u64);
-            // # Safety
-            //
-            // The address must be page aligned.
-            let page_addr = unsafe { PageAddr::from_start_address_unchecked(virt_addr) };
+            let region = &record.region;
+            let addr = NonNull::new(region.start.as_mut_ptr() as *mut c_void).unwrap();
+            let length = (region.end - region.start).bytes();
+            let pages = (region.end - region.start).items();
 
-            Class::Trimmed
-                .info(Flags::MODIFIED)
-                .accept(page_addr)
+            // On the other hand, failing in any of these operations is expected to
+            // crash the enclave because it is due either to a software bug, or a
+            // malicious host.
+            if let Err(e) = self.modify_sgx_page_type(addr, length, Class::Trimmed as _) {
+                debugln!(
+                    self,
+                    "[{tid}] ERROR munmap: modify_sgx_page_type FAILED !!! {e:?}"
+                );
+                self.attacked();
+            }
+
+            for i in 0..pages {
+                let virt_addr =
+                    VirtAddr::new((region.start + Offset::from_items(i)).as_ptr() as u64);
+                // # Safety
+                //
+                // The address must be page aligned.
+                let page_addr = unsafe { PageAddr::from_start_address_unchecked(virt_addr) };
+
+                Class::Trimmed
+                    .info(Flags::MODIFIED)
+                    .accept(page_addr)
+                    .unwrap_or_else(|_| self.attacked());
+            }
+
+            self.munmap_host(addr, length)
                 .unwrap_or_else(|_| self.attacked());
-        }
-
-        self.munmap_host(addr_in, length.bytes())
-            .unwrap_or_else(|_| self.attacked());
+        })
+        .map_err(|_| ENOMEM)?;
 
         Ok(())
     }
@@ -917,14 +1083,10 @@ impl<'a> Handler<'a> {
         // Allocate the whole block of memory used for the thread.
         // It is easier to do this in one go and punch holes in it,
         // than to allocate each part separately.
-        let addr = self.mmap(
-            &usermemscope,
-            None,
-            size_of::<ThreadMem>(),
+        let addr = self.do_mmap(
             PROT_READ | PROT_WRITE,
-            MAP_PRIVATE | MAP_ANONYMOUS,
-            -1,
-            0,
+            size_of::<ThreadMem>(),
+            MMapStrategy::Direct,
         )?;
 
         // # Safety
@@ -988,6 +1150,119 @@ impl<'a> Handler<'a> {
         );
 
         self.munmap(&usermemscope, tm_addr, size_of::<ThreadMem>())?;
+
+        Ok(())
+    }
+
+    fn handle_page_fault(&mut self, addr: usize, error_code: PageFaultErrorCode) -> Result<(), ()> {
+        let tid = self.tcb.tid;
+        let addr = addr & !(Page::SIZE - 1);
+
+        debugln!(self, "[{tid}] handle_page_fault: {addr:#x} {error_code:?}");
+
+        // check for non-valid flags
+        if !error_code
+            .intersection(
+                PageFaultErrorCode::PROTECTION_VIOLATION
+                    | PageFaultErrorCode::PROTECTION_KEY
+                    | PageFaultErrorCode::SGX,
+            )
+            .is_empty()
+        {
+            debugln!(
+                self,
+                "[{tid}] handle_page_fault: intersection {:#?}",
+                error_code.difference(
+                    PageFaultErrorCode::PROTECTION_VIOLATION
+                        | PageFaultErrorCode::PROTECTION_KEY
+                        | PageFaultErrorCode::SGX,
+                )
+            );
+
+            return Err(());
+        }
+
+        // check for must have flags
+        if !error_code.contains(PageFaultErrorCode::USER_MODE) {
+            return Err(());
+        }
+
+        let mut heap = HEAP.write();
+
+        let addr = Address::new(addr);
+        let length = Offset::from_items(1);
+
+        let access = match heap.contains(addr, length) {
+            None => {
+                debugln!(
+                    self,
+                    "[{tid}] handle_page_fault: access empty {:#?}",
+                    Region::new(addr, addr + length),
+                );
+                panic!();
+            }
+            Some(access) => {
+                // check for real page fault
+                if !access.contains(Access::READ)
+                    || (error_code.contains(PageFaultErrorCode::CAUSED_BY_WRITE)
+                        && !access.contains(Access::WRITE))
+                    || (error_code.contains(PageFaultErrorCode::INSTRUCTION_FETCH)
+                        && !access.contains(Access::READ | Access::EXECUTE))
+                {
+                    debugln!(
+                        self,
+                        "[{tid}] handle_page_fault: real page fault previous access {:#?}",
+                        Record {
+                            region: Region::new(addr, addr + length),
+                            access
+                        }
+                    );
+                    panic!();
+                }
+                access
+            }
+        };
+
+        if heap.mmap(Some(addr), length, access | Access::MMAPPED) != Some(addr) {
+            debugln!(
+                self,
+                "[{tid}] handle_page_fault: MMAPPED heap is inconsistent"
+            );
+            panic!();
+        }
+
+        if let Err(e) = self.mmap_host(
+            NonNull::new(addr.raw() as *mut _).unwrap(),
+            length.bytes(),
+            PROT_READ | PROT_WRITE,
+        ) {
+            debugln!(
+                self,
+                "[{tid}] handle_page_fault: ERROR mmap_host() = {e:#?}"
+            );
+            panic!();
+        }
+
+        self.mmap_guest(addr, length, flags_from_access(access));
+
+        // If the previous operations succeeded, the virtual memory area
+        // (VMA) is already RW.
+        if access != (Access::READ | Access::WRITE) {
+            let ret = NonNull::new(addr.raw() as *mut c_void).unwrap();
+
+            if let Err(e) = self.mprotect_unlocked(
+                &mut heap,
+                ret,
+                length.bytes() as c_size_t,
+                libc_from_access(access),
+            ) {
+                debugln!(
+                    self,
+                    "[{tid}] handle_page_fault: ERROR mprotect_unlocked() = {e:#?}"
+                );
+                panic!();
+            }
+        }
 
         Ok(())
     }

--- a/crates/shim-sgx/src/heap.rs
+++ b/crates/shim-sgx/src/heap.rs
@@ -2,30 +2,85 @@
 
 //! Allocate and deallocate memory on a Heap
 
-use mmledger::{Access, Ledger, Region};
+use const_default::ConstDefault;
+use core::fmt;
+
+use mmledger::{Ledger, LedgerAccess, Record};
 use primordial::{Address, Offset, Page};
 
+bitflags::bitflags! {
+    /// Memory access permissions.
+    #[derive(Default)]
+    #[repr(transparent)]
+    pub struct Access: usize {
+        /// Read access
+        const READ = 1 << 0;
+
+        /// Write access
+        const WRITE = 1 << 1;
+
+        /// Execute access
+        const EXECUTE = 1 << 2;
+
+        /// Execute access
+        const MMAPPED = 1 << 3;
+    }
+}
+
+impl ConstDefault for Access {
+    const DEFAULT: Self = Self::empty();
+}
+
+impl LedgerAccess for Access {
+    const ALL: Self = Self::all();
+}
+
+impl fmt::Display for Access {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{}{}{}",
+            if self.contains(Access::READ) {
+                'r'
+            } else {
+                '-'
+            },
+            if self.contains(Access::WRITE) {
+                'w'
+            } else {
+                '-'
+            },
+            if self.contains(Access::EXECUTE) {
+                'x'
+            } else {
+                '-'
+            },
+            if self.contains(Access::MMAPPED) {
+                'x'
+            } else {
+                '-'
+            }
+        )
+    }
+}
+
 /// A heap
+#[derive(Debug)]
 pub struct Heap {
-    start: Address<usize, Page>,
-    end: Address<usize, Page>,
     brk: Address<usize, Page>,
     brk_max: Address<usize, Page>,
     // FIXME: use a dynamic Ledger
     // https://github.com/enarx/enarx/issues/2264
-    ledger: Ledger<8188>,
+    ledger: Ledger<Access, 8188>,
 }
 
 impl Heap {
     /// Create a new instance.
-    pub const fn new(start: Address<usize, Page>, end: Address<usize, Page>) -> Self {
-        let region = Region::new(start, end);
+    pub fn new(addr: Address<usize, Page>, length: Offset<usize, Page>) -> Self {
         Self {
-            start,
-            end,
-            brk: start,
-            brk_max: start,
-            ledger: Ledger::new(region),
+            brk: addr,
+            brk_max: addr,
+            ledger: Ledger::new(addr, length),
         }
     }
 
@@ -46,7 +101,7 @@ impl Heap {
 
     /// Increase or decrease `brk` address.
     pub fn brk(&mut self, next: Address<usize, Page>) -> Address<usize, Page> {
-        if next < self.start || next >= self.end {
+        if !self.ledger.valid(next, Offset::from_items(1)) {
             return self.brk;
         }
 
@@ -61,10 +116,11 @@ impl Heap {
             return self.brk;
         }
 
-        match self
-            .ledger
-            .map(self.brk_max, length, Access::READ | Access::WRITE)
-        {
+        match self.ledger.map(
+            self.brk_max,
+            length,
+            Access::READ | Access::WRITE | Access::MMAPPED,
+        ) {
             Ok(_) => {
                 self.brk_max = next;
                 next
@@ -85,6 +141,16 @@ impl Heap {
         Some(addr)
     }
 
+    /// Change access permissions of an address range.
+    pub fn protect_with(
+        &mut self,
+        addr: Address<usize, Page>,
+        length: Offset<usize, Page>,
+        func: impl FnMut(&Record<Access>) -> Access,
+    ) -> Result<(), mmledger::Error> {
+        self.ledger.protect_with(addr, length, func)
+    }
+
     /// Release a region.
     pub fn munmap(
         &mut self,
@@ -93,6 +159,16 @@ impl Heap {
     ) -> Result<(), mmledger::Error> {
         self.ledger.unmap(addr, length)
     }
+
+    /// Release a region.
+    pub fn munmap_with(
+        &mut self,
+        addr: Address<usize, Page>,
+        length: Offset<usize, Page>,
+        func: impl FnMut(&Record<Access>),
+    ) -> Result<(), mmledger::Error> {
+        self.ledger.unmap_with(addr, length, func)
+    }
 }
 
 #[cfg(test)]
@@ -100,7 +176,6 @@ mod tests {
     use super::*;
 
     const PAGES: usize = 128;
-    const BYTES: usize = PAGES * Page::SIZE;
 
     trait HeapTestExt {
         fn is_allocated(&self, page: usize) -> bool;
@@ -122,7 +197,7 @@ mod tests {
 
     #[test]
     fn mmap_order() {
-        let mut heap = Heap::new(Address::new(0), Address::new(BYTES));
+        let mut heap = Heap::new(Address::new(0), Offset::from_items(PAGES));
 
         for pages in [128, 64] {
             let brk_page = PAGES - pages;
@@ -155,9 +230,9 @@ mod tests {
 
     #[test]
     fn mmap_oversubscribe() {
-        let mut heap = Heap::new(Address::new(0), Address::new(BYTES));
+        let mut heap = Heap::new(Address::new(0), Offset::from_items(PAGES));
         assert_eq!(
-            heap.mmap(None, Offset::from_items(BYTES + Page::SIZE), Access::READ),
+            heap.mmap(None, Offset::from_items(PAGES + 1), Access::READ),
             None
         );
     }

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -38,7 +38,7 @@ pub const CSSA_1_PLUS_STACK_SIZE: usize =
     0x800000 - Page::SIZE - NUM_SSA * core::mem::size_of::<StateSaveArea>(); // 8MB - TCS - SSA
 
 /// FIXME: doc
-pub const ENCL_SIZE_BITS: u8 = 32;
+pub const ENCL_SIZE_BITS: u8 = 34;
 /// FIXME: doc
 pub const ENCL_SIZE: usize = 1 << ENCL_SIZE_BITS;
 
@@ -63,14 +63,8 @@ const KEEP_FEATURES: Features = FEATURES;
 /// Default enclave CPU attributes
 pub const ATTR: Attributes = Attributes::new(KEEP_FEATURES, XFRM);
 
-/// Default miscelaneous SSA data selector
-pub const MISC: MiscSelect = {
-    if cfg!(dbg) {
-        MiscSelect::EXINFO
-    } else {
-        MiscSelect::empty()
-    }
-};
+/// Default miscellaneous SSA data selector
+pub const MISC: MiscSelect = MiscSelect::EXINFO;
 
 /// The size of the sallyport block
 pub const BLOCK_SIZE: usize = 69632;

--- a/src/backend/sgx/enarxcall.rs
+++ b/src/backend/sgx/enarxcall.rs
@@ -19,7 +19,7 @@ use sallyport::host::{deref_aligned, deref_slice};
 use sallyport::item;
 use sallyport::item::enarxcall::sgx::{Report, TargetInfo};
 use sallyport::item::{enarxcall, Item};
-use tracing::{error, trace_span};
+use tracing::{error, trace, trace_span};
 
 pub(crate) fn sgx_enarxcall<'a>(
     enarxcall: &'a mut enarxcall::Payload,
@@ -303,7 +303,8 @@ pub(crate) fn sgx_enarxcall<'a>(
             // Safety: the parameters have been sanity checked before, that only
             // enclave memory is unmapped.
             unsafe {
-                libc::munmap(*addr as *mut _, *len);
+                let ret = libc::munmap(*addr as *mut _, *len);
+                trace!("munmap({:#x}, {:#x}) = {}", *addr, *len, ret);
             }
 
             let remove_pages = RemovePages::new(*addr - keep.mem.addr(), *len);

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -6,12 +6,12 @@ use crate::backend::execute_gdb;
 use crate::backend::Command;
 
 use std::arch::asm;
-use std::io;
 use std::iter;
 use std::mem::{size_of, MaybeUninit};
 #[cfg(feature = "gdb")]
 use std::net::TcpStream;
 use std::sync::Arc;
+use std::{io, ptr};
 
 use anyhow::{bail, Context, Result};
 use sallyport::item;
@@ -25,7 +25,7 @@ pub struct Thread {
     keep: Arc<super::Keep>,
     vdso: &'static Symbol,
     tcs: super::Tcs,
-    block: Vec<usize>,
+    block: [Vec<usize>; 2],
     cssa: usize,
     how: usize,
     #[cfg(feature = "gdb")]
@@ -53,7 +53,10 @@ impl super::super::Keep for super::Keep {
             None => return Ok(None),
         };
 
-        let block = vec![0; self.sallyport_block_size as usize / size_of::<usize>()];
+        let block = [
+            vec![0; self.sallyport_block_size as usize / size_of::<usize>()],
+            vec![0; self.sallyport_block_size as usize / size_of::<usize>()],
+        ];
 
         Ok(Some(Box::new(Thread {
             keep: self,
@@ -80,6 +83,12 @@ impl super::super::Thread for Thread {
         let oldfs = FS::read_base().as_u64();
         let oldgs = GS::read_base().as_u64();
 
+        let block = if self.cssa == 1 || self.cssa == 2 {
+            self.block[self.cssa - 1].as_mut_ptr()
+        } else {
+            ptr::null_mut()
+        };
+
         // The `enclu` instruction consumes `rax`, `rbx` and `rcx`. However,
         // the vDSO function preserves `rbx` AND sets `rax` as the return
         // value. All other registers are passed to and from the enclave
@@ -99,7 +108,7 @@ impl super::super::Thread for Thread {
                 "pop  rbp",       // restore rbp
                 "pop  rbx",       // restore rbx
 
-                inout("rdi") self.block.as_mut_ptr() => _,
+                inout("rdi") block => _,
                 lateout("rsi") _,
                 lateout("rdx") _,
                 inout("rcx") how => _,
@@ -121,10 +130,20 @@ impl super::super::Thread for Thread {
         let exit_status = exit_status as i32;
 
         self.how = match run.function as usize {
-            EENTER | ERESUME if run.vector == Vector::InvalidOpcode => EENTER,
+            EENTER | ERESUME if run.vector == Vector::InvalidOpcode => {
+                //trace!("Vector::InvalidOpcode cssa={} EENTER", self.cssa);
+                EENTER
+            }
+            EENTER | ERESUME if run.vector == Vector::Page => {
+                trace!(
+                    "Vector::Page: address = {:>#016x}, error code = {:>#016b} cssa={}",
+                    run.exception_addr,
+                    run.exception_error_code,
+                    self.cssa
+                );
 
-            #[cfg(feature = "gdb")]
-            EENTER | ERESUME if run.vector == Vector::Page => EENTER,
+                EENTER
+            }
 
             EEXIT if self.cssa > 0 => ERESUME,
             EEXIT if self.cssa == 0 => {
@@ -158,8 +177,8 @@ impl super::super::Thread for Thread {
             _ => unreachable!(),
         }
 
-        if self.cssa > 3 {
-            error!("SGX CSSA overflow");
+        if self.cssa > 4 {
+            error!("CSSA overflow");
             bail!("SGX CSSA overflow");
         }
 
@@ -171,9 +190,9 @@ impl super::super::Thread for Thread {
         //
         // After the sallyport rework, we can test the sallyport itself and
         // remove this logic.
-        if self.cssa > 0 {
+        if self.cssa == 1 || self.cssa == 2 {
             if let (EENTER, ERESUME) = (how, self.how) {
-                let block: Block = self.block.as_mut_slice().into();
+                let block: Block = self.block[self.cssa - 1].as_mut_slice().into();
                 for item in block {
                     match item {
                         Item::Gdbcall(_gdbcall, _data) => {


### PR DESCRIPTION
This will allow to map the whole 2GB address range of the wasm application, which will speedup execution a lot.
