### PR TITLE
fix: use `spin` crate instead of `spinning`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ dependencies = [
  "primordial",
  "rcrt1",
  "sallyport",
- "spinning",
+ "spin 0.9.4",
  "testaso",
  "x86_64",
  "xsave",
@@ -1314,7 +1314,7 @@ dependencies = [
  "rcrt1",
  "sallyport",
  "sgx",
- "spinning",
+ "spin 0.9.4",
  "testaso",
  "x86_64",
  "xsave",
@@ -2109,7 +2109,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -2953,7 +2953,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -3438,10 +3438,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spinning"
-version = "0.1.0"
+name = "spin"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ serial_test = { version = "0.9.0", default-features = false }
 sgx = { version = "0.5.0", default-features = false }
 sha2 = { version = "0.10.2", default-features = false }
 shell-words = { version = "1.1.0", default-features = false }
-spinning = { version = "0.1.0", default-features = false }
+spin = { version = "0.9.4", default-features = false, features = ["lock_api", "spin_mutex", "rwlock", "lazy"] }
 static_assertions = { version = "1.1.0", default-features = false }
 tempfile = { version = "3.3.0", default-features = false }
 testaso = { version = "0.1.0", default-features = false }

--- a/crates/shim-kvm/Cargo.toml
+++ b/crates/shim-kvm/Cargo.toml
@@ -26,7 +26,7 @@ paste = { workspace = true }
 primordial = { workspace = true }
 rcrt1 = { workspace = true }
 sallyport = { workspace = true }
-spinning = { workspace = true }
+spin = { workspace = true }
 x86_64 = { workspace = true, features = ["inline_asm", "instructions"] }
 xsave = { workspace = true }
 

--- a/crates/shim-kvm/src/allocator.rs
+++ b/crates/shim-kvm/src/allocator.rs
@@ -23,7 +23,7 @@ use lset::{Line, Span};
 use nbytes::bytes;
 use primordial::{Address, Page as Page4KiB};
 use sallyport::guest::Handler;
-use spinning::Lazy;
+use spin::Lazy;
 use x86_64::instructions::tlb::flush_all;
 use x86_64::structures::paging::mapper::{MapToError, UnmapError};
 use x86_64::structures::paging::{
@@ -206,8 +206,8 @@ impl EnarxAllocator {
 
         let end_of_mem = mem_start + mem_size;
 
-        *NEXT_MMAP_RWLOCK.write() =
-            (*NEXT_MMAP_RWLOCK.read() + code_size).align_up(Page::<Size4KiB>::SIZE);
+        let mut nmr = NEXT_MMAP_RWLOCK.write();
+        *nmr = (*nmr + code_size).align_up(Page::<Size4KiB>::SIZE);
 
         let allocator = Heap::empty();
 

--- a/crates/shim-kvm/src/debug.rs
+++ b/crates/shim-kvm/src/debug.rs
@@ -181,7 +181,7 @@ unsafe fn stack_trace_from_rbp(mut rbp: usize) {
     print::_eprint(format_args!("TRACE:\n"));
 
     if SHIM_PAGETABLE.try_read().is_none() {
-        SHIM_PAGETABLE.force_unlock_write()
+        SHIM_PAGETABLE.force_write_unlock()
     }
 
     let shim_offset = SHIM_VIRT_OFFSET as usize;

--- a/crates/shim-kvm/src/gdt.rs
+++ b/crates/shim-kvm/src/gdt.rs
@@ -8,7 +8,7 @@ use crate::syscall::_syscall_enter;
 use core::ops::Deref;
 
 use nbytes::bytes;
-use spinning::Lazy;
+use spin::Lazy;
 use x86_64::instructions::segmentation::{Segment, Segment64, CS, DS, ES, FS, GS, SS};
 use x86_64::instructions::tables::load_tss;
 use x86_64::registers::model_specific::{KernelGsBase, LStar, SFMask, Star};

--- a/crates/shim-kvm/src/hostcall.rs
+++ b/crates/shim-kvm/src/hostcall.rs
@@ -28,7 +28,7 @@ use sallyport::libc::{
 };
 use sallyport::util::ptr::is_aligned_non_null;
 use sallyport::{libc, KVM_SYSCALL_TRIGGER_PORT};
-use spinning::Lazy;
+use spin::Lazy;
 use x86_64::instructions::port::Port;
 use x86_64::instructions::segmentation::{Segment64, FS, GS};
 use x86_64::instructions::tlb::flush_all;

--- a/crates/shim-kvm/src/interrupts.rs
+++ b/crates/shim-kvm/src/interrupts.rs
@@ -16,7 +16,7 @@ use core::mem::size_of;
 use core::ops::Deref;
 
 use paste::paste;
-use spinning::Lazy;
+use spin::Lazy;
 use x86_64::structures::idt::InterruptDescriptorTable;
 use x86_64::VirtAddr;
 use xsave::XSave;

--- a/crates/shim-kvm/src/snp/ghcb.rs
+++ b/crates/shim-kvm/src/snp/ghcb.rs
@@ -19,7 +19,7 @@ use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce, Tag};
 use bitflags::bitflags;
 use const_default::ConstDefault;
 use sallyport::libc::{EINVAL, EIO};
-use spinning::Lazy;
+use spin::Lazy;
 use x86_64::registers::model_specific::Msr;
 use x86_64::structures::paging::{Page, Size4KiB};
 use x86_64::{PhysAddr, VirtAddr};

--- a/crates/shim-kvm/src/snp/secrets_page.rs
+++ b/crates/shim-kvm/src/snp/secrets_page.rs
@@ -4,7 +4,7 @@
 
 use crate::spin::{Locked, RacyCell};
 
-use spinning::Lazy;
+use spin::Lazy;
 
 /// The SEV-SNP secrets page OS area
 ///

--- a/crates/shim-kvm/src/spin.rs
+++ b/crates/shim-kvm/src/spin.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! wrapper around spinning types to permit trait implementations.
+//! wrapper around spin types to permit trait implementations.
 
 use core::cell::UnsafeCell;
-use spinning::{Mutex, MutexGuard, RawMutex, RawRwLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use spin::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// Cell type that should be preferred over a `static mut` is better to use in a
 /// `static`
@@ -38,7 +38,7 @@ impl<T> RacyCell<T> {
 
 unsafe impl<T: Sync> Sync for RacyCell<T> {}
 
-/// A wrapper around spinning::Mutex to permit trait implementations.
+/// A wrapper around spin::Mutex to permit trait implementations.
 pub struct Locked<A> {
     inner: Mutex<A>,
 }
@@ -48,18 +48,18 @@ impl<A> Locked<A> {
     #[inline]
     pub const fn new(inner: A) -> Self {
         Self {
-            inner: Mutex::const_new(RawMutex::const_new(), inner),
+            inner: Mutex::new(inner),
         }
     }
 
-    /// get a [`MutexGuard`](spinning::MutexGuard)
+    /// get a [`MutexGuard`](spin::MutexGuard)
     #[inline]
     pub fn lock(&self) -> MutexGuard<'_, A> {
         self.inner.lock()
     }
 }
 
-/// A wrapper around spinning::RwLock to permit trait implementations.
+/// A wrapper around spin::RwLock to permit trait implementations.
 pub struct RwLocked<A> {
     inner: RwLock<A>,
 }
@@ -69,17 +69,17 @@ impl<A> RwLocked<A> {
     #[inline]
     pub const fn new(inner: A) -> Self {
         Self {
-            inner: RwLock::const_new(RawRwLock::const_new(), inner),
+            inner: RwLock::new(inner),
         }
     }
 
-    /// get a [`RwLockReadGuard`](spinning::RwLockReadGuard)
+    /// get a [`RwLockReadGuard`](spin::RwLockReadGuard)
     #[inline]
     pub fn read(&self) -> RwLockReadGuard<'_, A> {
         self.inner.read()
     }
 
-    /// get a [`RwLockWriteGuard`](spinning::RwLockWriteGuard)
+    /// get a [`RwLockWriteGuard`](spin::RwLockWriteGuard)
     #[inline]
     pub fn write(&self) -> RwLockWriteGuard<'_, A> {
         self.inner.write()

--- a/crates/shim-kvm/src/syscall.rs
+++ b/crates/shim-kvm/src/syscall.rs
@@ -13,7 +13,7 @@ use sallyport::guest::Handler;
 use sallyport::item::enarxcall::{SYS_GETATT, SYS_GETKEY};
 #[cfg(feature = "dbg")]
 use sallyport::libc::{SYS_write, STDERR_FILENO, STDOUT_FILENO};
-use spinning::Lazy;
+use spin::Lazy;
 
 #[repr(C)]
 struct X8664DoubleReturn {

--- a/crates/shim-sgx/Cargo.toml
+++ b/crates/shim-sgx/Cargo.toml
@@ -23,7 +23,7 @@ primordial = { workspace = true, features = ["const-default"] }
 rcrt1 = { workspace = true }
 sallyport = { workspace = true }
 sgx = { workspace = true }
-spinning = { workspace = true }
+spin = { workspace = true }
 x86_64 = { workspace = true }
 xsave = { workspace = true }
 

--- a/crates/shim-sgx/src/handler/mod.rs
+++ b/crates/shim-sgx/src/handler/mod.rs
@@ -60,7 +60,7 @@ use sallyport::libc::{
 use sgx::page::{Class, Flags};
 use sgx::ssa::StateSaveArea;
 use sgx::ssa::Vector;
-use spinning::{Lazy, RwLock};
+use spin::{Lazy, RwLock};
 use x86_64::addr::VirtAddr;
 use x86_64::structures::paging::Page as PageAddr;
 

--- a/crates/shim-sgx/src/thread.rs
+++ b/crates/shim-sgx/src/thread.rs
@@ -11,7 +11,7 @@ use crate::{CSSA_0_STACK_SIZE, CSSA_1_PLUS_STACK_SIZE, NUM_SSA};
 use sallyport::guest::ThreadLocalStorage;
 use sallyport::libc::pid_t;
 use sgx::ssa::{GenPurposeRegs, StateSaveArea};
-use spinning::{Lazy, RwLock};
+use spin::{Lazy, RwLock};
 
 /// A constant array to enqueue and dequeue from.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
`spinning` showed some instabilities while implementing threads on in the VM.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
