### PR TITLE
feat(shim-kvm): remove exception stacks

### DIFF
--- a/crates/shim-kvm/src/gdt.rs
+++ b/crates/shim-kvm/src/gdt.rs
@@ -2,9 +2,7 @@
 
 //! Global Descriptor Table init
 
-use crate::shim_stack::init_stack_with_guard;
 use crate::syscall::_syscall_enter;
-use crate::{SHIM_EX_STACK_SIZE, SHIM_EX_STACK_START};
 
 use alloc::boxed::Box;
 
@@ -13,43 +11,8 @@ use x86_64::instructions::tables::load_tss;
 use x86_64::registers::model_specific::{KernelGsBase, LStar, SFMask, Star};
 use x86_64::registers::rflags::RFlags;
 use x86_64::structures::gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector};
-use x86_64::structures::paging::{Page, PageTableFlags, Size2MiB, Size4KiB};
 use x86_64::structures::tss::TaskStateSegment;
-use x86_64::{align_up, VirtAddr};
-
-#[cfg_attr(coverage, no_coverage)]
-fn new_tss(stack_pointer: VirtAddr) -> &'static mut TaskStateSegment {
-    let mut tss = Box::new(TaskStateSegment::new());
-
-    tss.privilege_stack_table[0] = stack_pointer;
-
-    let ptr_interrupt_stack_table = core::ptr::addr_of_mut!(tss.interrupt_stack_table);
-    let mut interrupt_stack_table = unsafe { ptr_interrupt_stack_table.read_unaligned() };
-
-    // Assign the stacks for the exceptions and interrupts
-    interrupt_stack_table
-        .iter_mut()
-        .enumerate()
-        .for_each(|(idx, p)| {
-            let offset: u64 = align_up(
-                SHIM_EX_STACK_SIZE
-                    .checked_add(Page::<Size4KiB>::SIZE.checked_mul(2).unwrap())
-                    .unwrap(),
-                Page::<Size2MiB>::SIZE,
-            );
-
-            let stack_offset = offset.checked_mul(idx as _).unwrap();
-            let start = VirtAddr::new(SHIM_EX_STACK_START.checked_add(stack_offset).unwrap());
-
-            *p = init_stack_with_guard(start, SHIM_EX_STACK_SIZE, PageTableFlags::empty()).pointer;
-        });
-
-    unsafe {
-        ptr_interrupt_stack_table.write_unaligned(interrupt_stack_table);
-    }
-
-    Box::leak(tss)
-}
+use x86_64::VirtAddr;
 
 /// Initialize the GDT
 ///
@@ -57,11 +20,10 @@ fn new_tss(stack_pointer: VirtAddr) -> &'static mut TaskStateSegment {
 /// The caller has to ensure that the stack pointer is valid and 16 byte aligned.
 #[cfg_attr(coverage, no_coverage)]
 pub unsafe fn init(stack_pointer: VirtAddr) {
-    #[cfg(debug_assertions)]
     eprintln!("init_gdt");
 
     let gdt = Box::leak(Box::new(GlobalDescriptorTable::new()));
-    let tss = new_tss(stack_pointer);
+
     // `syscall` loads segments from STAR MSR assuming a data_segment follows `kernel_code_segment`
     // so the ordering is crucial here. Star::write() will panic otherwise later.
     let code = gdt.add_entry(Descriptor::kernel_code_segment());
@@ -72,6 +34,9 @@ pub unsafe fn init(stack_pointer: VirtAddr) {
     let user_data = gdt.add_entry(Descriptor::user_data_segment());
     let user_code = gdt.add_entry(Descriptor::user_code_segment());
 
+    let mut tss = Box::new(TaskStateSegment::new());
+    tss.privilege_stack_table[0] = stack_pointer;
+    let tss = Box::leak(tss);
     let tss_selector = gdt.add_entry(Descriptor::tss_segment(tss));
 
     gdt.load();

--- a/crates/shim-kvm/src/interrupts.rs
+++ b/crates/shim-kvm/src/interrupts.rs
@@ -380,12 +380,10 @@ pub static IDT: Lazy<InterruptDescriptorTable> = Lazy::new(|| {
     let mut idt = InterruptDescriptorTable::new();
     unsafe {
         let virt = VirtAddr::new_unsafe(vmm_communication_exception_handler as usize as u64);
-        idt.vmm_communication_exception
-            .set_handler_addr(virt)
-            .set_stack_index(0);
+        idt.vmm_communication_exception.set_handler_addr(virt);
 
         let virt = VirtAddr::new_unsafe(page_fault_handler as usize as u64);
-        idt.page_fault.set_handler_addr(virt).set_stack_index(6);
+        idt.page_fault.set_handler_addr(virt);
 
         #[cfg(all(feature = "dbg", not(test)))]
         debug::idt_add_debug_exception_handlers(&mut idt);
@@ -410,84 +408,64 @@ mod debug {
     pub(crate) fn idt_add_debug_exception_handlers(idt: &mut InterruptDescriptorTable) {
         unsafe {
             let virt = VirtAddr::new_unsafe(divide_error_handler as usize as u64);
-            idt.divide_error.set_handler_addr(virt).set_stack_index(6);
+            idt.divide_error.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(debug_handler as usize as u64);
-            idt.debug.set_handler_addr(virt).set_stack_index(1);
+            idt.debug.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(non_maskable_interrupt_handler as usize as u64);
-            idt.non_maskable_interrupt
-                .set_handler_addr(virt)
-                .set_stack_index(2);
+            idt.non_maskable_interrupt.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(breakpoint_handler as usize as u64);
-            let br_opts = idt.breakpoint.set_handler_addr(virt).set_stack_index(1);
+            let br_opts = idt.breakpoint.set_handler_addr(virt);
             if cfg!(feature = "gdb") {
                 br_opts.set_privilege_level(x86_64::PrivilegeLevel::Ring3);
             }
 
             let virt = VirtAddr::new_unsafe(overflow_handler as usize as u64);
-            idt.overflow.set_handler_addr(virt).set_stack_index(6);
+            idt.overflow.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(bound_range_exceeded_handler as usize as u64);
-            idt.bound_range_exceeded
-                .set_handler_addr(virt)
-                .set_stack_index(6);
+            idt.bound_range_exceeded.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(invalid_opcode_handler as usize as u64);
-            idt.invalid_opcode.set_handler_addr(virt).set_stack_index(5);
+            idt.invalid_opcode.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(device_not_available_handler as usize as u64);
-            idt.device_not_available
-                .set_handler_addr(virt)
-                .set_stack_index(5);
+            idt.device_not_available.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(double_fault_handler as usize as u64);
-            idt.double_fault.set_handler_addr(virt).set_stack_index(3);
+            idt.double_fault.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(invalid_tss_handler as usize as u64);
-            idt.invalid_tss.set_handler_addr(virt).set_stack_index(6);
+            idt.invalid_tss.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(segment_not_present_handler as usize as u64);
-            idt.segment_not_present
-                .set_handler_addr(virt)
-                .set_stack_index(6);
+            idt.segment_not_present.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(stack_segment_fault as usize as u64);
-            idt.stack_segment_fault
-                .set_handler_addr(virt)
-                .set_stack_index(6);
+            idt.stack_segment_fault.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(general_protection_fault as usize as u64);
-            idt.general_protection_fault
-                .set_handler_addr(virt)
-                .set_stack_index(6);
+            idt.general_protection_fault.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(x87_floating_point_handler as usize as u64);
-            idt.x87_floating_point
-                .set_handler_addr(virt)
-                .set_stack_index(6);
+            idt.x87_floating_point.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(alignment_check_handler as usize as u64);
-            idt.alignment_check
-                .set_handler_addr(virt)
-                .set_stack_index(6);
+            idt.alignment_check.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(machine_check_handler as usize as u64);
-            idt.machine_check.set_handler_addr(virt).set_stack_index(3);
+            idt.machine_check.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(simd_floating_point_handler as usize as u64);
-            idt.simd_floating_point
-                .set_handler_addr(virt)
-                .set_stack_index(6);
+            idt.simd_floating_point.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(virtualization_handler as usize as u64);
-            idt.virtualization.set_handler_addr(virt).set_stack_index(6);
+            idt.virtualization.set_handler_addr(virt);
 
             let virt = VirtAddr::new_unsafe(security_exception_handler as usize as u64);
-            idt.security_exception
-                .set_handler_addr(virt)
-                .set_stack_index(6);
+            idt.security_exception.set_handler_addr(virt);
         }
     }
 


### PR DESCRIPTION
As we disabled red zone in the shim, and we panic on double faults anyway, remove the unnecessary exception stacks.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
