### PR TITLE
ci: fix labeler github token permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
     - uses: actions/labeler@v4
       with:


### PR DESCRIPTION
After changing the default permissions for the Actions tokens, this makes sure the labeler still has permissions to update issues.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>