### PR TITLE
fix(shim-kvm): pagetables fixups

### DIFF
--- a/crates/shim-kvm/src/pagetables.rs
+++ b/crates/shim-kvm/src/pagetables.rs
@@ -23,7 +23,7 @@ use crate::spin::RacyCell;
 
 /// A page-aligned Page Table.
 #[repr(C, align(4096))]
-pub struct AlignedPageTable(pub [u64; 512]);
+pub struct AlignedPageTable([u64; 512]);
 
 const HUGE_PAGE_TABLE_FLAGS: u64 = PageTableFlags::HUGE_PAGE.bits()
     | PageTableFlags::WRITABLE.bits()
@@ -116,7 +116,7 @@ pub enum Error {
 
 /// smash the pagetable entries to 4k pages
 pub fn smash(addr: VirtAddr) -> Result<(), Error> {
-    let trans = paging::SHIM_PAGETABLE.write().translate(addr);
+    let trans = paging::SHIM_PAGETABLE.read().translate(addr);
     match trans {
         TranslateResult::Mapped {
             frame,
@@ -239,7 +239,7 @@ pub fn clear_c_bit_address_range(start: VirtAddr, end: VirtAddr) -> Result<(), E
         if current >= end {
             return Ok(());
         }
-        let trans = paging::SHIM_PAGETABLE.write().translate(current);
+        let trans = paging::SHIM_PAGETABLE.read().translate(current);
 
         current += match trans {
             TranslateResult::Mapped {


### PR DESCRIPTION
`pagetables::smash()` only needs read-only lock `SHIM_PAGETABLE`.

AlignedPageTable does not need a public inner.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
