### PR TITLE
feat(backend/kvm): handle park/unpark enarxcalls

### DIFF
--- a/src/backend/sgx/enarxcall.rs
+++ b/src/backend/sgx/enarxcall.rs
@@ -104,10 +104,9 @@ pub(crate) fn sgx_enarxcall<'a>(
                     // Safety: `deref_aligned` gives us a pointer to an aligned `timespec` struct.
                     // We also know, that the resulting pointer is inside the allocated sallyport block, where `data`
                     // is a subslice of.
-                    (*deref_aligned::<MaybeUninit<timespec>>(data, *timeout, 1)
+                    *deref_aligned::<timespec>(data, *timeout, 1)
                         .map_err(io::Error::from_raw_os_error)
-                        .context("sgx_enarxcall deref")?)
-                    .assume_init()
+                        .context("failed to dereference timespec in Park enarxcall")?
                 })
             } else {
                 None

--- a/tests/exec/mod.rs
+++ b/tests/exec/mod.rs
@@ -14,13 +14,7 @@ use std::sync::Arc;
 use tempfile::Builder;
 
 #[test]
-#[cfg_attr(not(host_can_test_sgx), ignore = "Backend does not support SGX")]
 fn futex() {
-    if !is_sgx() {
-        eprintln!("SGX backend is disabled, ignoring");
-        return;
-    }
-
     let bin = env!("CARGO_BIN_FILE_ENARX_EXEC_TESTS_futex");
 
     run_test(bin, 0, None, None, None);


### PR DESCRIPTION
This enables futex proxying for shim-kvm.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
