### PR TITLE
feat(shim-kvm): order lock of the page table and allocator

### DIFF
--- a/crates/shim-kvm/src/allocator.rs
+++ b/crates/shim-kvm/src/allocator.rs
@@ -5,40 +5,40 @@
 use crate::addr::{ShimPhysAddr, ShimVirtAddr, SHIM_VIRT_OFFSET};
 use crate::exec::NEXT_MMAP_RWLOCK;
 use crate::hostcall::{HostCall, SHIM_LOCAL_STORAGE};
-use crate::paging::{EncPhysOffset, SHIM_PAGETABLE};
+use crate::paging::{ShimPageTable, SHIM_PAGETABLE};
 use crate::snp::{get_cbit_mask, pvalidate, snp_active, PvalidateSize};
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::cmp::{max, min};
 use core::convert::TryFrom;
-use core::mem::{align_of, size_of};
 use core::ops::Deref;
 use core::ptr::NonNull;
+use core::sync::atomic::{compiler_fence, Ordering};
 
 use goblin::elf::header::header64::Header;
 use goblin::elf::header::ELFMAG;
 use goblin::elf::program_header::program_header64::*;
 use linked_list_allocator::Heap;
 use lset::{Line, Span};
-use primordial::{Address, Page as Page4KiB};
+use primordial::Address;
 use sallyport::guest::Handler;
-use spin::{Lazy, Mutex, RwLockWriteGuard};
+use spin::{Lazy, Mutex, MutexGuard, RwLockWriteGuard};
 use x86_64::instructions::tlb::flush_all;
 use x86_64::structures::paging::mapper::{MapToError, UnmapError};
 use x86_64::structures::paging::{
     self, FrameAllocator, Mapper, Page, PageTableFlags, PhysFrame, Size1GiB, Size2MiB, Size4KiB,
 };
-use x86_64::structures::paging::{MappedPageTable, PageSize};
 use x86_64::{align_down, align_up, PhysAddr, VirtAddr};
+
+const PG_USIZE: usize = Page::<Size4KiB>::SIZE as usize;
 
 /// Frame of the zero page
 pub static ZERO_PAGE_FRAME: Lazy<PhysFrame<Size4KiB>> = Lazy::new(|| {
     let frame = ALLOCATOR.lock().allocate_frame().unwrap();
     let shim_phys_page = ShimPhysAddr::try_from(frame.start_address()).unwrap();
     let shim_virt: *mut u8 = ShimVirtAddr::from(shim_phys_page).into();
-    unsafe {
-        core::ptr::write_bytes(shim_virt, 0, Size4KiB::SIZE as _);
-    }
+    // Safety: fresh unreferenced memory
+    unsafe { core::ptr::write_bytes(shim_virt, 0, PG_USIZE) };
     frame
 });
 
@@ -101,6 +101,275 @@ fn msb(val: usize) -> u32 {
         }
 
         r += 1;
+    }
+}
+
+/// Struct to hold a lock of the page table and allocator
+///
+/// For operations needing both the page table and the allocator.
+/// To avoid deadlocks the page table lock must be acquired first.
+pub struct PageTableAllocatorLock<'a> {
+    shim_page_table: RwLockWriteGuard<'a, ShimPageTable>,
+    allocator: MutexGuard<'a, EnarxAllocator>,
+}
+
+impl Default for PageTableAllocatorLock<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PageTableAllocatorLock<'_> {
+    /// Get a lock of the page table and allocator
+    pub fn new() -> Self {
+        let shim_page_table = SHIM_PAGETABLE.write();
+        // prevent earlier writes from being moved beyond this point
+        compiler_fence(Ordering::Release);
+        let allocator = ALLOCATOR.lock();
+        Self {
+            shim_page_table,
+            allocator,
+        }
+    }
+
+    /// Allocate memory and map it to the given virtual address
+    pub fn allocate_and_map_memory(
+        &mut self,
+        map_to: VirtAddr,
+        size: usize,
+        flags: PageTableFlags,
+        parent_flags: PageTableFlags,
+    ) -> Result<&'static mut [u8], AllocateError> {
+        if size == 0 {
+            return Err(AllocateError::ZeroSize);
+        }
+
+        if !map_to.is_aligned(Page::<Size4KiB>::SIZE) {
+            return Err(AllocateError::NotAligned);
+        }
+
+        if size != align_down(size as _, Page::<Size4KiB>::SIZE) as usize {
+            return Err(AllocateError::NotAligned);
+        }
+
+        let curr_size = (2usize).checked_pow(msb(size)).unwrap();
+
+        let (first_half, first_half_size) = {
+            while self.allocator.free() < curr_size {
+                self.allocator.balloon();
+            }
+            let (chunk, chunk_size) = self.allocator.try_alloc_half(curr_size);
+
+            if chunk.is_null() {
+                self.allocator.balloon();
+                self.allocator.try_alloc_half(curr_size)
+            } else {
+                (chunk, chunk_size)
+            }
+        };
+
+        let first_half = NonNull::new(first_half).ok_or(AllocateError::OutOfMemory)?;
+
+        let second_half_size = size.checked_sub(first_half_size).unwrap();
+
+        if second_half_size > 0 {
+            if let Err(e) = self.allocate_and_map_memory(
+                map_to + first_half_size,
+                second_half_size,
+                flags,
+                parent_flags,
+            ) {
+                // Safety: the pointer is page aligned and points to allocated pages
+                unsafe { self.allocator.dealloc_pages(first_half, first_half_size) };
+                return Err(e);
+            }
+        }
+
+        let phys = shim_virt_to_enc_phys(first_half.as_ptr());
+        // Safety: the memory mapped from was not used before and map_memory does not allow mapping to already mapped memory
+        if let Err(e) =
+            unsafe { self.map_memory(phys, map_to, first_half_size, flags, parent_flags) }
+        {
+            // Safety: the pointer is page aligned and points to allocated pages
+            unsafe { self.allocator.dealloc_pages(first_half, first_half_size) };
+            let _ = self.unmap_memory(map_to + first_half_size, second_half_size);
+            return Err(e);
+        }
+        // Safety: the memory is mapped to the given virtual address and page aligned
+        Ok(unsafe { core::slice::from_raw_parts_mut(map_to.as_mut_ptr() as *mut u8, size) })
+    }
+
+    /// Map the zero page to the given virtual address
+    ///
+    /// FIXME: change PhysAddr to ShimPhysAddr to ensure encrypted memory
+    /// https://github.com/enarx/enarx/issues/2506
+    pub fn map_memory_zero(
+        &mut self,
+        map_to: VirtAddr,
+        size: usize,
+        mut flags: PageTableFlags,
+        parent_flags: PageTableFlags,
+    ) -> Result<&'static mut [u8], AllocateError> {
+        if size == 0 {
+            return Err(AllocateError::ZeroSize);
+        }
+
+        let page_range_to = {
+            let start = map_to;
+            let end = start + size - 1u64;
+            let start_page = Page::<Size4KiB>::containing_address(start);
+            let end_page = Page::<Size4KiB>::containing_address(end);
+            Page::range_inclusive(start_page, end_page)
+        };
+
+        if flags.contains(PageTableFlags::WRITABLE) {
+            flags.remove(PageTableFlags::WRITABLE);
+            flags |= PageTableFlags::BIT_10;
+        }
+
+        let zero_frame = *ZERO_PAGE_FRAME;
+
+        for page_to in page_range_to {
+            // Safety: the memory mapped is the read-only zero page and the real
+            // memory will be allocated in the page fault handler.
+            unsafe {
+                self.shim_page_table.map_to_with_table_flags(
+                    page_to,
+                    zero_frame,
+                    flags,
+                    parent_flags,
+                    &mut *self.allocator,
+                )
+            }
+            .map_err(|e| match e {
+                MapToError::FrameAllocationFailed => AllocateError::OutOfMemory,
+                MapToError::ParentEntryHugePage => AllocateError::ParentEntryHugePage,
+                MapToError::PageAlreadyMapped(_) => AllocateError::PageAlreadyMapped,
+            })?
+            .ignore();
+        }
+        flush_all();
+
+        // Safety: the memory is mapped to the given virtual address and page aligned
+        Ok(unsafe { core::slice::from_raw_parts_mut(map_to.as_mut_ptr() as *mut u8, size) })
+    }
+
+    /// Map physical memory to the given virtual address
+    ///
+    /// FIXME: change PhysAddr to ShimPhysAddr to ensure encrypted memory
+    /// https://github.com/enarx/enarx/issues/2506
+    ///
+    /// ## Safety
+    ///
+    /// Creating page table mappings is a fundamentally unsafe operation because
+    /// there are various ways to break memory safety through it. For example,
+    /// re-mapping an in-use page to a different frame changes and invalidates
+    /// all values stored in that page, resulting in undefined behavior on the
+    /// next use.
+    ///
+    /// The caller must ensure that no undefined behavior or memory safety
+    /// violations can occur through the new mapping. Among other things, the
+    /// caller must prevent the following:
+    ///
+    /// - Aliasing of `&mut` references, i.e. two `&mut` references that point to
+    ///   the same physical address. This is undefined behavior in Rust.
+    ///     - This can be ensured by mapping each page to an individual physical
+    ///       frame that is not mapped anywhere else.
+    /// - Creating uninitalized or invalid values: Rust requires that all values
+    ///   have a correct memory layout. For example, a `bool` must be either a 0
+    ///   or a 1 in memory, but not a 3 or 4. An exception is the `MaybeUninit`
+    ///   wrapper type, which abstracts over possibly uninitialized memory.
+    ///     - This is only a problem when re-mapping pages to different physical
+    ///       frames. Mapping a page that is not in use yet is fine.
+    ///
+    /// Special care must be taken when sharing pages with other address spaces,
+    /// e.g. by setting the `GLOBAL` flag. For example, a global mapping must be
+    /// the same in all address spaces, otherwise undefined behavior can occur
+    /// because of TLB races. It's worth noting that all the above requirements
+    /// also apply to shared mappings, including the aliasing requirements.
+    pub unsafe fn map_memory(
+        &mut self,
+        map_from: PhysAddr,
+        map_to: VirtAddr,
+        size: usize,
+        flags: PageTableFlags,
+        parent_flags: PageTableFlags,
+    ) -> Result<(), AllocateError> {
+        if size == 0 {
+            return Err(AllocateError::ZeroSize);
+        }
+        let frame_range_from = {
+            let start = map_from;
+            let end = start + size - 1u64;
+            let start_frame = PhysFrame::<Size4KiB>::containing_address(start);
+            let end_frame = PhysFrame::<Size4KiB>::containing_address(end);
+            PhysFrame::range_inclusive(start_frame, end_frame)
+        };
+
+        let page_range_to = {
+            let start = map_to;
+            let end = start + size - 1u64;
+            let start_page = Page::<Size4KiB>::containing_address(start);
+            let end_page = Page::<Size4KiB>::containing_address(end);
+            Page::range_inclusive(start_page, end_page)
+        };
+
+        for (frame_from, page_to) in frame_range_from.zip(page_range_to) {
+            // Safety: this function must uphold the safety requirements of the called function
+            unsafe {
+                self.shim_page_table
+                    .map_to_with_table_flags(
+                        page_to,
+                        frame_from,
+                        flags,
+                        parent_flags,
+                        &mut *self.allocator,
+                    )
+                    .map_err(|e| match e {
+                        MapToError::FrameAllocationFailed => AllocateError::OutOfMemory,
+                        MapToError::ParentEntryHugePage => AllocateError::ParentEntryHugePage,
+                        MapToError::PageAlreadyMapped(_) => AllocateError::PageAlreadyMapped,
+                    })?
+                    .ignore();
+            }
+        }
+        flush_all();
+
+        Ok(())
+    }
+
+    /// Unmap `size` bytes from the given virtual address and deallocate the corresponding physical pages
+    pub fn unmap_memory(&mut self, virt_addr: VirtAddr, size: usize) -> Result<(), UnmapError> {
+        if size == 0 {
+            return Ok(());
+        }
+
+        let page_range_to = {
+            let start = virt_addr;
+            let end = start + size - 1u64;
+            let start_page = Page::<Size4KiB>::containing_address(start);
+            let end_page = Page::<Size4KiB>::containing_address(end);
+            Page::range_inclusive(start_page, end_page)
+        };
+
+        for frame_from in page_range_to {
+            let (phys_frame, _) = self.shim_page_table.unmap(frame_from)?;
+            if phys_frame == *ZERO_PAGE_FRAME {
+                continue;
+            }
+
+            let phys = phys_frame.start_address();
+            let free_start_phys = Address::<usize, _>::from(phys.as_u64() as *const u8);
+            let shim_phys_page = ShimPhysAddr::from(free_start_phys);
+            let shim_virt: NonNull<u8> =
+                NonNull::new(ShimVirtAddr::from(shim_phys_page).into()).unwrap();
+            // Safety: the pointer is page aligned and points to allocated pages, which were just unmapped.
+            // Allocated pages are not mapped more than once, except for the zero page, which is never deallocated.
+            unsafe { self.allocator.dealloc_pages(shim_virt, PG_USIZE) };
+        }
+
+        flush_all();
+        Ok(())
     }
 }
 
@@ -209,7 +478,7 @@ impl EnarxAllocator {
                     > region.count
             );
 
-            align_up(region.count as u64, Page4KiB::SIZE as u64) as usize
+            align_up(region.count as u64, Page::<Size4KiB>::SIZE) as usize
         };
 
         let mem_size = align_up(
@@ -218,7 +487,7 @@ impl EnarxAllocator {
                 .unwrap()
                 .checked_add(code_size as u64)
                 .unwrap(),
-            Page4KiB::SIZE as u64,
+            Page::<Size4KiB>::SIZE,
         ) as usize;
 
         let end_of_mem = mem_start + mem_size;
@@ -245,7 +514,7 @@ impl EnarxAllocator {
                 .checked_mul(last_size as u64)
                 .unwrap_or(last_size as u64) as _;
             let new_size = new_size.min(self.max_alloc);
-            let num_pages = new_size.checked_div(Page4KiB::SIZE as _).unwrap();
+            let num_pages = new_size.checked_div(PG_USIZE).unwrap();
 
             let mut tls = SHIM_LOCAL_STORAGE.write();
             let ret = HostCall::try_new(&mut tls).unwrap().balloon_memory(
@@ -269,9 +538,7 @@ impl EnarxAllocator {
                         let virt_region = Span::new(free_start as usize, new_size);
                         let virt_line = Line::from(virt_region);
 
-                        for addr in
-                            (virt_line.start..virt_line.end).step_by(Page::<Size4KiB>::SIZE as _)
-                        {
+                        for addr in (virt_line.start..virt_line.end).step_by(PG_USIZE) {
                             let va = VirtAddr::new(addr as _);
                             pvalidate(va, PvalidateSize::Size4K, true).unwrap();
                         }
@@ -292,7 +559,7 @@ impl EnarxAllocator {
                     // Failed to get more memory.
                     // Try again with half of the memory.
                     last_size = last_size.checked_div(2).unwrap();
-                    if last_size < Page4KiB::SIZE {
+                    if last_size < PG_USIZE {
                         // Host does not have even a page of memory
                         return false;
                     }
@@ -302,7 +569,7 @@ impl EnarxAllocator {
     }
 
     fn try_alloc_half(&mut self, mut size: usize) -> (*mut u8, usize) {
-        assert!(size >= size_of::<Page4KiB>());
+        assert!(size >= PG_USIZE);
         loop {
             let p = self.alloc_pages(size);
 
@@ -313,7 +580,7 @@ impl EnarxAllocator {
                 return (p.as_ptr(), size);
             }
 
-            if size == size_of::<Page4KiB>() {
+            if size == PG_USIZE {
                 return (core::ptr::null_mut(), size);
             }
 
@@ -323,213 +590,17 @@ impl EnarxAllocator {
 
     fn alloc_pages(&mut self, size: usize) -> Result<NonNull<u8>, ()> {
         self.allocator
-            .allocate_first_fit(Layout::from_size_align(size, align_of::<Page4KiB>()).unwrap())
+            .allocate_first_fit(Layout::from_size_align(size, PG_USIZE).unwrap())
     }
 
-    unsafe fn dealloc_pages(&mut self, ptr: *mut u8, size: usize) {
-        self.allocator.deallocate(
-            NonNull::new_unchecked(ptr),
-            Layout::from_size_align_unchecked(size, align_of::<Page4KiB>()),
-        )
-    }
-
-    /// Allocate memory and map it to the given virtual address
-    pub fn allocate_and_map_memory(
-        &mut self,
-        map_to: VirtAddr,
-        size: usize,
-        flags: PageTableFlags,
-        parent_flags: PageTableFlags,
-    ) -> Result<&'static mut [u8], AllocateError> {
-        if size == 0 {
-            return Err(AllocateError::ZeroSize);
-        }
-
-        if !map_to.is_aligned(align_of::<Page4KiB>() as u64) {
-            return Err(AllocateError::NotAligned);
-        }
-
-        if size != align_down(size as _, Page::<Size4KiB>::SIZE) as usize {
-            return Err(AllocateError::NotAligned);
-        }
-
-        let curr_size = (2usize).checked_pow(msb(size)).unwrap();
-
-        let (first_half, first_half_size) = {
-            while self.allocator.free() < curr_size {
-                self.balloon();
-            }
-            let (chunk, chunk_size) = self.try_alloc_half(curr_size);
-
-            if chunk.is_null() {
-                self.balloon();
-                self.try_alloc_half(curr_size)
-            } else {
-                (chunk, chunk_size)
-            }
-        };
-
-        if first_half.is_null() {
-            return Err(AllocateError::OutOfMemory);
-        }
-
-        let second_half_size = size.checked_sub(first_half_size).unwrap();
-
-        if second_half_size > 0 {
-            if let Err(e) = self.allocate_and_map_memory(
-                map_to + first_half_size,
-                second_half_size,
-                flags,
-                parent_flags,
-            ) {
-                unsafe {
-                    self.dealloc_pages(first_half, first_half_size);
-                }
-                return Err(e);
-            }
-        }
-
-        let phys = shim_virt_to_enc_phys(first_half);
-        if let Err(e) = self.map_memory(phys, map_to, first_half_size, flags, parent_flags) {
-            unsafe {
-                self.dealloc_pages(first_half, first_half_size);
-            }
-            let _ = self.unmap_memory(map_to + first_half_size, second_half_size);
-            return Err(e);
-        }
-        // transmute the whole thing to one big bytes slice
-        Ok(unsafe { core::slice::from_raw_parts_mut(map_to.as_mut_ptr() as *mut u8, size) })
-    }
-
-    /// Map the zero page to the given virtual address
+    /// Deallocate pages
     ///
-    /// FIXME: change PhysAddr to ShimPhysAddr to ensure encrypted memory
-    pub fn map_memory_zero(
-        &mut self,
-        shim_page_table: &mut RwLockWriteGuard<'_, MappedPageTable<'_, EncPhysOffset>>,
-        map_to: VirtAddr,
-        size: usize,
-        mut flags: PageTableFlags,
-        parent_flags: PageTableFlags,
-    ) -> Result<&'static mut [u8], AllocateError> {
-        if size == 0 {
-            return Err(AllocateError::ZeroSize);
-        }
-
-        let page_range_to = {
-            let start = map_to;
-            let end = start + size - 1u64;
-            let start_page = Page::<Size4KiB>::containing_address(start);
-            let end_page = Page::<Size4KiB>::containing_address(end);
-            Page::range_inclusive(start_page, end_page)
-        };
-
-        if flags.contains(PageTableFlags::WRITABLE) {
-            flags.remove(PageTableFlags::WRITABLE);
-            flags |= PageTableFlags::BIT_10;
-        }
-
-        let zero_frame = *ZERO_PAGE_FRAME;
-
-        for page_to in page_range_to {
-            unsafe {
-                shim_page_table
-                    .map_to_with_table_flags(page_to, zero_frame, flags, parent_flags, self)
-                    .map_err(|e| match e {
-                        MapToError::FrameAllocationFailed => AllocateError::OutOfMemory,
-                        MapToError::ParentEntryHugePage => AllocateError::ParentEntryHugePage,
-                        MapToError::PageAlreadyMapped(_) => AllocateError::PageAlreadyMapped,
-                    })?
-                    .ignore();
-            }
-        }
-        flush_all();
-
-        // transmute the whole thing to one big bytes slice
-        Ok(unsafe { core::slice::from_raw_parts_mut(map_to.as_mut_ptr() as *mut u8, size) })
-    }
-
-    /// Map physical memory to the given virtual address
-    ///
-    /// FIXME: change PhysAddr to ShimPhysAddr to ensure encrypted memory
-    pub fn map_memory(
-        &mut self,
-        map_from: PhysAddr,
-        map_to: VirtAddr,
-        size: usize,
-        flags: PageTableFlags,
-        parent_flags: PageTableFlags,
-    ) -> Result<(), AllocateError> {
-        if size == 0 {
-            return Err(AllocateError::ZeroSize);
-        }
-        let frame_range_from = {
-            let start = map_from;
-            let end = start + size - 1u64;
-            let start_frame = PhysFrame::<Size4KiB>::containing_address(start);
-            let end_frame = PhysFrame::<Size4KiB>::containing_address(end);
-            PhysFrame::range_inclusive(start_frame, end_frame)
-        };
-
-        let page_range_to = {
-            let start = map_to;
-            let end = start + size - 1u64;
-            let start_page = Page::<Size4KiB>::containing_address(start);
-            let end_page = Page::<Size4KiB>::containing_address(end);
-            Page::range_inclusive(start_page, end_page)
-        };
-
-        let mut shim_page_table = SHIM_PAGETABLE.write();
-
-        for (frame_from, page_to) in frame_range_from.zip(page_range_to) {
-            unsafe {
-                shim_page_table
-                    .map_to_with_table_flags(page_to, frame_from, flags, parent_flags, self)
-                    .map_err(|e| match e {
-                        MapToError::FrameAllocationFailed => AllocateError::OutOfMemory,
-                        MapToError::ParentEntryHugePage => AllocateError::ParentEntryHugePage,
-                        MapToError::PageAlreadyMapped(_) => AllocateError::PageAlreadyMapped,
-                    })?
-                    .ignore();
-            }
-        }
-        flush_all();
-
-        Ok(())
-    }
-
-    /// FIXME: unmap
-    pub fn unmap_memory(&mut self, virt_addr: VirtAddr, size: usize) -> Result<(), UnmapError> {
-        if size == 0 {
-            return Ok(());
-        }
-
-        let page_range_to = {
-            let start = virt_addr;
-            let end = start + size - 1u64;
-            let start_page = Page::<Size4KiB>::containing_address(start);
-            let end_page = Page::<Size4KiB>::containing_address(end);
-            Page::range_inclusive(start_page, end_page)
-        };
-
-        for frame_from in page_range_to {
-            let (phys_frame, _) = SHIM_PAGETABLE.write().unmap(frame_from)?;
-            if phys_frame == *ZERO_PAGE_FRAME {
-                continue;
-            }
-
-            let phys = phys_frame.start_address();
-
-            let free_start_phys = Address::<usize, _>::from(phys.as_u64() as *const u8);
-            let shim_phys_page = ShimPhysAddr::from(free_start_phys);
-            let shim_virt: *mut u8 = ShimVirtAddr::from(shim_phys_page).into();
-            unsafe {
-                self.dealloc_pages(shim_virt, Page::<Size4KiB>::SIZE as usize);
-            }
-        }
-
-        flush_all();
-        Ok(())
+    /// # Safety
+    /// `ptr` must be a pointer to page aligned unmapped physical memory
+    unsafe fn dealloc_pages(&mut self, ptr: NonNull<u8>, size: usize) {
+        assert_eq!(size % PG_USIZE, 0);
+        let layout = Layout::from_size_align_unchecked(size, PG_USIZE);
+        self.allocator.deallocate(ptr, layout)
     }
 
     /// Allocate memory by Layout
@@ -563,15 +634,10 @@ impl EnarxAllocator {
 unsafe impl paging::FrameAllocator<Size4KiB> for EnarxAllocator {
     #[allow(unused_unsafe)]
     fn allocate_frame(&mut self) -> Option<PhysFrame<Size4KiB>> {
-        self.try_alloc(unsafe {
-            Layout::from_size_align_unchecked(
-                Page::<Size4KiB>::SIZE as _,
-                Page::<Size4KiB>::SIZE as _,
-            )
-        })
-        .map(|a| a.as_ptr())
-        .map(shim_virt_to_enc_phys)
-        .map(PhysFrame::containing_address)
+        self.try_alloc(Layout::from_size_align(PG_USIZE, PG_USIZE).unwrap())
+            .map(|a| a.as_ptr())
+            .map(shim_virt_to_enc_phys)
+            .map(PhysFrame::containing_address)
     }
 }
 

--- a/crates/shim-kvm/src/start.rs
+++ b/crates/shim-kvm/src/start.rs
@@ -8,7 +8,7 @@
 extern crate rcrt1;
 
 use enarx_shim_kvm::addr::SHIM_VIRT_OFFSET;
-use enarx_shim_kvm::allocator::ZERO_PAGE_FRAME;
+use enarx_shim_kvm::allocator::{ALLOCATOR, ZERO_PAGE_FRAME};
 use enarx_shim_kvm::gdt;
 use enarx_shim_kvm::hostcall::BLOCK_SIZE;
 use enarx_shim_kvm::interrupts;
@@ -113,6 +113,8 @@ unsafe extern "sysv64" fn _pre_main(c_bit_mask: u64) -> ! {
     C_BIT_MASK.store(c_bit_mask, Ordering::Relaxed);
 
     unmap_identity();
+
+    Lazy::force(&ALLOCATOR);
 
     let stack_pointer = shim_stack().pointer;
 


### PR DESCRIPTION
Create the `PageTableAllocatorLock` struct to acquire the locks of the page table and allocator in a defined order to avoid dead locks.

Move all methods needing both locks under this struct.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
