### PR TITLE
feat: set the keep's DEBUG flag on features dbg or gdb

### DIFF
--- a/crates/shim-kvm/src/main.rs
+++ b/crates/shim-kvm/src/main.rs
@@ -35,8 +35,17 @@ use rcrt1::dyn_reloc;
 use sallyport::{elf::note, REQUIRES};
 use x86_64::registers::control::{Cr0Flags, Cr4Flags, EferFlags};
 
+const POLICY_FLAGS: PolicyFlags = PolicyFlags::SMT;
+
+#[cfg(not(any(features = "dbg", features = "gdb")))]
+const KEEP_POLICY_FLAGS: PolicyFlags = POLICY_FLAGS;
+
+#[cfg(any(features = "dbg", features = "gdb"))]
+const KEEP_POLICY_FLAGS: PolicyFlags =
+    PolicyFlags::from_bits_truncate(POLICY_FLAGS.bits() | POLICY_FLAGS::DEBUG.bits());
+
 const POLICY: u64 = Policy {
-    flags: PolicyFlags::SMT,
+    flags: KEEP_POLICY_FLAGS,
     minfw: Version {
         major: 1,
         minor: 51,

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -51,8 +51,17 @@ const XFRM: Xfrm = Xfrm::from_bits_truncate(
         | Xfrm::HI16_ZMM.bits(),
 );
 
+const FEATURES: Features = Features::MODE64BIT;
+
+#[cfg(any(features = "dbg", features = "gdb"))]
+const KEEP_FEATURES: Features =
+    Features::from_bits_truncate(FEATURES.bits() | Features::DEBUG.bits());
+
+#[cfg(not(any(features = "dbg", features = "gdb")))]
+const KEEP_FEATURES: Features = FEATURES;
+
 /// Default enclave CPU attributes
-pub const ATTR: Attributes = Attributes::new(Features::MODE64BIT, XFRM);
+pub const ATTR: Attributes = Attributes::new(KEEP_FEATURES, XFRM);
 
 /// Default miscelaneous SSA data selector
 pub const MISC: MiscSelect = {


### PR DESCRIPTION
This will prevent, that these keeps will get an attestation validation.

Signed-off-by: Harald Hoyer <harald@profian.com>

Fixes: https://github.com/enarx/enarx/issues/1408