### PR TITLE
fix: unused import: `std::process::ExitCode`

### DIFF
--- a/src/cli/unstable/exec.rs
+++ b/src/cli/unstable/exec.rs
@@ -2,8 +2,6 @@
 
 use crate::cli::BackendOptions;
 
-use std::process::ExitCode;
-
 use camino::Utf8PathBuf;
 use clap::Args;
 
@@ -42,7 +40,7 @@ pub struct Options {
 
 #[cfg(enarx_with_shim)]
 impl Options {
-    pub fn execute(self) -> anyhow::Result<ExitCode> {
+    pub fn execute(self) -> anyhow::Result<std::process::ExitCode> {
         use crate::backend::Signatures;
 
         let Self {


### PR DESCRIPTION
for `#[cfg(not(enarx_with_shim))]`.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
