### PR TITLE
test: fix wasm::listen_tcp

### DIFF
--- a/tests/crates/enarx_wasm_tests/src/bin/listen.rs
+++ b/tests/crates/enarx_wasm_tests/src/bin/listen.rs
@@ -30,6 +30,10 @@ fn main() -> anyhow::Result<()> {
     );
 
     let listener = unsafe { TcpListener::from_raw_fd(3) };
+    listener
+        .set_nonblocking(false)
+        .context("failed to set listener to blocking")?;
+
     let (stream, _) = listener
         .accept()
         .context("failed to accept first connection")?;


### PR DESCRIPTION
The test expects a blocking listen socket.
Because 9bd4de72d0e09c98f79614f03dea5cd4ac3dd45c sets nonblocking for the wasm preopened sockets, this test could fail.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
