### PR TITLE
build: bump Rust toolchain to 2023-01-02

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,11 +46,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-12-14 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2023-01-02 -y
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-12-14
+          toolchain: nightly-2023-01-02
           profile: minimal
           components: llvm-tools-preview
 

--- a/.github/workflows/sbom_manifest_action.yml
+++ b/.github/workflows/sbom_manifest_action.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-musl
-          toolchain: nightly-2022-12-14
+          toolchain: nightly-2023-01-02
           override: true
 
       - name: Install cargo-cyclonedx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2022-12-14 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2023-01-02 -y
       - uses: actions-rs/toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2022-12-14
+          toolchain: nightly-2023-01-02
           profile: minimal
 
       - uses: actions-rs/cargo@v1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-12-14"
+channel = "nightly-2023-01-02"
 targets = [
     "aarch64-apple-darwin",
     "aarch64-unknown-linux-musl",

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -94,7 +94,7 @@ pub fn keep_exec(
     _gdblisten: Option<String>,
 ) -> anyhow::Result<ExitCode> {
     let keep = backend.keep(shim.as_ref(), exec.as_ref(), signatures)?;
-    let mut thread = keep.clone().spawn()?.unwrap();
+    let mut thread = keep.spawn()?.unwrap();
     loop {
         match thread.enter(&_gdblisten)? {
             Command::Continue => (),


### PR DESCRIPTION
This pulls in the Cargo bindeps bugfix that landed in https://github.com/rust-lang/cargo/pull/11478 .

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
