### PR TITLE
fix(kvm): set Cr0Flags::MONITOR_COPROCESSOR

### DIFF
--- a/crates/shim-kvm/src/start.rs
+++ b/crates/shim-kvm/src/start.rs
@@ -495,5 +495,5 @@ global_asm!(
         SEV_GHCB_MSR = const 0xC001_0130u32,
         CR4_FLAGS = const (Cr4Flags::FSGSBASE.bits() | Cr4Flags::PHYSICAL_ADDRESS_EXTENSION.bits() | Cr4Flags::OSFXSR.bits() | Cr4Flags::OSXMMEXCPT_ENABLE.bits() | Cr4Flags::OSXSAVE.bits()),
         PROTECTED_MODE_ENABLE = const Cr0Flags::PROTECTED_MODE_ENABLE.bits(),
-        CR0_PAGING = const Cr0Flags::PAGING.bits()  | Cr0Flags::WRITE_PROTECT.bits() ,
+        CR0_PAGING = const Cr0Flags::PAGING.bits()  | Cr0Flags::WRITE_PROTECT.bits() | Cr0Flags::MONITOR_COPROCESSOR.bits(),
 );


### PR DESCRIPTION
Otherwise SSE/AVX does not work properly.

Before:

AMD KVM: 544 MFLOPS

After:

AMD KVM: 1140 MFLOPS

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
