### PR TITLE
feat(sgx): handle CSSA 0-3 with 2 sallyport blocks

### DIFF
--- a/crates/shim-sgx/layout.ld
+++ b/crates/shim-sgx/layout.ld
@@ -62,7 +62,7 @@ SECTIONS {
         . += 16;
         QUAD(ADDR(.enarx.ssa))   /* OSSA */
         LONG(0)                   /* CSSA */
-        LONG(3)                   /* NSSA */
+        LONG(4)                   /* NSSA */
         QUAD(_start)              /* OENTRY */
         . = ALIGN(4K);
     } :tcs =0

--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -439,7 +439,7 @@ impl<'a> Handler<'a> {
     }
 
     /// Finish handling an exception
-    pub fn finish(ssa: &'a mut StateSaveArea, block: &'a mut [usize], tcb: &'a mut Tcb) {
+    pub fn finish(ssa: &'a mut StateSaveArea, block: Option<&'a mut [usize]>, tcb: &'a mut Tcb) {
         if let Some(Vector::InvalidOpcode) = ssa.vector() {
             if let OP_SYSCALL | OP_CPUID = unsafe { read_unaligned(ssa.gpr.rip as _) } {
                 // Skip the instruction.
@@ -448,8 +448,10 @@ impl<'a> Handler<'a> {
             }
         }
 
-        let mut h = Self::new(ssa, block, tcb, 0);
-        h.print_ssa_stack_trace();
+        if let Some(block) = block {
+            let mut h = Self::new(ssa, block, tcb, 0);
+            h.print_ssa_stack_trace();
+        }
 
         unsafe { asm!("ud2", options(noreturn)) };
     }


### PR DESCRIPTION
CSSA 1 and 2 get their own block.
CSSA 0 and 3 don't need a block.

Normal block usage looks like this:
* Enclave CSSA 0 fills in registers and executes syscall op.
* Host sees exception, calls CSSA 1 with sallyport block 0.
  * Enclave CSSA 1 fills in sallyport block, executes syscall op.
  * Host sees exception, handles sallyport block 0 and calls CSSA 2.
    * Enclave CSSA 2 confirms CSSA 1 syscall op and increases instruction pointer of CSSA 1. Exits to the host.
    * Host sees clean EEXIT of CSSA 2, calls CSSA 1.
  * Enclave CSSA 1 continues after syscall op and handles sallyport block 0, then increases CSSA 0 instruction pointer and   exits to the host.
  * Host sees clean EEXIT of CSSA 1, calls CSSA 0.
* Enclave CSSA 0 handles result of syscall.

Now, if there was lazy memory allocation for CSSA 0, with page fault handling, the following situation could occur: While enclave CSSA 1 handles the result of sallyport block 0 and copies data back to the userspace memory, a page fault could occur. Therefore we need a second sallyport block, which could be uses by CSSA 2 to handle the page fault occuring in CSSA 1.

This situation looks like this:
* Enclave CSSA 0 fills in registers and executes syscall op.
* Host sees exception, calls CSSA 1 with sallyport block 0.
  * Enclave CSSA 1 fills in sallyport block, executes syscall op.
  * Host sees exception, handles sallyport block 0 and calls CSSA 2.
    * Enclave CSSA 2 confirms CSSA 1 syscall op and increases instruction pointer of CSSA 1. Exits to the host.
    * Host sees clean EEXIT of CSSA 2, calls CSSA 1.
  * Enclave CSSA 1 continues after syscall op and handles sallyport block 0, and encountes a page fault for touching not yet mapped memory of CSSA 0.
  * Host sees page fault exception, calls CSSA 2.
    * CSSA 2 sees page fault exception, does some memory operations using sallyport block 1 and syscall op.
    * Host sees syscall exception, handles sallyport block 1 and calls CSSA 3.
      * Enclave CSSA 3 confirms CSSA 2 syscall op and increases instruction pointer of CSSA 2. Exits to the host.
      * Host sees clean EEXIT of CSSA 3, calls CSSA 2.
    * Enclave CSSA 2 continues after syscall op and handles sallyport block 1, then increases CSSA 1 instruction pointer and exits to the thost.
    * Host sees clean EEXIT of CSSA 2, calls CSSA 1.
  * Enclave CSSA 1 continues handling sallyport block 0, now that the page
  is correctly mapped, then increases CSSA 0 instruction pointer and exits
  to the host.
  * Host sees clean EEXIT of CSSA 1, calls CSSA 0.
* Enclave CSSA 0 handles result of syscall.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
