### PR TITLE
fix: return `ExitCode`, don't 'exit'

### DIFF
--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -160,7 +160,7 @@ impl super::super::Thread for Thread {
 
         if self.cssa > 3 {
             error!("CSSA overflow");
-            std::process::exit(1);
+            return Ok(Command::Exit(1));
         }
 
         // If we have handled an InvalidOpcode error, evaluate the sallyport.
@@ -210,7 +210,7 @@ impl super::super::Thread for Thread {
                             error!(
                                 "exit({code}) syscall used over sallyport, when it should not be"
                             );
-                            std::process::exit(1);
+                            return Ok(Command::Exit(1));
                         }
 
                         // Catch exit_group for a clean shutdown

--- a/src/cli/config/init.rs
+++ b/src/cli/config/init.rs
@@ -3,6 +3,7 @@
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::path::Path;
+use std::process::ExitCode;
 
 use anyhow::bail;
 use clap::Args;
@@ -13,7 +14,7 @@ use enarx_config::CONFIG_TEMPLATE;
 pub struct Options;
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let enarx_toml_path = Path::new("Enarx.toml");
         if enarx_toml_path.exists() {
             bail!("{enarx_toml_path:?} does already exist.");
@@ -25,6 +26,6 @@ impl Options {
             .open(enarx_toml_path)?;
 
         enarx_toml.write_all(CONFIG_TEMPLATE.as_bytes())?;
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/config/mod.rs
+++ b/src/cli/config/mod.rs
@@ -2,6 +2,8 @@
 
 mod init;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// Commands for working with Enarx configuration files.
@@ -11,7 +13,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Init(cmd) => cmd.execute(),
         }

--- a/src/cli/key/mod.rs
+++ b/src/cli/key/mod.rs
@@ -3,6 +3,8 @@
 pub mod sev;
 mod sgx;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// Commands for utilizing keys to interact with Enarx.
@@ -16,7 +18,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Sgx(subcmd) => subcmd.dispatch(),
             Self::Sev(subcmd) => subcmd.dispatch(),

--- a/src/cli/key/sev/create.rs
+++ b/src/cli/key/sev/create.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::stdout;
+use std::process::ExitCode;
 
 use camino::Utf8PathBuf;
 use clap::Args;
@@ -20,7 +21,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let rng = rand::thread_rng();
         let signing_key = SigningKey::random(rng);
 
@@ -33,6 +34,6 @@ impl Options {
             stdout().write_all(res_key.as_bytes())?;
         }
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/key/sev/digest.rs
+++ b/src/cli/key/sev/digest.rs
@@ -7,6 +7,7 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::stdout;
+use std::process::ExitCode;
 
 use anyhow::{bail, Context};
 use camino::Utf8PathBuf;
@@ -52,7 +53,7 @@ fn sev_key_digest(sev_key: &SigningKey) -> anyhow::Result<Vec<u8>> {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let mut sev_key_file = File::open(&self.key).context("Failed to open SEV key file")?;
         let mut buffer = String::new();
         sev_key_file.read_to_string(&mut buffer)?;
@@ -68,7 +69,7 @@ impl Options {
             stdout().write_all(out.as_bytes())?;
         }
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }
 

--- a/src/cli/key/sev/mod.rs
+++ b/src/cli/key/sev/mod.rs
@@ -4,6 +4,8 @@ mod create;
 mod digest;
 pub mod sign;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// SEV-specific functionality
@@ -15,7 +17,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Digest(cmd) => cmd.execute(),
             Self::Sign(cmd) => cmd.execute(),

--- a/src/cli/key/sev/sign.rs
+++ b/src/cli/key/sev/sign.rs
@@ -6,6 +6,7 @@ use crate::backend::ByteSized;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::prelude::*;
+use std::process::ExitCode;
 
 use anyhow::{bail, Context};
 use camino::Utf8PathBuf;
@@ -82,7 +83,7 @@ pub fn sign_id_sev_key(
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let mut sev_author_key_file =
             File::open(&self.author_key).context("Failed to open SEV author key file")?;
         let mut buffer = String::new();
@@ -105,7 +106,7 @@ impl Options {
         f.write_all(&buf)
             .with_context(|| format!("Failed to write to output file {}", self.out))?;
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }
 

--- a/src/cli/key/sgx/create.rs
+++ b/src/cli/key/sgx/create.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::stdout;
+use std::process::ExitCode;
 
 use camino::Utf8PathBuf;
 use clap::Args;
@@ -20,7 +21,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let mut rng = thread_rng();
         let exp = BigUint::from(3u8);
         let key = RsaPrivateKey::new_with_exp(&mut rng, 384 * 8, &exp)?;
@@ -34,6 +35,6 @@ impl Options {
             stdout().write_all(res_key.as_bytes())?;
         }
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/key/sgx/digest.rs
+++ b/src/cli/key/sgx/digest.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::stdout;
+use std::process::ExitCode;
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
@@ -39,7 +40,7 @@ pub fn sgx_key_digest(sgx_key: &RsaPrivateKey) -> anyhow::Result<Vec<u8>> {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let mut sgx_key = File::open(&self.key).context("Failed to open SGX key file")?;
         let mut buffer = String::new();
         sgx_key.read_to_string(&mut buffer)?;
@@ -55,7 +56,7 @@ impl Options {
             stdout().write_all(out.as_bytes())?;
         }
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }
 

--- a/src/cli/key/sgx/mod.rs
+++ b/src/cli/key/sgx/mod.rs
@@ -3,6 +3,8 @@
 mod create;
 mod digest;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// SGX-specific functionality
@@ -13,7 +15,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Create(cmd) => cmd.execute(),
             Self::Digest(cmd) => cmd.execute(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,6 +17,7 @@ mod user;
 use crate::backend::{Backend, BACKENDS};
 
 use std::ops::Deref;
+use std::process::ExitCode;
 use std::str::FromStr;
 
 use anyhow::{anyhow, bail};
@@ -46,7 +47,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         self.logger.init();
 
         info!("logging initialized!");
@@ -84,7 +85,7 @@ enum Subcommands {
 }
 
 impl Subcommands {
-    fn dispatch(self) -> anyhow::Result<()> {
+    fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Run(cmd) => cmd.execute(),
             Self::Config(subcmd) => subcmd.dispatch(),

--- a/src/cli/package/fetch.rs
+++ b/src/cli/package/fetch.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Download a local copy of a package.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/package/info.rs
+++ b/src/cli/package/info.rs
@@ -3,6 +3,7 @@
 use crate::drawbridge::{client, TagSpec};
 
 use std::ffi::OsString;
+use std::process::ExitCode;
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
@@ -24,7 +25,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let cl = client(
             self.spec.host,
             self.oidc_domain,
@@ -38,6 +39,6 @@ impl Options {
             .context("Failed to retrieve package information")?;
         println!("{}", serde_json::to_string_pretty(&tag_entry)?);
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/package/mod.rs
+++ b/src/cli/package/mod.rs
@@ -5,6 +5,8 @@ mod info;
 mod publish;
 mod yank;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// Commands for working with Enarx packages.
@@ -19,7 +21,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Info(cmd) => cmd.execute(),
             Self::Fetch(cmd) => cmd.execute(),

--- a/src/cli/package/publish.rs
+++ b/src/cli/package/publish.rs
@@ -4,6 +4,7 @@ use crate::drawbridge::{client, TagSpec};
 
 use std::ffi::OsString;
 use std::fs::read_dir;
+use std::process::ExitCode;
 
 use anyhow::{bail, Context};
 use camino::Utf8PathBuf;
@@ -26,7 +27,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let cl = client(
             self.spec.host,
             self.oidc_domain,
@@ -59,6 +60,6 @@ impl Options {
             .create_from_path_unsigned(self.path)
             .context("Failed to create tag and upload tree")?;
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/package/yank.rs
+++ b/src/cli/package/yank.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Yank a published package.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/platform/info.rs
+++ b/src/cli/platform/info.rs
@@ -4,6 +4,7 @@ use crate::backend::{Backend, BACKENDS};
 
 use std::fmt::{self, Formatter};
 use std::ops::Deref;
+use std::process::ExitCode;
 
 use clap::Args;
 #[cfg(unix)]
@@ -19,7 +20,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let backends = BACKENDS.deref();
 
         #[cfg(windows)]
@@ -70,7 +71,7 @@ impl Options {
             println!("{}", info);
         }
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }
 

--- a/src/cli/platform/mod.rs
+++ b/src/cli/platform/mod.rs
@@ -6,6 +6,8 @@ mod sgx;
 #[cfg(enarx_with_shim)]
 mod snp;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// Commands for configuration of trusted execution environments.
@@ -21,7 +23,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Info(cmd) => cmd.execute(),
             #[cfg(enarx_with_shim)]

--- a/src/cli/platform/sgx/mod.rs
+++ b/src/cli/platform/sgx/mod.rs
@@ -2,6 +2,8 @@
 
 mod register;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// SGX-specific functionality
@@ -11,7 +13,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Register(cmd) => cmd.execute(),
         }

--- a/src/cli/platform/sgx/register.rs
+++ b/src/cli/platform/sgx/register.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use anyhow::Context;
 use clap::Args;
 
@@ -13,7 +15,7 @@ const URL: &str = "https://api.trustedservices.intel.com/sgx/registration/v1/pla
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let path = format!("{PATH}/{EFI_NAME}-{EFI_UUID}");
         let bytes = std::fs::read(path).context("unable to read platform data")?;
 
@@ -21,6 +23,6 @@ impl Options {
             .set("Content-Type", "application/octet-stream")
             .send_bytes(&bytes[8..])?;
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/platform/snp/mod.rs
+++ b/src/cli/platform/snp/mod.rs
@@ -3,6 +3,8 @@
 mod update;
 mod vcek;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// SNP-specific functionality
@@ -13,7 +15,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Vcek(cmd) => cmd.execute(),
             Self::Update(cmd) => cmd.execute(),

--- a/src/cli/platform/snp/update.rs
+++ b/src/cli/platform/snp/update.rs
@@ -2,6 +2,8 @@
 
 use crate::backend::sev::snp::vcek::vcek_write;
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Download the current VCEK certificate for this platform
@@ -10,9 +12,8 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         // try to write to the system cache
-        vcek_write()?;
-        Ok(())
+        vcek_write().map(|()| ExitCode::SUCCESS)
     }
 }

--- a/src/cli/platform/snp/vcek.rs
+++ b/src/cli/platform/snp/vcek.rs
@@ -3,6 +3,7 @@
 use crate::backend::sev::snp::vcek::{get_vcek_reader, get_vcek_reader_with_path, sev_cache_dir};
 
 use std::io::{self, ErrorKind};
+use std::process::ExitCode;
 
 use clap::Args;
 
@@ -15,12 +16,12 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         if self.file {
             match get_vcek_reader_with_path(sev_cache_dir()?) {
                 Ok((path, _)) => {
                     println!("{:?}", path);
-                    Ok(())
+                    Ok(ExitCode::SUCCESS)
                 }
                 Err(e) => {
                     if matches!(
@@ -28,7 +29,7 @@ impl Options {
                         Some(ErrorKind::NotFound)
                     ) {
                         eprintln!("No cache file found.");
-                        Ok(())
+                        Ok(ExitCode::SUCCESS)
                     } else {
                         Err(e)
                     }
@@ -37,7 +38,7 @@ impl Options {
         } else {
             let mut reader = get_vcek_reader()?;
             io::copy(&mut reader, &mut io::stdout())?;
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
     }
 }

--- a/src/cli/repo/info.rs
+++ b/src/cli/repo/info.rs
@@ -3,6 +3,7 @@
 use crate::drawbridge::{client, RepoSpec};
 
 use std::ffi::OsString;
+use std::process::ExitCode;
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
@@ -32,7 +33,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let cl = client(
             self.spec.host,
             self.oidc_domain,
@@ -47,6 +48,6 @@ impl Options {
         let tags = repo.tags().context("Failed to retrieve repository tags")?;
         let info = RepoInfo { config, tags };
         println!("{}", serde_json::to_string_pretty(&info)?);
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/repo/mod.rs
+++ b/src/cli/repo/mod.rs
@@ -6,6 +6,8 @@ mod search;
 mod token;
 mod yank;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// Commands for working with repositories on an Enarx package host.
@@ -22,7 +24,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Info(cmd) => cmd.execute(),
             Self::Register(cmd) => cmd.execute(),

--- a/src/cli/repo/register.rs
+++ b/src/cli/repo/register.rs
@@ -3,6 +3,7 @@
 use crate::drawbridge::{client, RepoSpec};
 
 use std::ffi::OsString;
+use std::process::ExitCode;
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
@@ -25,7 +26,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let cl = client(
             self.spec.host,
             self.oidc_domain,
@@ -40,6 +41,6 @@ impl Options {
         };
         repo.create(&repo_config)
             .context("Failed to register repository")?;
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/repo/search.rs
+++ b/src/cli/repo/search.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Search for repositories that match a given query.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/repo/token/generate.rs
+++ b/src/cli/repo/token/generate.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Generate a new access token for a repository.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/repo/token/info.rs
+++ b/src/cli/repo/token/info.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// List the names of all outstanding access tokens for a repository.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/repo/token/mod.rs
+++ b/src/cli/repo/token/mod.rs
@@ -4,6 +4,8 @@ mod generate;
 mod info;
 mod revoke;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// Commands for working with repository access tokens.
@@ -15,7 +17,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Info(cmd) => cmd.execute(),
             Self::Generate(cmd) => cmd.execute(),

--- a/src/cli/repo/token/revoke.rs
+++ b/src/cli/repo/token/revoke.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Revoke a repository access token.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/repo/yank.rs
+++ b/src/cli/repo/yank.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Yank all packages published to a repository.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -7,6 +7,7 @@ use crate::exec::{open_package, run_package, EXECS};
 use std::fmt::Debug;
 #[cfg(unix)]
 use std::os::unix::io::IntoRawFd;
+use std::process::ExitCode;
 
 use anyhow::anyhow;
 use camino::Utf8PathBuf;
@@ -41,7 +42,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let Self {
             backend,
             wasmcfgfile,
@@ -79,7 +80,7 @@ impl Options {
             Ok(pkg)
         };
 
-        let code = run_package(
+        run_package(
             backend,
             exec,
             signatures,
@@ -88,7 +89,6 @@ impl Options {
             #[cfg(feature = "gdb")]
             Some(gdblisten),
             get_pkg,
-        )?;
-        std::process::exit(code);
+        )
     }
 }

--- a/src/cli/sign.rs
+++ b/src/cli/sign.rs
@@ -12,6 +12,7 @@ use std::io::prelude::*;
 use std::io::{stdout, Read};
 use std::mem::size_of;
 use std::ops::Deref;
+use std::process::ExitCode;
 
 use crate::backend::sev::snp::sign::PublicKey;
 use anyhow::{anyhow, bail, Context, Result};
@@ -134,7 +135,7 @@ impl Options {
         Ok((sev_key, sev_id_key_signature))
     }
 
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         use mmarinus::{perms, Map, Private};
         let binary = if let Some(ref path) = self.binpath {
             Some(Map::load(path, Private, perms::Read)?)
@@ -187,7 +188,7 @@ impl Options {
         } else {
             stdout().write_all(serde_json::to_string(&signatures)?.as_bytes())?;
         }
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }
 

--- a/src/cli/tree/digest.rs
+++ b/src/cli/tree/digest.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Calculate the cryptographic digest of a set of files.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/tree/fetch.rs
+++ b/src/cli/tree/fetch.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Download a file tree from an Enarx package host.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/tree/info.rs
+++ b/src/cli/tree/info.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Retrieve information about a file tree on an Enarx package host.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/tree/mod.rs
+++ b/src/cli/tree/mod.rs
@@ -4,6 +4,8 @@ mod digest;
 mod fetch;
 mod info;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// Commands for working with file trees inside of Enarx packages.
@@ -15,7 +17,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Info(cmd) => cmd.execute(),
             Self::Fetch(cmd) => cmd.execute(),

--- a/src/cli/unstable/exec.rs
+++ b/src/cli/unstable/exec.rs
@@ -2,6 +2,8 @@
 
 use crate::cli::BackendOptions;
 
+use std::process::ExitCode;
+
 use camino::Utf8PathBuf;
 use clap::Args;
 
@@ -40,7 +42,7 @@ pub struct Options {
 
 #[cfg(enarx_with_shim)]
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         use crate::backend::Signatures;
 
         let Self {
@@ -70,7 +72,6 @@ impl Options {
         #[cfg(feature = "gdb")]
         let gdblisten = Some(gdblisten);
 
-        let exit_code = keep_exec(backend, backend.shim(), binary, signatures, gdblisten)?;
-        std::process::exit(exit_code);
+        keep_exec(backend, backend.shim(), binary, signatures, gdblisten)
     }
 }

--- a/src/cli/unstable/mod.rs
+++ b/src/cli/unstable/mod.rs
@@ -2,6 +2,8 @@
 
 mod exec;
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 /// Deliberately unstable commands.
@@ -15,7 +17,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             #[cfg(not(enarx_with_shim))]
             Self::Exec(_) => anyhow::bail!("exec option not supported"),

--- a/src/cli/user/info.rs
+++ b/src/cli/user/info.rs
@@ -3,6 +3,7 @@
 use crate::drawbridge::{client, UserSpec};
 
 use std::ffi::OsString;
+use std::process::ExitCode;
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
@@ -24,7 +25,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let cl = client(
             self.spec.host,
             self.oidc_domain,
@@ -37,6 +38,6 @@ impl Options {
             .get()
             .with_context(|| format!("Failed to get record for user: {}", self.spec.ctx.name))?;
         println!("{}", serde_json::to_string_pretty(&record)?);
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/user/login.rs
+++ b/src/cli/user/login.rs
@@ -4,6 +4,7 @@ use super::oidc_client_secret;
 use crate::drawbridge::{LoginContext, OidcLoginFlow};
 
 use std::ffi::OsString;
+use std::process::ExitCode;
 
 use clap::Args;
 use oauth2::url::Url;
@@ -28,7 +29,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let Self {
             ref oidc_domain,
             oidc_client_id,
@@ -51,6 +52,6 @@ impl Options {
 
         println!("Login successful.");
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/user/logout.rs
+++ b/src/cli/user/logout.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::process::ExitCode;
+
 use clap::Args;
 
 /// Log out of an Enarx package host and delete local credentials.
@@ -7,7 +9,7 @@ use clap::Args;
 pub struct Options {}
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         unimplemented!()
     }
 }

--- a/src/cli/user/mod.rs
+++ b/src/cli/user/mod.rs
@@ -6,6 +6,7 @@ mod logout;
 mod register;
 
 use std::env::{var, VarError};
+use std::process::ExitCode;
 
 use anyhow::bail;
 use clap::Subcommand;
@@ -22,7 +23,7 @@ pub enum Subcommands {
 }
 
 impl Subcommands {
-    pub fn dispatch(self) -> anyhow::Result<()> {
+    pub fn dispatch(self) -> anyhow::Result<ExitCode> {
         match self {
             Self::Info(cmd) => cmd.execute(),
             Self::Login(cmd) => cmd.execute(),

--- a/src/cli/user/register.rs
+++ b/src/cli/user/register.rs
@@ -4,6 +4,7 @@ use super::oidc_client_secret;
 use crate::drawbridge::{client, get_token, LoginContext, OidcLoginFlow, UserSpec};
 
 use std::ffi::OsString;
+use std::process::ExitCode;
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
@@ -38,7 +39,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<()> {
+    pub fn execute(self) -> anyhow::Result<ExitCode> {
         let Self {
             ca_bundle,
             insecure_auth_token,
@@ -105,6 +106,6 @@ impl Options {
         user.create(&record)
             .context("Failed to register new user")?;
 
-        Ok(())
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,11 @@ mod exec;
 #[cfg(enarx_with_shim)]
 mod protobuf;
 
+use std::process::ExitCode;
+
 use clap::Parser;
 
-fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<ExitCode> {
     let app = cli::Options::parse();
     app.execute()
 }


### PR DESCRIPTION
This ensures that `enarx` binary exits only in one stable (except for `thread` failure) location (`main`) in a consistent way and makes sure that all destructors run

Closes https://github.com/enarx/enarx/issues/2383

cc @ish-meal
