### PR TITLE
fix: cross-platform `--workspace` support

### DIFF
--- a/crates/sallyport/src/item/block.rs
+++ b/crates/sallyport/src/item/block.rs
@@ -148,8 +148,7 @@ impl<'a> Iterator for BlockIterator<'a> {
 mod tests {
     use super::*;
     use crate::item::Header;
-
-    use libc::{SYS_exit, SYS_read, ENOSYS};
+    use crate::libc::{SYS_exit, SYS_read, ENOSYS};
 
     const HEADER_USIZE_COUNT: usize = size_of::<Header>() / size_of::<usize>();
 

--- a/crates/sallyport/src/lib.rs
+++ b/crates/sallyport/src/lib.rs
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-#![cfg(any(
-    all(test, target_arch = "x86_64", target_os = "linux"),
-    target_vendor = "unknown"
-))]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(test), no_std)]
 #![deny(clippy::all)]
@@ -14,7 +10,15 @@
 #![feature(slice_ptr_len)]
 
 pub mod elf;
+#[cfg(any(
+    all(test, target_arch = "x86_64", target_os = "linux"),
+    target_vendor = "unknown"
+))]
 pub mod guest;
+#[cfg(any(
+    all(test, target_arch = "x86_64", target_os = "linux"),
+    target_vendor = "unknown"
+))]
 pub mod host;
 pub mod item;
 pub mod libc;

--- a/tests/crates/enarx_exec_tests/src/bin/futex.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/futex.rs
@@ -2,13 +2,14 @@
 
 use enarx_exec_tests::musl_fsbase_fix;
 
-use std::io;
-use std::sync::atomic::AtomicU32;
-use std::time;
-
 musl_fsbase_fix!();
 
+#[cfg(target_os = "linux")]
 fn main() {
+    use std::io;
+    use std::sync::atomic::AtomicU32;
+    use std::time;
+
     let futex = AtomicU32::new(0);
     let futex_ptr = &futex as *const AtomicU32;
     let timespec = libc::timespec {
@@ -32,4 +33,9 @@ fn main() {
     assert_eq!(err, libc::ETIMEDOUT);
 
     assert!(now.elapsed().as_secs() >= 2);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    panic!("only supported on Linux")
 }

--- a/tests/crates/enarx_exec_tests/src/bin/unix_echo.rs
+++ b/tests/crates/enarx_exec_tests/src/bin/unix_echo.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use enarx_exec_tests::musl_fsbase_fix;
-use std::io::{self, stdin, Read, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::PathBuf;
 
 musl_fsbase_fix!();
 
-fn main() -> io::Result<()> {
+#[cfg(unix)]
+fn main() -> std::io::Result<()> {
+    use std::io::{stdin, Read, Write};
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::path::PathBuf;
+
     let mut dir_name = String::new();
 
     stdin().read_line(&mut dir_name)?;
@@ -23,4 +25,9 @@ fn main() -> io::Result<()> {
     let mut socket = UnixStream::connect(dir_name.join("enarx_unix_echo_from_bin")).unwrap();
     socket.write_all(&buffer)?;
     Ok(())
+}
+
+#[cfg(not(unix))]
+fn main() {
+    panic!("only supported on Unix")
 }

--- a/tests/crates/enarx_exec_tests/src/lib.rs
+++ b/tests/crates/enarx_exec_tests/src/lib.rs
@@ -8,6 +8,7 @@ macro_rules! musl_fsbase_fix {
         /// Set FSBASE
         ///
         /// Overwrite the only location in musl, which uses the `arch_prctl` syscall
+        #[cfg(all(target_arch = "x86_64",  target_vendor = "unknown", target_os = "linux", target_env = "musl"))]
         #[no_mangle]
         #[inline(never)]
         pub extern "C" fn __set_thread_area(p: *mut core::ffi::c_void) -> core::ffi::c_int {

--- a/tests/crates/enarx_syscall_tests/src/lib.rs
+++ b/tests/crates/enarx_syscall_tests/src/lib.rs
@@ -10,6 +10,7 @@ pub use macros::*;
 pub use sallyport::libc;
 
 use core::arch::asm;
+use core::ffi::c_long;
 
 pub type Result<T> = core::result::Result<T, i32>;
 
@@ -109,7 +110,7 @@ pub struct Args {
     pub arg5: usize,
 }
 
-pub fn syscall(nr: i64, args: Args) -> (usize, usize) {
+pub fn syscall(nr: c_long, args: Args) -> (usize, usize) {
     let rax: usize;
     let rdx: usize;
     unsafe {
@@ -234,7 +235,7 @@ pub fn close(fd: i32) -> Result<()> {
 
 pub fn is_enarx() -> bool {
     #[allow(non_upper_case_globals)]
-    const SYS_fork: i64 = 57;
+    const SYS_fork: c_long = 57;
 
     let ret = syscall(SYS_fork, Args::default()).0 as i32;
 
@@ -270,7 +271,7 @@ impl TryFrom<u64> for TeeTech {
 }
 
 pub fn get_att(nonce: Option<&mut [u8]>, buf: Option<&mut [u8]>) -> Result<(usize, TeeTech)> {
-    const SYS_GETATT: i64 = 0xEA01;
+    const SYS_GETATT: c_long = 0xEA01;
 
     let arg1 = if let Some(ref nonce) = nonce {
         nonce.len()

--- a/tests/crates/enarx_wasm_tests/src/bin/connect.rs
+++ b/tests/crates/enarx_wasm_tests/src/bin/connect.rs
@@ -2,19 +2,20 @@
 
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
-use enarx_wasm_tests::assert_stream;
-
-use std::env;
-use std::net::TcpStream;
-
 #[cfg(unix)]
 use std::os::unix::io::FromRawFd;
 #[cfg(target_os = "wasi")]
 use std::os::wasi::io::FromRawFd;
 
-use anyhow::{ensure, Context};
-
+#[cfg(any(target_os = "wasi", unix))]
 fn main() -> anyhow::Result<()> {
+    use enarx_wasm_tests::assert_stream;
+
+    use std::env;
+    use std::net::TcpStream;
+
+    use anyhow::{ensure, Context};
+
     let fd_count: usize = env::var("FD_COUNT")
         .context("failed to lookup `FD_COUNT`")?
         .parse()
@@ -29,4 +30,9 @@ fn main() -> anyhow::Result<()> {
     );
 
     assert_stream(unsafe { TcpStream::from_raw_fd(3) })
+}
+
+#[cfg(not(any(target_os = "wasi", unix)))]
+fn main() {
+    panic!("unsupported on this target")
 }

--- a/tests/crates/enarx_wasm_tests/src/bin/listen.rs
+++ b/tests/crates/enarx_wasm_tests/src/bin/listen.rs
@@ -2,19 +2,20 @@
 
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
-use enarx_wasm_tests::assert_stream;
-
-use std::net::TcpListener;
-use std::{env, io};
-
 #[cfg(unix)]
 use std::os::unix::io::FromRawFd;
 #[cfg(target_os = "wasi")]
 use std::os::wasi::io::FromRawFd;
 
-use anyhow::{anyhow, bail, ensure, Context};
-
+#[cfg(any(target_os = "wasi", unix))]
 fn main() -> anyhow::Result<()> {
+    use enarx_wasm_tests::assert_stream;
+
+    use std::net::TcpListener;
+    use std::{env, io};
+
+    use anyhow::{anyhow, bail, ensure, Context};
+
     let fd_count: usize = env::var("FD_COUNT")
         .context("failed to lookup `FD_COUNT`")?
         .parse()
@@ -56,4 +57,9 @@ fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(not(any(target_os = "wasi", unix)))]
+fn main() {
+    panic!("unsupported on this target")
 }


### PR DESCRIPTION
Fix-up Windows and Mac support broken by #2419 