### PR TITLE
fix(shim-kvm): add TranslateFrom trait

### DIFF
--- a/crates/shim-kvm/src/exec.rs
+++ b/crates/shim-kvm/src/exec.rs
@@ -2,8 +2,9 @@
 
 //! Functions dealing with the exec
 
-use crate::addr::ShimPhysAddr;
+use crate::addr::{ShimPhysAddr, TranslateFrom};
 use crate::allocator::ALLOCATOR;
+use crate::paging::SHIM_PAGETABLE;
 use crate::random::random;
 use crate::shim_stack::init_stack_with_guard;
 use crate::snp::cpuid;
@@ -12,7 +13,6 @@ use crate::{
     EXEC_BRK_VIRT_ADDR_BASE, EXEC_ELF_VIRT_ADDR_BASE, EXEC_STACK_SIZE, EXEC_STACK_VIRT_ADDR_BASE,
 };
 
-use core::convert::TryFrom;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use crt0stack::{self, Builder, Entry};
@@ -65,7 +65,7 @@ fn map_elf(app_virt_start: VirtAddr) -> &'static Header {
     };
 
     // Convert to shim physical addresses with potential SEV C-Bit set
-    let code_start_phys = ShimPhysAddr::try_from(header as *const _)
+    let code_start_phys = ShimPhysAddr::translate_from(&SHIM_PAGETABLE.read(), header as *const _)
         .unwrap()
         .raw()
         .raw();

--- a/crates/shim-kvm/src/paging.rs
+++ b/crates/shim-kvm/src/paging.rs
@@ -38,14 +38,15 @@ unsafe impl PageTableFrameMapping for EncPhysOffset {
     }
 }
 
+/// The shim's page table type
+pub type ShimPageTable = MappedPageTable<'static, EncPhysOffset>;
+
 /// The global `MappedPageTable` of the shim for encrypted pages.
-pub static SHIM_PAGETABLE: Lazy<RwLock<MappedPageTable<'static, EncPhysOffset>>> =
-    Lazy::new(|| {
-        let enc_phys_offset = EncPhysOffset::default();
+pub static SHIM_PAGETABLE: Lazy<RwLock<ShimPageTable>> = Lazy::new(|| {
+    let enc_phys_offset = EncPhysOffset::default();
 
-        let enc_offset_page_table = unsafe {
-            MappedPageTable::new(&mut (*(PML4T.get() as *mut PageTable)), enc_phys_offset)
-        };
+    let enc_offset_page_table =
+        unsafe { MappedPageTable::new(&mut (*(PML4T.get() as *mut PageTable)), enc_phys_offset) };
 
-        RwLock::new(enc_offset_page_table)
-    });
+    RwLock::new(enc_offset_page_table)
+});


### PR DESCRIPTION
Taking an explicit `ShimPageTable` reference, instead of locking the global `SHIM_PAGETABLE` itself.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
