### PR TITLE
chore(shim-kvm): remove remenants of exception stacks

### DIFF
--- a/crates/shim-kvm/src/lib.rs
+++ b/crates/shim-kvm/src/lib.rs
@@ -70,19 +70,6 @@ pub const SHIM_STACK_START: u64 = 0xFFFF_FF48_4800_0000;
 #[allow(clippy::integer_arithmetic)]
 pub const SHIM_STACK_SIZE: u64 = bytes![2; MiB];
 
-/// The virtual address of the exception kernel stacks
-pub const SHIM_EX_STACK_START: u64 = 0xFFFF_FF48_F000_0000;
-
-/// The size of the main kernel stack for exceptions
-#[allow(clippy::integer_arithmetic)]
-pub const SHIM_EX_STACK_SIZE: u64 = {
-    if cfg!(feature = "gdb") {
-        bytes![2; MiB]
-    } else {
-        bytes![32; KiB]
-    }
-};
-
 /// Exec virtual address, where the elf binary is mapped to, plus a random offset
 const EXEC_ELF_VIRT_ADDR_BASE: VirtAddr = VirtAddr::new_truncate(0x7f00_0000_0000);
 

--- a/crates/shim-kvm/src/start.rs
+++ b/crates/shim-kvm/src/start.rs
@@ -19,7 +19,7 @@ use enarx_shim_kvm::snp::C_BIT_MASK;
 use enarx_shim_kvm::sse;
 use enarx_shim_kvm::stdio::enable_printing;
 use enarx_shim_kvm::SHIM_STACK_START;
-use enarx_shim_kvm::{exec, SHIM_EX_STACK_START, SHIM_STACK_SIZE};
+use enarx_shim_kvm::{exec, SHIM_STACK_SIZE};
 
 use core::arch::{asm, global_asm};
 use core::mem::size_of;
@@ -75,7 +75,6 @@ static INITIAL_SHIM_STACK: [Page; INITIAL_STACK_PAGES] = [Page::zeroed(); INITIA
 /// Create a shim stack
 pub fn shim_stack() -> GuardedStack {
     let start = VirtAddr::new(SHIM_STACK_START);
-    assert!((start + SHIM_STACK_SIZE).as_u64() < SHIM_EX_STACK_START);
     init_stack_with_guard(start, SHIM_STACK_SIZE, PageTableFlags::empty())
 }
 


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
