### PR TITLE
feat(shim-kvm): cleanup print macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,6 +1298,7 @@ dependencies = [
  "aes-gcm",
  "array-const-fn-init",
  "bitflags",
+ "cfg-if 1.0.0",
  "const-default",
  "crt0stack",
  "gdbstub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ async-std = { version = "1.11.0", default-features = false, features = ["attribu
 atty = { version = "0.2.0", default-features = false }
 bitflags = { version = "1.2.0", default-features = false }
 camino = { version = "1.0.9", default-features = false }
+cfg-if = { version = "1.0.0", default-features = false }
 chrono = { version = "0.4.19", features = ["clock", "serde", "std"], default-features = false }
 clap = { version = "4.0", features = ["std", "derive", "env", "error-context", "help", "usage", "wrap_help"], default-features = false }
 colorful = { version = "0.2.0", default-features = false }

--- a/crates/shim-kvm/Cargo.toml
+++ b/crates/shim-kvm/Cargo.toml
@@ -16,6 +16,7 @@ bench = []
 aes-gcm = { workspace = true }
 array-const-fn-init = { workspace = true }
 bitflags = { workspace = true }
+cfg-if = { workspace = true }
 const-default = { workspace = true, features = ["derive"] }
 crt0stack = { workspace = true }
 goblin = { workspace = true }

--- a/crates/shim-kvm/src/gdb.rs
+++ b/crates/shim-kvm/src/gdb.rs
@@ -265,7 +265,7 @@ pub(crate) fn gdb_session(stack_frame: &mut ExtendedInterruptStackFrameValue) {
     regs.regs
         .iter()
         .enumerate()
-        .for_each(|(i, v)| eprintln!("r{} = {:#x}", i, v));
+        .for_each(|(i, v)| eprintln!("r{i} = {v:#x}"));
 
     let mut target = GdbTarget::new(stack_frame);
 
@@ -273,7 +273,7 @@ pub(crate) fn gdb_session(stack_frame: &mut ExtendedInterruptStackFrameValue) {
 
     eprintln!("Starting GDB session...");
 
-    eprintln!("symbol-file -o {:#x} <shim>", SHIM_VIRT_OFFSET);
+    eprintln!("symbol-file -o {SHIM_VIRT_OFFSET:#x} <shim>");
 
     if EXEC_READY.load(Ordering::Relaxed) {
         let exec_virt = *EXEC_VIRT_ADDR.read();
@@ -302,7 +302,7 @@ pub(crate) fn gdb_session(stack_frame: &mut ExtendedInterruptStackFrameValue) {
             }
 
             Err(GdbStubError::TargetError(e)) => {
-                eprintln!("resume: {:#?}", e);
+                eprintln!("resume: {e:#?}");
                 break;
             }
 
@@ -314,7 +314,7 @@ pub(crate) fn gdb_session(stack_frame: &mut ExtendedInterruptStackFrameValue) {
                 GdbStubError::PacketUnexpected => break,
                 GdbStubError::TargetMismatch => break,
                 GdbStubError::UnsupportedStopReason => break,
-                _ => eprintln!("gdbstub internal error: {:#?}", e),
+                _ => eprintln!("gdbstub internal error: {e:#?}"),
             },
         };
     }

--- a/crates/shim-kvm/src/gdt.rs
+++ b/crates/shim-kvm/src/gdt.rs
@@ -58,7 +58,7 @@ fn new_tss(stack_pointer: VirtAddr) -> &'static mut TaskStateSegment {
 #[cfg_attr(coverage, no_coverage)]
 pub unsafe fn init(stack_pointer: VirtAddr) {
     #[cfg(debug_assertions)]
-    crate::eprintln!("init_gdt");
+    eprintln!("init_gdt");
 
     let gdt = Box::leak(Box::new(GlobalDescriptorTable::new()));
     let tss = new_tss(stack_pointer);
@@ -108,5 +108,5 @@ pub unsafe fn init(stack_pointer: VirtAddr) {
         GS::write_base(base);
     }
 
-    crate::eprintln!("init_gdt done");
+    eprintln!("init_gdt done");
 }

--- a/crates/shim-kvm/src/interrupts.rs
+++ b/crates/shim-kvm/src/interrupts.rs
@@ -2,10 +2,9 @@
 
 //! Interrupt handling
 
-#[cfg(feature = "dbg")]
+#[cfg(all(feature = "dbg", not(test)))]
 use crate::debug::{interrupt_trace, print_stack_trace};
-#[cfg(any(debug_assertions, feature = "dbg"))]
-use crate::eprintln;
+#[cfg(any(all(feature = "dbg", not(test)), not(feature = "gdb")))]
 use crate::hostcall::shim_exit;
 use crate::snp::cpuid_count;
 
@@ -360,9 +359,9 @@ declare_interrupt!(
         if handle_page_fault(address, error_code).is_err() {
             eprintln!("EXCEPTION: PAGE FAULT");
 
-            eprintln!("Accessed Address: {:?}", address);
-            eprintln!("Error Code: {:?}", error_code);
-            #[cfg(feature = "dbg")]
+            eprintln!("Accessed Address: {address:?}");
+            eprintln!("Error Code: {error_code:?}");
+            #[cfg(all(feature = "dbg", not(test)))]
             interrupt_trace(_stack_frame);
 
             #[cfg(feature = "gdb")]
@@ -388,7 +387,7 @@ pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
         let virt = VirtAddr::new_unsafe(page_fault_handler as usize as u64);
         idt.page_fault.set_handler_addr(virt).set_stack_index(6);
 
-        #[cfg(feature = "dbg")]
+        #[cfg(all(feature = "dbg", not(test)))]
         debug::idt_add_debug_exception_handlers(&mut idt);
     }
     idt
@@ -402,7 +401,7 @@ pub fn init() {
     IDT.load();
 }
 
-#[cfg(feature = "dbg")]
+#[cfg(all(feature = "dbg", not(test)))]
 mod debug {
     use super::*;
     use core::arch::asm;

--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -24,8 +24,14 @@ use primordial::Page as Page4KiB;
 use shared::no_std::cpuid_page::CpuidPage;
 use x86_64::VirtAddr;
 
-#[macro_use]
-pub mod print;
+cfg_if::cfg_if! {
+    if #[cfg(not(test))] {
+        #[macro_use]
+        pub mod stdio;
+    } else {
+        pub use std::{println, print, eprintln, eprint};
+    }
+}
 pub mod addr;
 pub mod allocator;
 pub mod debug;

--- a/crates/shim-kvm/src/start.rs
+++ b/crates/shim-kvm/src/start.rs
@@ -13,11 +13,11 @@ use enarx_shim_kvm::gdt;
 use enarx_shim_kvm::hostcall::BLOCK_SIZE;
 use enarx_shim_kvm::interrupts;
 use enarx_shim_kvm::pagetables::{unmap_identity, PDPT, PDT_C000_0000, PML4T, PT_FFE0_0000};
-use enarx_shim_kvm::print::enable_printing;
 use enarx_shim_kvm::shim_stack::{init_stack_with_guard, GuardedStack};
 use enarx_shim_kvm::snp::launch::{Policy, PolicyFlags, Version};
 use enarx_shim_kvm::snp::C_BIT_MASK;
 use enarx_shim_kvm::sse;
+use enarx_shim_kvm::stdio::enable_printing;
 use enarx_shim_kvm::SHIM_STACK_START;
 use enarx_shim_kvm::{exec, SHIM_EX_STACK_START, SHIM_STACK_SIZE};
 
@@ -148,7 +148,7 @@ fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
     use core::sync::atomic::AtomicBool;
     use enarx_shim_kvm::debug::_enarx_asm_triple_fault;
     #[cfg(feature = "dbg")]
-    use enarx_shim_kvm::print::{self, is_printing_enabled};
+    use enarx_shim_kvm::stdio::{self, is_printing_enabled};
 
     static mut ALREADY_IN_PANIC: AtomicBool = AtomicBool::new(false);
 
@@ -160,7 +160,7 @@ fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
         {
             #[cfg(feature = "dbg")]
             if is_printing_enabled() {
-                print::_eprint(format_args!("{_info}\n"));
+                stdio::_eprint(format_args!("{_info}\n"));
                 enarx_shim_kvm::debug::print_stack_trace();
             }
             // FIXME: might want to have a custom panic hostcall

--- a/crates/shim-kvm/src/syscall.rs
+++ b/crates/shim-kvm/src/syscall.rs
@@ -129,7 +129,7 @@ extern "sysv64" fn syscall_rust(
 
     #[cfg(feature = "dbg")]
     if !(nr == SYS_write as usize && (a == STDERR_FILENO as usize || a == STDOUT_FILENO as usize)) {
-        eprintln!("syscall {} ...", nr)
+        eprintln!("syscall {nr} ...")
     }
 
     let mut tls = THREAD_TLS.lock();


### PR DESCRIPTION
- use `write!` to enable inlining of arguments
- for `cfg(test)` use the `std` versions to enable the clippy linter
- inline all the arguments
- rename `print` module to differ from `print!` macro

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
