### PR TITLE
build: fix `cargo clippy --workspace` and address warnings

### DIFF
--- a/crates/sallyport/src/guest/alloc/tests.rs
+++ b/crates/sallyport/src/guest/alloc/tests.rs
@@ -9,7 +9,7 @@ fn assert_block_eq<const N: usize>(got: [usize; N], expected: [usize; N]) {
     #[inline]
     fn format(iter: impl IntoIterator<Item = impl LowerHex>) -> String {
         iter.into_iter()
-            .fold("\n[\n".into(), |s, el| format!("{} {:#018x},\n", s, el))
+            .fold("\n[\n".into(), |s, el| format!("{s} {el:#018x},\n"))
             + "]\n"
     }
     assert_eq!(

--- a/crates/sallyport/src/host/mod.rs
+++ b/crates/sallyport/src/host/mod.rs
@@ -176,7 +176,7 @@ mod tests {
     #[test]
     fn deref_aligned() {
         let mut data = [0u128; 4];
-        let (prefix, mut data, suffix) = unsafe { data.align_to_mut() };
+        let (prefix, data, suffix) = unsafe { data.align_to_mut() };
         assert!(prefix.is_empty());
         assert!(suffix.is_empty());
 
@@ -196,7 +196,7 @@ mod tests {
         ];
         test_deref(
             |data, offset, len| super::deref_aligned::<u16>(data, offset, len),
-            &mut data,
+            data,
             cases,
         );
     }
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn deref_aligned_slice() {
         let mut data = [0u128; 4];
-        let (prefix, mut data, suffix) = unsafe { data.align_to_mut() };
+        let (prefix, data, suffix) = unsafe { data.align_to_mut() };
         assert!(prefix.is_empty());
         assert!(suffix.is_empty());
 
@@ -306,7 +306,7 @@ mod tests {
         ];
         test_deref(
             |data, offset, len| super::deref_aligned_slice::<u16>(data, offset, len),
-            &mut data,
+            data,
             cases,
         );
     }

--- a/crates/sallyport/src/item/mod.rs
+++ b/crates/sallyport/src/item/mod.rs
@@ -93,7 +93,7 @@ mod tests {
             (0x04, Err(EINVAL)),
             (0xff, Err(EINVAL)),
         ] {
-            assert_eq!(v.try_into(), expected, "Invalid mapping for {}", v);
+            assert_eq!(v.try_into(), expected, "Invalid mapping for {v}");
         }
     }
 }

--- a/crates/sallyport/tests/integration.rs
+++ b/crates/sallyport/tests/integration.rs
@@ -152,18 +152,18 @@ where
 {
     for i in 0..iterations {
         thread::Builder::new()
-            .name(format!("iteration {}", i))
+            .name(format!("iteration {i}"))
             .spawn(move || {
                 let mut platform = TestPlatform;
                 let mut handler = TestHandler {
-                    block: block.clone(),
+                    block,
                     tls: Default::default(),
                 };
                 f(i, &mut platform, &mut handler);
             })
-            .expect(&format!("couldn't spawn test iteration {} thread", i))
+            .unwrap_or_else(|_| panic!("couldn't spawn test iteration {i} thread"))
             .join()
-            .expect(&format!("couldn't join test iteration {} thread", i))
+            .unwrap_or_else(|_| panic!("couldn't join test iteration {i} thread"))
     }
 }
 

--- a/crates/sallyport/tests/integration.rs
+++ b/crates/sallyport/tests/integration.rs
@@ -168,8 +168,7 @@ where
 }
 
 pub fn recv_udp(sock: UdpSocket, expected: &str) {
-    let mut buf = Vec::with_capacity(expected.len());
-    buf.resize(expected.len(), 0);
+    let mut buf = vec![0; expected.len()];
     assert_eq!(
         sock.recv(&mut buf).expect("couldn't recv data"),
         expected.len()

--- a/crates/sallyport/tests/syscall/mod.rs
+++ b/crates/sallyport/tests/syscall/mod.rs
@@ -33,11 +33,7 @@ use sallyport::guest::{syscall, Handler, Platform};
 use sallyport::item::syscall::sigaction;
 use serial_test::serial;
 
-fn syscall_socket<'a, 'b>(
-    opaque: bool,
-    platform: &'a impl Platform,
-    exec: &'b mut impl Handler,
-) -> c_int {
+fn syscall_socket(opaque: bool, platform: &impl Platform, exec: &mut impl Handler) -> c_int {
     let fd = if !opaque {
         exec.socket(AF_INET, SOCK_STREAM, 0)
             .expect("couldn't execute 'socket' syscall")
@@ -56,10 +52,10 @@ fn syscall_socket<'a, 'b>(
     fd
 }
 
-fn syscall_recv<'a, 'b>(
+fn syscall_recv(
     opaque: bool,
-    platform: &'a impl Platform,
-    exec: &'b mut impl Handler,
+    platform: &impl Platform,
+    exec: &mut impl Handler,
     fd: c_int,
     buf: &mut [u8],
 ) {

--- a/crates/shim-kvm/src/interrupts.rs
+++ b/crates/shim-kvm/src/interrupts.rs
@@ -243,7 +243,7 @@ declare_interrupt!(
                     stack_frame.instruction_pointer += 2u64
                 }
             }
-            _ => panic!("Unhandled #VC: {:x?}", error_code),
+            _ => panic!("Unhandled #VC: {error_code:x?}"),
         }
     }
 );

--- a/crates/shim-kvm/src/main.rs
+++ b/crates/shim-kvm/src/main.rs
@@ -130,8 +130,8 @@ extern "sysv64" fn main() -> ! {
 ///
 /// Reverts to a triple fault, which causes a `#VMEXIT` and a KVM shutdown,
 /// if it can't print the panic and exit normally with an error code.
+#[cfg(target_os = "none")]
 #[panic_handler]
-#[cfg(not(test))]
 #[cfg_attr(coverage, no_coverage)]
 fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
     use core::sync::atomic::AtomicBool;

--- a/crates/shim-kvm/src/snp/ghcb.rs
+++ b/crates/shim-kvm/src/snp/ghcb.rs
@@ -1044,6 +1044,6 @@ mod test {
 
         let plain_slice = &mut plaintext[0..request.hdr.msg_sz as usize];
         let dec_ret = cipher.decrypt_in_place_detached(nonce, asssoc_data, plain_slice, tag);
-        let _ = dec_ret.expect("decrypt failed!");
+        dec_ret.expect("decrypt failed!");
     }
 }

--- a/crates/shim-sgx/src/main.rs
+++ b/crates/shim-sgx/src/main.rs
@@ -5,7 +5,7 @@
 //! This crate contains the system that traps the syscalls (and cpuid
 //! instructions) from the enclave code and proxies them to the host.
 
-#![no_std]
+#![cfg_attr(target_os = "none", no_std)]
 #![feature(asm_const)]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
@@ -35,8 +35,8 @@ use sallyport::{elf::note, REQUIRES};
 use sgx::parameters::{Attributes, MiscSelect};
 use sgx::ssa::{GenPurposeRegs, StateSaveArea};
 
+#[cfg(target_os = "none")]
 #[panic_handler]
-#[cfg(not(test))]
 #[allow(clippy::empty_loop)]
 fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
     loop {}

--- a/tests/crates/enarx_exec_tests/src/bin/memspike.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/memspike.rs
@@ -11,6 +11,6 @@ musl_fsbase_fix!();
 
 fn main() -> Result<(), TryReserveError> {
     let mut alloc: Vec<u8> = Vec::new();
-    let _ = alloc.try_reserve(40_000_000)?;
+    alloc.try_reserve(40_000_000)?;
     Ok(())
 }

--- a/tests/crates/enarx_exec_tests/src/bin/sev_attestation.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/sev_attestation.rs
@@ -199,7 +199,7 @@ const ASN_OCTET_STRING: u8 = 0x04;
 // header_len = tag_size + length_prefix + nbytes
 // header_len = 1 + (0 or 1) + nbytes
 fn decode_len(buf: &[u8]) -> Option<(u32, usize)> {
-    match *buf.get(0)? {
+    match *buf.first()? {
         // Note: per X.690 Section 8.1.3.6.1 the byte 0x80 encodes indefinite
         // lengths, which are not allowed in DER, so disallow that byte.
         len if len < 0x80 => Some((len.into(), 2)),
@@ -248,7 +248,7 @@ fn get_att(mut nonce: [u8; 64]) -> std::io::Result<()> {
 
     eprintln!("To be pasted in https://lapo.it/asn1js/ :");
     for b in chunks {
-        eprint!("{:02x} ", b);
+        eprint!("{b:02x} ");
     }
     eprintln!("\n");
 
@@ -279,11 +279,11 @@ fn get_att(mut nonce: [u8; 64]) -> std::io::Result<()> {
     assert_eq!(report.version, 2);
     assert_eq!(nonce, report.report_data);
 
-    eprintln!("report_buf: {:?}", report_buf);
+    eprintln!("report_buf: {report_buf:?}");
 
-    eprintln!("report: {:?}", report);
+    eprintln!("report: {report:?}");
 
-    eprintln!("vcek: {:?}", vcek_buf);
+    eprintln!("vcek: {vcek_buf:?}");
 
     eprintln!("ID_KEY_DIGEST = {}", hex::encode(report.id_key_digest));
     eprintln!(

--- a/tests/crates/enarx_exec_tests/src/bin/sgx_attestation.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/sgx_attestation.rs
@@ -113,7 +113,7 @@ fn main() -> std::io::Result<()> {
 
     let bytes = &buffer[MRSIGNER_START..][..32];
     let out = hex::encode(bytes);
-    println!("MRSIGNER = {}", out);
+    println!("MRSIGNER = {out}");
 
     let bytes = &buffer[QUOTE_SIG_START..len];
 

--- a/tests/crates/enarx_syscall_tests/src/lib.rs
+++ b/tests/crates/enarx_syscall_tests/src/lib.rs
@@ -299,10 +299,10 @@ pub fn get_att(nonce: Option<&mut [u8]>, buf: Option<&mut [u8]>) -> Result<(usiz
     let (rax, rdx) = syscall(
         SYS_GETATT,
         Args {
-            arg0: arg0,
-            arg1: arg1,
-            arg2: arg2,
-            arg3: arg3,
+            arg0,
+            arg1,
+            arg2,
+            arg3,
             ..Default::default()
         },
     );

--- a/tests/crates/enarx_wasm_tests/src/bin/listen.rs
+++ b/tests/crates/enarx_wasm_tests/src/bin/listen.rs
@@ -12,7 +12,7 @@ use std::os::unix::io::FromRawFd;
 #[cfg(target_os = "wasi")]
 use std::os::wasi::io::FromRawFd;
 
-use anyhow::{ensure, anyhow, Context, bail};
+use anyhow::{anyhow, bail, ensure, Context};
 
 fn main() -> anyhow::Result<()> {
     let fd_count: usize = env::var("FD_COUNT")

--- a/tests/crates/enarx_wasm_tests/src/bin/memspike.rs
+++ b/tests/crates/enarx_wasm_tests/src/bin/memspike.rs
@@ -8,6 +8,6 @@ use std::collections::TryReserveError;
 
 fn main() -> Result<(), TryReserveError> {
     let mut alloc: Vec<u8> = Vec::new();
-    let _ = alloc.try_reserve(16_000_000)?;
+    alloc.try_reserve(16_000_000)?;
     Ok(())
 }


### PR DESCRIPTION
Partially closes #2270 