### PR TITLE
feat(shim-kvm): introduce thread control block Tcb

### DIFF
--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -48,6 +48,7 @@ pub mod snp;
 pub mod spin;
 pub mod sse;
 pub mod syscall;
+pub mod thread;
 pub mod usermode;
 
 extern "C" {

--- a/crates/shim-kvm/src/syscall.rs
+++ b/crates/shim-kvm/src/syscall.rs
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! syscall interface layer between assembler and rust
+#![allow(non_upper_case_globals)]
 
 use crate::hostcall::{HostCall, UserMemScope};
-use crate::spin::{Locked, RacyCell};
+use crate::thread::TcbRefCell;
 
 use core::arch::global_asm;
 use core::mem::size_of;
 
-use sallyport::guest;
 use sallyport::guest::Handler;
 use sallyport::item::enarxcall::{SYS_GETATT, SYS_GETKEY};
 #[cfg(feature = "dbg")]
 use sallyport::libc::{SYS_write, STDERR_FILENO, STDOUT_FILENO};
-use spin::Lazy;
+use x86_64::VirtAddr;
 
 #[repr(C)]
 struct X8664DoubleReturn {
@@ -30,10 +30,10 @@ extern "sysv64" {
     #[cfg_attr(coverage, no_coverage)]
     pub fn _syscall_enter() -> !;
 }
-// TaskStateSegment.privilege_stack_table[0]
-const KERNEL_RSP_OFF: usize = size_of::<u32>();
-// TaskStateSegment.privilege_stack_table[3]
-const USR_RSP_OFF: usize = size_of::<u32>() + 3 * size_of::<u64>();
+// offset Tcb.kernel_stack
+const KERNEL_RSP_OFF: usize = 0;
+// offset Tcb.userspace_stack
+const USR_RSP_OFF: usize = size_of::<VirtAddr>();
 global_asm!(
         ".pushsection .text.syscall_enter,\"ax\",@progbits",
         ".global _syscall_enter",
@@ -48,7 +48,7 @@ global_asm!(
         "mov    QWORD PTR gs:{USR},     rsp",               // save userspace rsp
         "mov    rsp,                    QWORD PTR gs:{KRN}",// load kernel rsp
         "push   QWORD PTR gs:{USR}",                        // push userspace rsp - stack_pointer_ring_3
-        "mov    QWORD PTR gs:{USR},     0x0",               // clear userspace rsp in the TSS
+        "mov    QWORD PTR gs:{USR},     0x0",               // clear userspace rsp in the Tcb
         "push   r11",                                       // push RFLAGS stored in r11
         "push   rcx",                                       // push userspace return pointer
         "push   rbp",
@@ -106,14 +106,6 @@ global_asm!(
         syscall_rust = sym syscall_rust,
 );
 
-/// Thread local storage
-/// FIXME: when using multithreading
-pub static THREAD_TLS: Lazy<Locked<&mut guest::ThreadLocalStorage>> = Lazy::new(|| unsafe {
-    static TLSHANDLE: RacyCell<guest::ThreadLocalStorage> =
-        RacyCell::new(guest::ThreadLocalStorage::new());
-    Locked::<&mut guest::ThreadLocalStorage>::new(&mut (*TLSHANDLE.get()))
-});
-
 /// Handle a syscall in rust
 #[allow(clippy::many_single_char_names)]
 extern "sysv64" fn syscall_rust(
@@ -126,14 +118,14 @@ extern "sysv64" fn syscall_rust(
     nr: usize,
 ) -> X8664DoubleReturn {
     let orig_rdx: usize = c;
+    let mut tcb = TcbRefCell::from_gs_base().borrow_mut();
+    let mut h = HostCall::syscall(&mut tcb);
 
     #[cfg(feature = "dbg")]
     if !(nr == SYS_write as usize && (a == STDERR_FILENO as usize || a == STDOUT_FILENO as usize)) {
-        eprintln!("syscall {nr} ...")
+        let tid = h.get_tid();
+        eprintln!("[{tid}] syscall {nr} ...");
     }
-
-    let mut tls = THREAD_TLS.lock();
-    let mut h = HostCall::try_new(&mut tls).unwrap();
 
     let usermemscope = UserMemScope;
 
@@ -141,7 +133,6 @@ extern "sysv64" fn syscall_rust(
         SYS_GETKEY => {
             let ret = h.get_key(&usermemscope, a, b);
 
-            #[cfg(feature = "dbg")]
             eprintln!(
                 "syscall SYS_GETKEY = {}",
                 ret.map_or_else(|e| -e as usize, |v| v)

--- a/crates/shim-kvm/src/thread.rs
+++ b/crates/shim-kvm/src/thread.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Thread handling
+
+use crate::hostcall::BlockGuard;
+
+use core::cell::{Cell, UnsafeCell};
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+use core::ptr::NonNull;
+
+use sallyport::guest::ThreadLocalStorage;
+use sallyport::libc::pid_t;
+use x86_64::instructions::segmentation::{Segment64, GS};
+use x86_64::VirtAddr;
+
+/// Thread Control Block
+///
+/// The first 2 elements are unsafely accessed by the syscall exception handler.
+/// Because of this, they must be the first 2 elements in the struct.
+/// It is sound, because the syscall exception handler is the only code that
+/// accesses these elements and single threaded.
+#[repr(C)]
+pub struct Tcb {
+    /// storage for the kernel stack
+    /// private, because it is accessed via the gsbase in the syscall exception
+    kernel_stack: VirtAddr,
+    /// storage for the userspace stack
+    /// private, because it is accessed via the gsbase in the syscall exception
+    userspace_stack: VirtAddr,
+    /// The thread ID
+    pub tid: pid_t,
+    /// sallyport thread local storage
+    pub tls: ThreadLocalStorage,
+    /// sallyport block,
+    pub block: BlockGuard,
+}
+
+/// RefCell<Tcb> variant that is stored in the gsbase
+///
+/// Because `RefCell` is not repr(C) and the syscall exception asm needs
+/// to access the first two fields, we need to use a custom struct.
+#[repr(C)]
+pub struct TcbRefCell {
+    value: UnsafeCell<Tcb>,
+    borrow: Cell<BorrowFlag>,
+}
+
+type BorrowFlag = isize;
+const UNUSED: BorrowFlag = 0;
+
+#[inline(always)]
+fn is_writing(x: BorrowFlag) -> bool {
+    x < UNUSED
+}
+
+/// core::cell::BorrowRefMut clone
+struct TcbBorrowRefMut<'b> {
+    borrow: &'b Cell<BorrowFlag>,
+}
+
+impl Drop for TcbBorrowRefMut<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        let borrow = self.borrow.get();
+        debug_assert!(is_writing(borrow));
+        self.borrow.set(borrow + 1);
+    }
+}
+
+impl<'b> TcbBorrowRefMut<'b> {
+    #[inline]
+    fn new(borrow: &'b Cell<BorrowFlag>) -> Option<TcbBorrowRefMut<'b>> {
+        // NOTE: Unlike BorrowRefMut::clone, new is called to create the initial
+        // mutable reference, and so there must currently be no existing
+        // references. Thus, while clone increments the mutable refcount, here
+        // we explicitly only allow going from UNUSED to UNUSED - 1.
+        match borrow.get() {
+            UNUSED => {
+                borrow.set(UNUSED - 1);
+                Some(TcbBorrowRefMut { borrow })
+            }
+            _ => None,
+        }
+    }
+}
+
+/// A wrapper type for a mutably borrowed value from a `TcbRefCell<T>`.
+///
+/// core::cell::RefMut clone
+pub struct TcbRefMut<'b, T: ?Sized> {
+    // NB: we use a pointer instead of `&'b mut T` to avoid `noalias` violations, because a
+    // `RefMut` argument doesn't hold exclusivity for its whole scope, only until it drops.
+    value: NonNull<T>,
+    #[allow(dead_code)]
+    borrow: TcbBorrowRefMut<'b>,
+    // `NonNull` is covariant over `T`, so we need to reintroduce invariance.
+    marker: PhantomData<&'b mut T>,
+}
+
+impl<T: ?Sized> Deref for TcbRefMut<'_, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: the value is accessible as long as we hold our borrow.
+        unsafe { self.value.as_ref() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for TcbRefMut<'_, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: the value is accessible as long as we hold our borrow.
+        unsafe { self.value.as_mut() }
+    }
+}
+
+impl TcbRefCell {
+    /// Create a new TCB
+    pub fn new(kernel_stack: VirtAddr, block: BlockGuard) -> Self {
+        Self {
+            value: UnsafeCell::new(Tcb {
+                kernel_stack,
+                userspace_stack: VirtAddr::zero(),
+                tid: 0,
+                tls: Default::default(),
+                block,
+            }),
+            borrow: Cell::new(UNUSED),
+        }
+    }
+
+    /// Get a mutable reference to the TCB
+    ///
+    /// panics if the TCB is already borrowed
+    pub fn borrow_mut(&self) -> TcbRefMut<'_, Tcb> {
+        match TcbBorrowRefMut::new(&self.borrow) {
+            Some(b) => {
+                // SAFETY: `TcbBorrowRefMut` guarantees unique access.
+                let value = unsafe { NonNull::new_unchecked(self.value.get()) };
+                TcbRefMut {
+                    value,
+                    borrow: b,
+                    marker: PhantomData,
+                }
+            }
+            None => panic!("try_borrow_mut: already mutably borrowed"),
+        }
+    }
+
+    /// Get a mutable reference to the CPU local Tcb.
+    pub fn from_gs_base() -> &'static TcbRefCell {
+        let base = GS::read_base();
+        let base = NonNull::new(base.as_u64() as _).unwrap();
+        // SAFETY:
+        // the GS base is set to the initialized TcbRefCell.
+        // The pointer is properly aligned.
+        // It is be "dereferenceable".
+        // The pointer points to an initialized instance of TcbRefCell.
+        // The lifetime is static and only per cpu.
+        let tcb = unsafe { base.as_ref() };
+        tcb
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Tcb;
+    use core::mem::size_of;
+    use primordial::Page;
+
+    #[test]
+    fn test_thread_control_block() {
+        assert!(size_of::<Tcb>() < Page::SIZE);
+    }
+}


### PR DESCRIPTION
Store the per cpu thread control block (Tcb) in the kernel GS register.

Introduce a `std::RefCell` like runtime borrow checker for the Tcb.

Do host syscall calls via the per cpu sallyport block and maintanence host calls via the global maintanence syscall block.

`HOST_CALL_ALLOC.try_alloc()` will also go away in follow up patches.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
