### PR TITLE
chore: better CRL fetching and parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid 0.9.0",
  "der_derive",
@@ -1119,7 +1119,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85789ce7dfbd0f0624c07ef653a08bb2ebf43d3e16531361f46d36dd54334fed"
 dependencies = [
- "der 0.6.0",
+ "der 0.6.1",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1139,7 +1139,7 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.4.8",
- "der 0.6.0",
+ "der 0.6.1",
  "digest 0.10.5",
  "ff",
  "generic-array",
@@ -1165,6 +1165,7 @@ dependencies = [
  "clap",
  "colorful",
  "const-default",
+ "der 0.6.1",
  "dirs",
  "drawbridge-client",
  "drawbridge-server",
@@ -1220,6 +1221,7 @@ dependencies = [
  "url",
  "vdso",
  "wat",
+ "x509-cert",
  "x86_64",
 ]
 
@@ -2627,7 +2629,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der 0.6.0",
+ "der 0.6.1",
  "spki 0.6.0",
 ]
 
@@ -3118,7 +3120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der 0.6.0",
+ "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
  "subtle",
@@ -3461,7 +3463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der 0.6.0",
+ "der 0.6.1",
 ]
 
 [[package]]
@@ -4410,7 +4412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd27a832a85efcf56cad058e4e3256d1781b927e113a9e37d96916d639e4af7"
 dependencies = [
  "const-oid 0.9.0",
- "der 0.6.0",
+ "der 0.6.1",
  "flagset",
  "spki 0.6.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ gdbstub = { workspace = true, features = ["std"], optional = true }
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 const-default = { workspace = true }
+der = { workspace = true }
 goblin = { workspace = true, features = ["elf32", "endian_fd", "std"], default-features = false }
 iocuddle = { workspace = true }
 kvm-bindings = { workspace = true }
@@ -72,6 +73,7 @@ sgx = { workspace = true, features = ["rcrypto"] }
 static_assertions = { workspace = true }
 ureq = { workspace = true }
 vdso = { workspace = true }
+x509-cert = { workspace = true }
 x86_64 = { workspace = true, features = ["instructions"] }
 
 # binary dependencies
@@ -145,6 +147,7 @@ colorful = { version = "0.2.0", default-features = false }
 const-default = { version = "1.0.0", default-features = false }
 const-oid = { version = "0.9.0", default-features = false }
 crt0stack = { version = "0.1.0", default-features = false }
+der = { version = "0.6.1", features = ["std"], default-features = false }
 dirs = { version = "4.0.0", default-features = false }
 drawbridge-client = { version = "0.2.2", default-features = false }
 drawbridge-server = { version = "0.2.2", default-features = false }

--- a/src/cli/platform/caching.rs
+++ b/src/cli/platform/caching.rs
@@ -1,34 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;
-use std::fs::OpenOptions;
-use std::path::Path;
 
-use sha2::{Digest, Sha256};
-
-/// Fetch a URL and save the contents as the hash of the URL
-pub fn save_file(url: &str, dest: &Path) -> anyhow::Result<()> {
-    let mut response = ureq::get(url)
+/// Fetch a URL and return the bytes
+pub fn fetch_file(url: &str) -> anyhow::Result<Vec<u8>> {
+    let mut reader = ureq::get(url)
         .call()
         .context(format!("retrieving CRL {url} from server"))?
         .into_reader();
 
-    let mut dest = dest.to_path_buf();
-    dest.push(hex::encode(Sha256::digest(url)));
+    let mut bytes = vec![];
+    reader
+        .read_to_end(&mut bytes)
+        .context("reading bytes buffer")?;
 
-    let mut file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(&dest)
-        .context(format!(
-            "opening destination file {:?} for saving CRL {url}",
-            dest.display()
-        ))?;
-
-    std::io::copy(&mut response, &mut file).context(format!(
-        "saving CRL {url} to destination file {:?}",
-        dest.display()
-    ))?;
-
-    Ok(())
+    Ok(bytes)
 }

--- a/src/cli/platform/snp/crl.rs
+++ b/src/cli/platform/snp/crl.rs
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::caching::save_file;
+use super::super::caching::fetch_file;
 use crate::backend::sev::snp::vcek::sev_cache_dir;
 
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::process::ExitCode;
 
+use anyhow::Context;
 use clap::Args;
+#[allow(unused_imports)]
+use der::{Decode, Encode};
+use x509_cert::crl::CertificateList;
+#[allow(unused_imports)]
+use x509_cert::der::Decode as _; // required for Musl target
+#[allow(unused_imports)]
+use x509_cert::der::Encode as _; // required for Musl target
 
 const GENOA: &str = "https://kdsintf.amd.com/vcek/v1/Genoa/crl";
 const MILAN: &str = "https://kdsintf.amd.com/vcek/v1/Milan/crl";
@@ -17,9 +27,34 @@ pub struct CrlCache {}
 
 impl CrlCache {
     pub fn execute(self) -> anyhow::Result<ExitCode> {
-        let dir = sev_cache_dir()?;
-        save_file(GENOA, &dir)?;
-        save_file(MILAN, &dir)?;
+        let mut dest_file = sev_cache_dir()?;
+        dest_file.push("crls.der");
+
+        let crls = [
+            fetch_file(GENOA).context(format!("fetching {GENOA}"))?,
+            fetch_file(MILAN).context(format!("fetching {MILAN}"))?,
+        ];
+
+        let crls = [
+            CertificateList::from_der(&crls[0])?,
+            CertificateList::from_der(&crls[1])?,
+        ];
+
+        let crls = crls
+            .to_vec()
+            .context("converting AMD CRLs to DER encoding")?;
+
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&dest_file)
+            .context(format!(
+                "opening destination file {dest_file:?} for saving AMD CRLs"
+            ))?
+            .write_all(&crls)
+            .context(format!("writing AMD CRLs to file {dest_file:?}"))?;
+
         Ok(ExitCode::SUCCESS)
     }
 }


### PR DESCRIPTION
A few changes were made to how CRLs are fetched.
* Validate the CRL by deserializing it
* Make an array of the CRL structs
* Serialize to ASN1
* Save as a file in the correct directory (vs having multiple files).

Signed-off-by: Richard Zak <richard@profian.com>