### PR TITLE
fix(shim-kvm): protect against interrupt injection

### DIFF
--- a/src/backend/sev/builder.rs
+++ b/src/backend/sev/builder.rs
@@ -75,7 +75,9 @@ impl TryFrom<super::config::Config> for Builder {
                 .context("Failed to create a virtual machine")?;
 
             let sev = retry(|| Firmware::open().context("Failed to open '/dev/sev'"))?;
-            let launcher = Launcher::new(vm_fd, sev).context("SNP Launcher init failed")?;
+            // FIXME: use SnpInitFlags::RESTRICTED_INJECTION when available
+            let launcher = Launcher::new(vm_fd, sev, SnpInitFlags::empty())
+                .context("SNP Launcher init failed")?;
 
             Ok((kvm_fd, launcher))
         })?;

--- a/src/backend/sev/snp/launch/linux.rs
+++ b/src/backend/sev/snp/launch/linux.rs
@@ -105,6 +105,13 @@ pub struct Init {
     flags: u64,
 }
 
+impl Init {
+    /// Create a new `Init` command
+    pub fn new(flags: u64) -> Self {
+        Self { flags }
+    }
+}
+
 /// Initialize the flow to launch a guest.
 #[repr(C)]
 pub struct LaunchStart<'a> {

--- a/src/backend/sev/snp/launch/mod.rs
+++ b/src/backend/sev/snp/launch/mod.rs
@@ -52,14 +52,14 @@ impl<T, V: AsRawFd> AsMut<VmFd> for Launcher<T, V> {
 impl<V: AsRawFd> Launcher<New, V> {
     /// Begin the SEV-SNP launch process by creating a Launcher and issuing the
     /// KVM_SNP_INIT ioctl.
-    pub fn new(vm_fd: VmFd, sev: V) -> Result<Self> {
+    pub fn new(vm_fd: VmFd, sev: V, flags: SnpInitFlags) -> Result<Self> {
         let mut launcher = Launcher {
             vm_fd,
             sev,
             state: PhantomData::default(),
         };
 
-        let init = Init::default();
+        let init = Init::new(flags.bits());
 
         let mut cmd = Command::from(&mut launcher.sev, &init);
         SNP_INIT
@@ -179,6 +179,18 @@ impl<'a> Update<'a> {
             vmpl2_perms: perms.1,
             vmpl1_perms: perms.0,
         }
+    }
+}
+
+bitflags! {
+    #[derive(Default)]
+    /// SNP_INIT command flags.
+    pub struct SnpInitFlags: u64 {
+        /// enable the restricted interrupt/exception injection
+        const RESTRICTED_INJECTION = 1;
+
+        /// enable the restricted injection timer
+        const RESTRICTED_TIMER_INJECTION = 1 << 1;
     }
 }
 


### PR DESCRIPTION
Because the current SEV-SNP linux kernel patchset does not allow to disable interrupt injection, mitigate against:
- #VMM with error_code 0x72 (VMEXIT_CPUID)
- page_fault handler without error_code or invalid error_code

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
