### PR TITLE
build: bump Rust toolchain to 2023-01-27

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,4 +10,7 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 [unstable]
 bindeps = true
-sparse-registry = true
+
+# In the future when sparse registries are the default, this key can be removed
+[registries.crates-io]
+protocol = "sparse"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,11 +46,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2023-01-02 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2023-01-24 -y
       - uses: dtolnay/rust-toolchain@master
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2023-01-02
+          toolchain: nightly-2023-01-24
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/sbom_manifest_action.yml
+++ b/.github/workflows/sbom_manifest_action.yml
@@ -17,7 +17,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           target: x86_64-unknown-linux-musl
-          toolchain: nightly-2023-01-02
+          toolchain: nightly-2023-01-24
           override: true
 
       - name: Install cargo-cyclonedx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install rustup
-        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2023-01-02 -y
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2023-01-24 -y
       - uses: dtolnay/rust-toolchain@master
         with:
           target: x86_64-unknown-linux-gnu
-          toolchain: nightly-2023-01-02
+          toolchain: nightly-2023-01-24
       - run: cargo test ${{ matrix.profile.flag }}
     strategy:
       fail-fast: false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-01-02"
+channel = "nightly-2023-01-24"
 targets = [
     "aarch64-apple-darwin",
     "aarch64-unknown-linux-musl",


### PR DESCRIPTION
Just a regular update to coincide with the Rust 1.67 release.

Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
