### PR TITLE
feat(sgx): add page fault handling and lazy mmap

### DIFF
--- a/crates/shim-sgx/src/lib.rs
+++ b/crates/shim-sgx/src/lib.rs
@@ -37,9 +37,12 @@ pub const CSSA_0_STACK_SIZE: usize = 0x800000 - Page::SIZE; // 8MB - TCB
 pub const CSSA_1_PLUS_STACK_SIZE: usize =
     0x800000 - Page::SIZE - NUM_SSA * core::mem::size_of::<StateSaveArea>(); // 8MB - TCS - SSA
 
-/// FIXME: doc
-pub const ENCL_SIZE_BITS: u8 = 32;
-/// FIXME: doc
+/// Defines the size of the enclave address space
+///
+/// This is now 16GB, enough for wasmtime to allocate 8GB of memory for the wasm payload
+/// and still have some memory left for the shim and the stack.
+pub const ENCL_SIZE_BITS: u8 = 34;
+/// Defines the size of the enclave address space
 pub const ENCL_SIZE: usize = 1 << ENCL_SIZE_BITS;
 
 const XFRM: Xfrm = Xfrm::from_bits_truncate(
@@ -63,14 +66,8 @@ const KEEP_FEATURES: Features = FEATURES;
 /// Default enclave CPU attributes
 pub const ATTR: Attributes = Attributes::new(KEEP_FEATURES, XFRM);
 
-/// Default miscelaneous SSA data selector
-pub const MISC: MiscSelect = {
-    if cfg!(dbg) {
-        MiscSelect::EXINFO
-    } else {
-        MiscSelect::empty()
-    }
-};
+/// Default miscellaneous SSA data selector
+pub const MISC: MiscSelect = MiscSelect::EXINFO;
 
 /// The size of the sallyport block
 pub const BLOCK_SIZE: usize = 69632;

--- a/src/backend/sgx/enarxcall.rs
+++ b/src/backend/sgx/enarxcall.rs
@@ -302,9 +302,7 @@ pub(crate) fn sgx_enarxcall<'a>(
 
             // Safety: the parameters have been sanity checked before, that only
             // enclave memory is unmapped.
-            unsafe {
-                libc::munmap(*addr as *mut _, *len);
-            }
+            unsafe { libc::munmap(*addr as *mut _, *len) };
 
             let remove_pages = RemovePages::new(*addr - keep.mem.addr(), *len);
             remove_pages

--- a/src/backend/sgx/enarxcall.rs
+++ b/src/backend/sgx/enarxcall.rs
@@ -229,15 +229,14 @@ pub(crate) fn sgx_enarxcall<'a>(
             ret,
             ..
         } => {
-            let fd_locked = keep.enclave.lock().unwrap();
-            let mut fd_cloned = fd_locked.try_clone().unwrap();
+            let mut fd_locked = keep.enclave.lock().unwrap();
             // Safety: an `mmap()` call is pointed to a file descriptor of the
             // created enclave, and can therefore only affect the memory
             // mappings within the address range given to ENCLAVE_CREATE.
             match unsafe {
                 Map::bytes(*len)
                     .onto(*addr)
-                    .from(&mut fd_cloned, 0)
+                    .from(&mut *fd_locked, 0)
                     .with_kind(Shared)
                     .with(perms::Unknown(*prot as i32))
             } {

--- a/src/backend/sgx/thread.rs
+++ b/src/backend/sgx/thread.rs
@@ -133,15 +133,13 @@ impl super::super::Thread for Thread {
             EENTER | ERESUME if run.vector == Vector::InvalidOpcode => EENTER,
             EENTER | ERESUME if run.vector == Vector::Page => {
                 trace!(
-                    "Vector::Page: address = {:>#016x}, error code = {:>#016b} cssa={}",
-                    run.exception_addr,
+                    ?run.vector,
+                    run.exception_addr = ?(run.exception_addr as *const u8),
                     run.exception_error_code,
-                    self.cssa
+                    cssa = self.cssa
                 );
-
                 EENTER
             }
-
             EEXIT if self.cssa > 0 => ERESUME,
             EEXIT if self.cssa == 0 => {
                 trace!("exit({exit_status})");
@@ -151,8 +149,11 @@ impl super::super::Thread for Thread {
             _ => {
                 if cfg!(feature = "dbg") {
                     error!(
-                        "Unexpected {:?}: address = {:>#016x}, error code = {:>#016b} cssa={}",
-                        run.vector, run.exception_addr, run.exception_error_code, self.cssa
+                        ?run.vector,
+                        run.exception_addr = ?(run.exception_addr as *const u8),
+                        run.exception_error_code,
+                        cssa = self.cssa,
+                        "Unexpected exception",
                     );
                     EENTER
                 } else {


### PR DESCRIPTION
This will allow to map the whole 2GB address range of the wasm application, which will speedup execution a lot.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
