### PR TITLE
fix: set nonblocking on TCP

### DIFF
--- a/crates/exec-wasmtime/src/runtime/net/mod.rs
+++ b/crates/exec-wasmtime/src/runtime/net/mod.rs
@@ -54,6 +54,8 @@ pub fn listen_file(
     };
     let tcp = std::net::TcpListener::bind((addr.as_str(), *port))?;
     let tcp = TcpListener::from_std(tcp);
+    tcp.set_nonblocking(true)
+        .context("Error setting channel to nonblocking")?;
     let file = match file {
         ListenFile::Tcp { .. } => wasmtime_wasi::net::Socket::from(tcp).into(),
         ListenFile::Tls { .. } => {


### PR DESCRIPTION
This makes the behaviour closer to wasmtime, and also unblocks .NET from running. .NET is expecting nonblocking sockets.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>