### PR TITLE
fix(snp): remove comment about SEV-SNP TCB

### DIFF
--- a/src/backend/sev/snp/vcek.rs
+++ b/src/backend/sev/snp/vcek.rs
@@ -7,7 +7,7 @@ use std::io::{self, ErrorKind, Read};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 
 /// Return a reader, which provides the VCEK certificate
 pub fn get_vcek_reader() -> anyhow::Result<Box<dyn Read>> {
@@ -65,14 +65,6 @@ fn get_vcek_url_path() -> anyhow::Result<(String, String)> {
     let status = sev
         .platform_status()
         .context("failed to query platform status")?;
-
-    // Ensure the versions match.
-    if status.tcb.platform_version != status.tcb.reported_version {
-        // It is not clear from the documentation what the difference between the two is,
-        // therefore only proceed if they are identical to ensure correctness.
-        // TODO: Figure out which one should be used and drop this check.
-        return Err(anyhow!("reported TCB version mismatch"));
-    }
 
     let url = id.vcek_url(&status.tcb.reported_version);
 


### PR DESCRIPTION
According to AMD, the ReportedTcb is the one we need for the VCEK key.

Reported <= Committed <= Current

Further infos:
[Video]
(https://youtu.be/7R0rnQfi86I)

[Slides]
(https://developer.amd.com/wp-content/resources/LSS-SNP_Attestation-r4.pdf)

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
