### PR TITLE
docs: remove crates.io version from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 <a href="https://github.com/enarx/enarx/actions/workflows/test.yml"><img alt="Test Status", src="https://github.com/enarx/enarx/actions/workflows/test.yml/badge.svg"></a>
 <a href="https://github.com/enarx/enarx/labels/bug"><img alt="Bug Status", src="https://img.shields.io/github/issues-raw/enarx/enarx/bug"></a>
 <a href="https://github.com/enarx/enarx/pulse"><img alt="Maintenance Status", src="https://img.shields.io/github/commit-activity/y/enarx/enarx"></a>
-<a href="https://crates.io/crates/enarx"><img alt="Version Status", src="https://img.shields.io/crates/v/enarx"></a>
 <a href="https://codecov.io/gh/enarx/enarx"><img alt="Coverage Status", src="https://codecov.io/gh/enarx/enarx/branch/main/graph/badge.svg?token=03QIZXNJ2Y"></a>
 </p>
 


### PR DESCRIPTION
Since we no longer publish to crates.io

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
