### PR TITLE
build: make commissery no longer check PR titles

### DIFF
--- a/.github/workflows/commisery.yml
+++ b/.github/workflows/commisery.yml
@@ -38,3 +38,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         pull_request: ${{ github.event.number }}
+        validate-pull-request: false
+        validate-pull-request-title-bump: false
+


### PR DESCRIPTION
We have no need for this feature and it causes no end of annoyance.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
