### PR TITLE
feat: add flame graph

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
           - name: debug
           - name: debug with dbg
             flag: --features=dbg
+          - name: debug with bench
+            flag: --features=bench
           - name: release
             flag: --release
 
@@ -63,6 +65,8 @@ jobs:
           - name: default-features
           - name: gdb
             flag: --features=gdb
+          - name: bench
+            flag: --features=bench
 
   macos:
     name: enarx MacOS

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ target/
 output/
 .idea/
 .vscode/
-tracing.folded
-*.svg

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 output/
 .idea/
 .vscode/
+tracing.folded
+*.svg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
  "testaso",
  "toml",
  "tracing",
+ "tracing-flame",
  "tracing-subscriber",
  "ureq",
  "url",
@@ -3689,6 +3690,17 @@ checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,7 @@ dependencies = [
  "tempfile",
  "toml",
  "tracing",
+ "tracing-flame",
  "tracing-subscriber",
  "ureq",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 gdb = ["dep:gdbstub", "enarx-shim-kvm/gdb", "enarx-shim-sgx/gdb"]
 dbg = [ "enarx-shim-kvm/dbg", "enarx-shim-sgx/dbg" ]
 disable-sgx-attestation = ["enarx-shim-sgx/disable-sgx-attestation"]
+bench = ["dep:tracing-flame", "enarx-exec-wasmtime/bench", "enarx-shim-kvm/bench", "enarx-shim-sgx/bench"]
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
@@ -34,7 +35,6 @@ hex = { workspace = true }
 keyring = { workspace = true }
 libc = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_info", "std"] }
-tracing-flame = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["ansi", "smallvec", "std", "tracing-log"] }
 oauth2 = { workspace = true }
 once_cell = { workspace = true, features = ["std"] }
@@ -51,6 +51,7 @@ url = { workspace = true }
 
 # optional dependencies
 gdbstub = { workspace = true, features = ["std"], optional = true }
+tracing-flame = { workspace = true, optional = true }
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 const-default = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ hex = { workspace = true }
 keyring = { workspace = true }
 libc = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_info", "std"] }
+tracing-flame = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["ansi", "smallvec", "std", "tracing-log"] }
 oauth2 = { workspace = true }
 once_cell = { workspace = true, features = ["std"] }
@@ -202,6 +203,7 @@ tempfile = { version = "3.3.0", default-features = false }
 testaso = { version = "0.1.0", default-features = false }
 toml = { version = "0.5.9", default-features = false }
 tracing = { version = "0.1.36", features = ["attributes"], default-features = false }
+tracing-flame = { version = "0.2.0", default-features = false }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter", "fmt"], default-features = false }
 ureq = { version = "2.4.0", default-features = false }
 url = { version = "2.2.2", default-features = false }

--- a/crates/exec-wasmtime/Cargo.toml
+++ b/crates/exec-wasmtime/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["The Enarx Project Developers"]
 repository = "https://github.com/enarx/enarx"
 license = "Apache-2.0"
 
+[features]
+bench = ["dep:tracing-flame"]
+
 [dependencies]
 anyhow = { workspace = true }
 cap-std = { workspace = true }
@@ -41,7 +44,7 @@ zeroize = { workspace = true }
 io-extras = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-tracing-flame = { workspace = true }
+tracing-flame = { workspace = true, optional = true }
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 sallyport = { workspace = true }

--- a/crates/exec-wasmtime/Cargo.toml
+++ b/crates/exec-wasmtime/Cargo.toml
@@ -40,6 +40,9 @@ zeroize = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 io-extras = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+tracing-flame = { workspace = true }
+
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 sallyport = { workspace = true }
 

--- a/crates/exec-wasmtime/src/lib.rs
+++ b/crates/exec-wasmtime/src/lib.rs
@@ -54,7 +54,7 @@ pub fn execute() -> anyhow::Result<()> {
     use anyhow::Context;
     use tracing::level_filters::LevelFilter;
     use tracing_subscriber::prelude::*;
-    use tracing_subscriber::{fmt, registry};
+    use tracing_subscriber::registry;
 
     // This is the FD of a Unix socket on which the host will send the TOML-encoded execution arguments
     // and shutdown the write half of it immediately after.
@@ -87,9 +87,12 @@ pub fn execute() -> anyhow::Result<()> {
     };
     let log_level: LevelFilter = log_level.map(Into::into).into();
     {
-        // TODO: Default to a secure log target
-        // https://github.com/enarx/enarx/issues/1042
-        let registry = registry().with(fmt::layer().with_filter(log_level));
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            // TODO: Default to a secure log target
+            // https://github.com/enarx/enarx/issues/1042
+            .with_writer(std::io::stderr)
+            .with_filter(log_level);
+        let registry = registry().with(fmt_layer);
         #[cfg(feature = "bench")]
         let registry = registry.with(flame_layer);
         let _guard = registry.set_default();

--- a/crates/exec-wasmtime/src/lib.rs
+++ b/crates/exec-wasmtime/src/lib.rs
@@ -17,6 +17,8 @@ pub use workload::{Package, Workload, PACKAGE_CONFIG, PACKAGE_ENTRYPOINT};
 
 use runtime::Runtime;
 
+use wiggle::tracing::instrument;
+
 /// The Arguments
 // NOTE: `repr(C)` is required, otherwise `toml` serialization fails with `values must be emitted before tables`
 #[derive(Debug)]
@@ -36,6 +38,7 @@ pub struct Args {
 }
 
 /// Execute package
+#[instrument]
 pub fn execute_package(pkg: Package) -> anyhow::Result<()> {
     Runtime::execute(pkg).map(|_| ())
 }

--- a/crates/exec-wasmtime/src/log.rs
+++ b/crates/exec-wasmtime/src/log.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+/// The level at which `exec-wasmtime` should log.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum Level {
+    /// Trace log level
+    Trace,
+    /// Debug log level
+    Debug,
+    /// Info log level
+    Info,
+    /// Warn log level
+    Warn,
+    /// Error log level
+    Error,
+}
+
+impl From<tracing::Level> for Level {
+    fn from(level: tracing::Level) -> Self {
+        match level {
+            tracing::Level::TRACE => Self::Trace,
+            tracing::Level::DEBUG => Self::Debug,
+            tracing::Level::INFO => Self::Info,
+            tracing::Level::WARN => Self::Warn,
+            tracing::Level::ERROR => Self::Error,
+        }
+    }
+}
+
+impl From<Level> for tracing::Level {
+    fn from(level: Level) -> Self {
+        match level {
+            Level::Trace => Self::TRACE,
+            Level::Debug => Self::DEBUG,
+            Level::Info => Self::INFO,
+            Level::Warn => Self::WARN,
+            Level::Error => Self::ERROR,
+        }
+    }
+}

--- a/crates/exec-wasmtime/src/main.rs
+++ b/crates/exec-wasmtime/src/main.rs
@@ -6,8 +6,6 @@
 #![warn(rust_2018_idioms)]
 
 use enarx_exec_wasmtime::execute;
-use tracing_subscriber::prelude::*;
-use tracing_subscriber::{fmt, EnvFilter};
 
 /// Set FSBASE
 ///
@@ -36,10 +34,5 @@ pub extern "C" fn __set_thread_area(p: *mut core::ffi::c_void) -> core::ffi::c_i
 }
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_default_env())
-        .init();
-
     execute()
 }

--- a/crates/exec-wasmtime/src/runtime/identity/mod.rs
+++ b/crates/exec-wasmtime/src/runtime/identity/mod.rs
@@ -7,7 +7,6 @@ mod platform;
 
 use pki::PrivateKeyInfoExt;
 use platform::{Platform, Technology};
-use tracing::instrument;
 
 use std::time::Duration;
 
@@ -22,6 +21,7 @@ use getrandom::getrandom;
 use pkcs8::PrivateKeyInfo;
 use sha2::{Digest, Sha256, Sha384};
 use url::Url;
+use wiggle::tracing::instrument;
 use x509_cert::attr::Attribute;
 use x509_cert::der::asn1::{BitStringRef, UIntRef};
 use x509_cert::der::{AnyRef, Decode, Encode};

--- a/crates/exec-wasmtime/src/runtime/identity/mod.rs
+++ b/crates/exec-wasmtime/src/runtime/identity/mod.rs
@@ -7,6 +7,7 @@ mod platform;
 
 use pki::PrivateKeyInfoExt;
 use platform::{Platform, Technology};
+use tracing::instrument;
 
 use std::time::Duration;
 
@@ -63,6 +64,7 @@ fn csr(pki: &PrivateKeyInfo<'_>, exts: Vec<Extension<'_>>) -> anyhow::Result<Vec
 }
 
 /// Generates a new private key and corresponding CSR
+#[instrument]
 pub fn generate() -> anyhow::Result<(Zeroizing<Vec<u8>>, Vec<u8>)> {
     let platform = Platform::get()?;
     let cert_algo = match platform.technology() {
@@ -103,6 +105,7 @@ pub fn generate() -> anyhow::Result<(Zeroizing<Vec<u8>>, Vec<u8>)> {
     Ok((raw, req))
 }
 
+#[instrument(skip(csr))]
 pub fn steward(url: &Url, csr: impl AsRef<[u8]>) -> anyhow::Result<Vec<Vec<u8>>> {
     if url.scheme() != "https" {
         bail!("refusing to use an unencrypted steward url");
@@ -122,6 +125,7 @@ pub fn steward(url: &Url, csr: impl AsRef<[u8]>) -> anyhow::Result<Vec<Vec<u8>>>
     path.iter().rev().map(|c| Ok(c.to_vec()?)).collect()
 }
 
+#[instrument(skip(key))]
 pub fn selfsigned(key: impl AsRef<[u8]>) -> anyhow::Result<Vec<Vec<u8>>> {
     let pki = PrivateKeyInfo::from_der(key.as_ref())?;
 

--- a/crates/exec-wasmtime/src/runtime/mod.rs
+++ b/crates/exec-wasmtime/src/runtime/mod.rs
@@ -15,12 +15,12 @@ use super::{Package, Workload};
 use anyhow::{bail, Context};
 use enarx_config::{Config, File};
 use once_cell::sync::Lazy;
-use tracing::{instrument, trace_span};
 use wasi_common::file::FileCaps;
 use wasi_common::WasiFile;
 use wasmtime::{AsContextMut, Engine, Linker, Module, Store, Trap, Val};
 use wasmtime_wasi::stdio::{stderr, stdin, stdout};
 use wasmtime_wasi::{add_to_linker, WasiCtxBuilder};
+use wiggle::tracing::{instrument, trace_span};
 
 /// Wasmtime config
 static WASMTIME_CONFIG: Lazy<wasmtime::Config> = Lazy::new(|| {

--- a/crates/exec-wasmtime/src/workload.rs
+++ b/crates/exec-wasmtime/src/workload.rs
@@ -12,6 +12,7 @@ use drawbridge_client::types::{Meta, TagEntry, TreeDirectory, TreeEntry, TreeNam
 use drawbridge_client::{scope, Client, Entity, Node, Scope};
 use enarx_config::Config;
 use once_cell::sync::Lazy;
+use tracing::instrument;
 use ureq::serde_json;
 use url::Url;
 
@@ -126,6 +127,7 @@ pub struct Workload {
 impl TryFrom<Package> for Workload {
     type Error = anyhow::Error;
 
+    #[instrument]
     fn try_from(mut pkg: Package) -> Result<Self, Self::Error> {
         match pkg {
             Package::Remote(ref url) => {

--- a/crates/exec-wasmtime/src/workload.rs
+++ b/crates/exec-wasmtime/src/workload.rs
@@ -12,9 +12,9 @@ use drawbridge_client::types::{Meta, TagEntry, TreeDirectory, TreeEntry, TreeNam
 use drawbridge_client::{scope, Client, Entity, Node, Scope};
 use enarx_config::Config;
 use once_cell::sync::Lazy;
-use tracing::instrument;
 use ureq::serde_json;
 use url::Url;
+use wiggle::tracing::instrument;
 
 /// Name of package entrypoint file
 pub static PACKAGE_ENTRYPOINT: Lazy<TreeName> = Lazy::new(|| "main.wasm".parse().unwrap());

--- a/crates/shim-kvm/Cargo.toml
+++ b/crates/shim-kvm/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [features]
 gdb = ["dep:gdbstub", "dep:gdbstub_arch", "dbg"]
 dbg = []
+bench = []
 
 [dependencies]
 aes-gcm = { workspace = true }

--- a/crates/shim-kvm/src/start.rs
+++ b/crates/shim-kvm/src/start.rs
@@ -30,10 +30,10 @@ use x86_64::registers::control::{Cr0Flags, Cr4Flags, EferFlags};
 
 const POLICY_FLAGS: PolicyFlags = PolicyFlags::SMT;
 
-#[cfg(not(any(features = "dbg", features = "gdb")))]
+#[cfg(not(any(features = "dbg", features = "gdb", features = "bench")))]
 const KEEP_POLICY_FLAGS: PolicyFlags = POLICY_FLAGS;
 
-#[cfg(any(features = "dbg", features = "gdb"))]
+#[cfg(any(features = "dbg", features = "gdb", features = "bench"))]
 const KEEP_POLICY_FLAGS: PolicyFlags =
     PolicyFlags::from_bits_truncate(POLICY_FLAGS.bits() | POLICY_FLAGS::DEBUG.bits());
 

--- a/crates/shim-sgx/Cargo.toml
+++ b/crates/shim-sgx/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [features]
 gdb = ["dep:gdbstub", "dep:gdbstub_arch", "dbg"]
 dbg = []
+bench = []
 disable-sgx-attestation = []
 
 [dependencies]

--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -56,11 +56,11 @@ const XFRM: Xfrm = Xfrm::from_bits_truncate(
 
 const FEATURES: Features = Features::MODE64BIT;
 
-#[cfg(any(features = "dbg", features = "gdb"))]
+#[cfg(any(features = "dbg", features = "gdb", features = "bench"))]
 const KEEP_FEATURES: Features =
     Features::from_bits_truncate(FEATURES.bits() | Features::DEBUG.bits());
 
-#[cfg(not(any(features = "dbg", features = "gdb")))]
+#[cfg(not(any(features = "dbg", features = "gdb", features = "bench")))]
 const KEEP_FEATURES: Features = FEATURES;
 
 /// Default enclave CPU attributes

--- a/src/backend/nil.rs
+++ b/src/backend/nil.rs
@@ -108,7 +108,7 @@ impl super::Thread for Thread {
         enarx_exec_wasmtime::execute()?;
 
         #[cfg(windows)]
-        enarx_exec_wasmtime::execute_with_args(self.0.take().unwrap())?;
+        enarx_exec_wasmtime::execute_package(self.0.take().unwrap().package)?;
 
         Ok(super::Command::Exit(0))
     }

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -45,7 +45,7 @@ impl Options {
     pub fn execute(
         self,
         #[cfg(unix)] log_level: Option<enarx_exec_wasmtime::LogLevel>,
-        #[cfg(unix)] profile: Option<impl IntoRawFd>,
+        #[cfg(all(unix, feature = "bench"))] profile: Option<impl IntoRawFd>,
     ) -> anyhow::Result<ExitCode> {
         let Self {
             backend,
@@ -141,7 +141,7 @@ impl Options {
                     get_pkg,
                     #[cfg(unix)]
                     log_level,
-                    #[cfg(unix)]
+                    #[cfg(all(unix, feature = "bench"))]
                     profile,
                 )
             }
@@ -156,7 +156,7 @@ impl Options {
                 || Ok(Package::Remote(package)),
                 #[cfg(unix)]
                 log_level,
-                #[cfg(unix)]
+                #[cfg(all(unix, feature = "bench"))]
                 profile,
             ),
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,6 +16,7 @@ mod user;
 
 use crate::backend::{Backend, BACKENDS};
 
+use std::fs::File;
 use std::ops::Deref;
 use std::process::ExitCode;
 use std::str::FromStr;
@@ -23,6 +24,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, bail};
 use clap::{ArgAction, Args, Parser, Subcommand};
 use tracing::info;
+use tracing_flame::FlameLayer;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
 
@@ -48,7 +50,7 @@ pub struct Options {
 
 impl Options {
     pub fn execute(self) -> anyhow::Result<ExitCode> {
-        self.logger.init();
+        let _guard = self.logger.init();
 
         info!("logging initialized!");
         info!("CLI opts: {:?}", self);
@@ -166,17 +168,27 @@ pub struct LogOptions {
 
 impl LogOptions {
     /// Build & initialize a global logger using [EnvFilter::builder].
-    pub fn init(&self) {
+    /// As with Builder::init(), this will panic if called more than once,
+    /// or if another library has already initialized a global logger.
+    pub fn init(&self) -> impl Drop {
         let env_filter = EnvFilter::builder()
             .with_default_directive(self.verbosity_level().into())
             .parse_lossy(self.log_filter.as_ref().unwrap_or(&"".to_owned()));
 
-        let fmt_layer = fmt::layer().with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
+        let fmt_layer = fmt::layer()
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .with_filter(env_filter);
+
+        let file = File::open("/dev/null"); // reserve fd 3
+        let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
+        drop(file);
 
         tracing_subscriber::registry()
             .with(fmt_layer)
-            .with(env_filter)
+            .with(flame_layer)
             .init();
+
+        _guard
     }
 
     /// Convert the -vvv.. count into a log level.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -57,7 +57,7 @@ impl Options {
             .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
             .with_filter(env_filter);
 
-        let (flame_layer, _) = if let Some(ref profile) = self.logger.profile {
+        let (flame_layer, _guard) = if let Some(ref profile) = self.logger.profile {
             // Open `/dev/null` to reserve fd 3 on Unix, which `exec-wasmtime` will expect to read config from
             // It will be dropped at the end of this block, freeing it for the following socketpair call
             #[cfg(unix)]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -45,7 +45,7 @@ impl Options {
     pub fn execute(
         self,
         #[cfg(unix)] log_level: Option<enarx_exec_wasmtime::LogLevel>,
-        #[cfg(unix)] profile: Option<impl IntoRawFd>,
+        #[cfg(all(unix, feature = "bench"))] profile: Option<impl IntoRawFd>,
     ) -> anyhow::Result<ExitCode> {
         let Self {
             backend,
@@ -95,7 +95,7 @@ impl Options {
             get_pkg,
             #[cfg(unix)]
             log_level,
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "bench"))]
             profile,
         )
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -42,7 +42,11 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn execute(self) -> anyhow::Result<ExitCode> {
+    pub fn execute(
+        self,
+        #[cfg(unix)] log_level: Option<enarx_exec_wasmtime::LogLevel>,
+        #[cfg(unix)] profile: Option<impl IntoRawFd>,
+    ) -> anyhow::Result<ExitCode> {
         let Self {
             backend,
             wasmcfgfile,
@@ -89,6 +93,10 @@ impl Options {
             #[cfg(feature = "gdb")]
             Some(gdblisten),
             get_pkg,
+            #[cfg(unix)]
+            log_level,
+            #[cfg(unix)]
+            profile,
         )
     }
 }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -30,10 +30,12 @@ use std::convert::Into;
 use std::fs::File;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(all(unix, feature = "bench"))]
+use std::os::unix::prelude::IntoRawFd;
 use std::path::PathBuf;
 use std::process::ExitCode;
 #[cfg(unix)]
-use std::{os::unix::prelude::IntoRawFd, time::Duration};
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use enarx_exec_wasmtime::{Args as ExecArgs, Package};
@@ -153,7 +155,7 @@ pub fn run_package(
     gdblisten: Option<String>,
     package: impl FnOnce() -> Result<Package>,
     log_level: Option<enarx_exec_wasmtime::LogLevel>,
-    profile: Option<impl IntoRawFd>,
+    #[cfg(feature = "bench")] profile: Option<impl IntoRawFd>,
 ) -> Result<ExitCode> {
     use std::io::Write;
     use std::net::Shutdown;
@@ -170,12 +172,11 @@ pub fn run_package(
     );
 
     let package = package()?;
-    // On `nil` backend, currently active logging configuration will be used.
-    let profile = profile.map(IntoRawFd::into_raw_fd);
     let args = toml::to_vec(&ExecArgs {
         package,
         log_level,
-        profile,
+        #[cfg(feature = "bench")]
+        profile: profile.map(IntoRawFd::into_raw_fd),
     })
     .context("failed to encode exec-wasmtime arguments")?;
 


### PR DESCRIPTION
partially closes #2176 
Refs https://github.com/enarx/enarx/issues/1042 (the `log-filter` part, `log-target` is still TODO)

produce flame graph with (requires inferno crate)
`cat tracing.folded | inferno-flamegraph > tracing-flamegraph.svg;`

![tracing-flamegraph](https://user-images.githubusercontent.com/44672716/207484513-f2abd53e-f1af-497f-a41f-cd66b56c011d.png)

notes:
add more functions to flame graph?
logging might have been broken (enarx -v)
includes wiggle