### PR TITLE
feat(sgx): use PROT_NONE

### DIFF
--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -330,8 +330,6 @@ impl guest::Handler for Handler<'_> {
         let tid = self.tcb.tid;
 
         let addr = addr.map(|v| v.as_ptr() as usize).unwrap_or(0);
-        // TODO: https://github.com/enarx/enarx/issues/1892
-        let prot = prot | PROT_READ;
 
         if addr != 0 || len == 0 || fd != -1 || offset != 0 || flags != MAP_PRIVATE | MAP_ANONYMOUS
         {
@@ -772,9 +770,8 @@ impl<'a> Handler<'a> {
             // pages was added.
             let page_addr = unsafe { PageAddr::from_start_address_unchecked(virt_addr) };
 
-            // TODO: https://github.com/enarx/enarx/issues/1892
             Class::Regular
-                .info(Flags::READ | Flags::RESTRICTED)
+                .info(Flags::RESTRICTED)
                 .accept(page_addr)
                 .unwrap_or_else(|_| self.attacked());
 

--- a/src/backend/sgx/enarxcall.rs
+++ b/src/backend/sgx/enarxcall.rs
@@ -13,7 +13,7 @@ use std::mem::{forget, size_of, MaybeUninit};
 use std::sync::Arc;
 
 use anyhow::Context;
-use libc::{timespec, EAGAIN, EINVAL, PROT_READ};
+use libc::{timespec, EAGAIN, EINVAL, PROT_NONE};
 use mmarinus::{perms, Map, Shared};
 use sallyport::host::{deref_aligned, deref_slice};
 use sallyport::item;
@@ -269,9 +269,8 @@ pub(crate) fn sgx_enarxcall<'a>(
                 return Ok(None);
             }
 
-            // TODO: https://github.com/enarx/enarx/issues/1892
             let parameters =
-                RestrictPermissions::new(*addr - keep.mem.addr(), *len, PROT_READ as _);
+                RestrictPermissions::new(*addr - keep.mem.addr(), *len, PROT_NONE as _);
             parameters
                 .execute(&keep.enclave)
                 .context("ENCLAVE_RESTRICT_PERMISSIONS failed")?;


### PR DESCRIPTION
Replace PROT_READ with PROT_NONE, once migrating to the mainline kernel. PROT_READ was just a workaround for the patch set version 4.

Fixes: https://github.com/enarx/enarx/issues/1892

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
