### PR TITLE
fix(sallyport): use workspace version of gdbstub

### DIFF
--- a/crates/sallyport/Cargo.toml
+++ b/crates/sallyport/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = { workspace = true }
 goblin = { workspace = true }
 
 # optional dependencies
-gdbstub = { version = "0.6", optional = true, default-features = false }
+gdbstub = { workspace = true, optional = true }
 
 [dev-dependencies]
 libc = { workspace = true, features = ["extra_traits"] }


### PR DESCRIPTION
makes `cargo clippy --all-features --workspace` work.

Don't care about the documentation links possibly be broken, until we switch to gdbstub 0.6 in the future.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
