### PR TITLE
fix: refine sgx error handling especially for threads

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -25,6 +25,7 @@ use binary::{Binary, Loader, Mapper};
 
 use std::fs::File;
 use std::io::Read;
+use std::panic::UnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -210,7 +211,7 @@ pub trait Keep {
     fn spawn(self: Arc<Self>) -> Result<Option<Box<dyn Thread>>>;
 }
 
-pub trait Thread: Send {
+pub trait Thread: Send + UnwindSafe {
     /// Enters the keep.
     fn enter(&mut self, gdblisten: &Option<String>) -> Result<Command>;
 }

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -13,7 +13,7 @@ use std::mem::{size_of, MaybeUninit};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use sallyport::item;
 use sallyport::item::{Block, Item};
 use sgx::enclu::{EENTER, EEXIT, ERESUME};
@@ -159,8 +159,8 @@ impl super::super::Thread for Thread {
         }
 
         if self.cssa > 3 {
-            error!("CSSA overflow");
-            return Ok(Command::Exit(1));
+            error!("SGX CSSA overflow");
+            bail!("SGX CSSA overflow");
         }
 
         // If we have handled an InvalidOpcode error, evaluate the sallyport.
@@ -210,7 +210,9 @@ impl super::super::Thread for Thread {
                             error!(
                                 "exit({code}) syscall used over sallyport, when it should not be"
                             );
-                            return Ok(Command::Exit(1));
+                            bail!(
+                                "exit({code}) syscall used over sallyport, when it should not be"
+                            );
                         }
 
                         // Catch exit_group for a clean shutdown


### PR DESCRIPTION
Some cases are real errors and not normal exit stati.
Also catch panics in child threads and use `process:exit()` to terminate everything immediately.
