### PR TITLE
ci: fix labeler github token permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,15 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+- pull_request_review
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
 
 jobs:
   triage:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
     steps:
     - uses: actions/labeler@v4
       with:


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
