### PR TITLE
refactor: remove unnecessary usage of Lazy

### DIFF
--- a/crates/exec-wasmtime/src/runtime/net/mod.rs
+++ b/crates/exec-wasmtime/src/runtime/net/mod.rs
@@ -22,19 +22,15 @@ use wasi_common::file::FileCaps;
 use wasi_common::WasiFile;
 use zeroize::Zeroizing;
 
-static DEFAULT_TLS_PROTOCOL_VERSIONS: Lazy<[&'static rustls::SupportedProtocolVersion; 1]> =
-    Lazy::new(|| [&TLS13]);
+static DEFAULT_TLS_PROTOCOL_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&TLS13];
 
-static DEFAULT_TLS_KX_GROUPS: Lazy<[&'static rustls::SupportedKxGroup; 3]> =
-    Lazy::new(|| [&X25519, &SECP384R1, &SECP256R1]);
+static DEFAULT_TLS_KX_GROUPS: &[&rustls::SupportedKxGroup] = &[&X25519, &SECP384R1, &SECP256R1];
 
-static DEFAULT_TLS_CIPHER_SUITES: Lazy<[rustls::SupportedCipherSuite; 3]> = Lazy::new(|| {
-    [
-        TLS13_AES_256_GCM_SHA384,
-        TLS13_AES_128_GCM_SHA256,
-        TLS13_CHACHA20_POLY1305_SHA256,
-    ]
-});
+static DEFAULT_TLS_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[
+    TLS13_AES_256_GCM_SHA384,
+    TLS13_AES_128_GCM_SHA256,
+    TLS13_CHACHA20_POLY1305_SHA256,
+];
 
 static LISTEN_CAPS: Lazy<FileCaps> = Lazy::new(|| {
     FileCaps::FILESTAT_GET | FileCaps::FDSTAT_SET_FLAGS | FileCaps::POLL_READWRITE | FileCaps::READ
@@ -62,9 +58,9 @@ pub fn listen_file(
         ListenFile::Tcp { .. } => wasmtime_wasi::net::Socket::from(tcp).into(),
         ListenFile::Tls { .. } => {
             let cfg = rustls::ServerConfig::builder()
-                .with_cipher_suites(DEFAULT_TLS_CIPHER_SUITES.deref())
-                .with_kx_groups(DEFAULT_TLS_KX_GROUPS.deref())
-                .with_protocol_versions(DEFAULT_TLS_PROTOCOL_VERSIONS.deref())?
+                .with_cipher_suites(DEFAULT_TLS_CIPHER_SUITES)
+                .with_kx_groups(DEFAULT_TLS_KX_GROUPS)
+                .with_protocol_versions(DEFAULT_TLS_PROTOCOL_VERSIONS)?
                 .with_no_client_auth() // TODO: https://github.com/enarx/enarx/issues/1547
                 .with_single_cert(certs, PrivateKey(key.deref().clone()))?;
             tls::Listener::new(tcp, Arc::new(cfg)).into()
@@ -106,9 +102,9 @@ pub fn connect_file(
                 },
             ));
             let cfg = rustls::ClientConfig::builder()
-                .with_cipher_suites(DEFAULT_TLS_CIPHER_SUITES.deref())
-                .with_kx_groups(DEFAULT_TLS_KX_GROUPS.deref())
-                .with_protocol_versions(DEFAULT_TLS_PROTOCOL_VERSIONS.deref())?
+                .with_cipher_suites(DEFAULT_TLS_CIPHER_SUITES)
+                .with_kx_groups(DEFAULT_TLS_KX_GROUPS)
+                .with_protocol_versions(DEFAULT_TLS_PROTOCOL_VERSIONS)?
                 .with_root_certificates(server_roots)
                 .with_single_cert(certs, PrivateKey(key.deref().clone()))?;
 

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -36,7 +36,6 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use enarx_exec_wasmtime::{Args as ExecArgs, Package};
-use once_cell::sync::Lazy;
 
 /// Write timeout for writing the arguments to exec-wasmtime.
 #[cfg(unix)]
@@ -80,13 +79,11 @@ impl Exec for NilExec {
     }
 }
 
-pub static EXECS: Lazy<Vec<Box<dyn Exec>>> = Lazy::new(|| {
-    vec![
-        #[cfg(enarx_with_shim)]
-        Box::new(exec_wasmtime::WasmExec),
-        Box::new(NilExec),
-    ]
-});
+pub static EXECS: &[&dyn Exec] = &[
+    #[cfg(enarx_with_shim)]
+    &exec_wasmtime::WasmExec,
+    &NilExec,
+];
 
 pub fn keep_exec(
     backend: &dyn Backend,


### PR DESCRIPTION
Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
