### PR TITLE
fix(shim-kvm): no random exec addresses in `dbg`

### DIFF
--- a/crates/shim-kvm/src/exec.rs
+++ b/crates/shim-kvm/src/exec.rs
@@ -28,12 +28,12 @@ use x86_64::{PhysAddr, VirtAddr};
 pub static EXEC_READY: AtomicBool = AtomicBool::new(false);
 
 /// The randomized virtual address of the exec
-#[cfg(not(feature = "gdb"))]
+#[cfg(not(any(feature = "gdb", feature = "dbg")))]
 pub static EXEC_VIRT_ADDR: Lazy<RwLock<VirtAddr>> =
     Lazy::new(|| RwLock::new(EXEC_ELF_VIRT_ADDR_BASE + (random() & 0x7F_FFFF_F000)));
 
 /// The non-randomized virtual address of the exec in case the gdb feature is active
-#[cfg(feature = "gdb")]
+#[cfg(any(feature = "gdb", feature = "dbg"))]
 pub static EXEC_VIRT_ADDR: Lazy<RwLock<VirtAddr>> =
     Lazy::new(|| RwLock::new(EXEC_ELF_VIRT_ADDR_BASE));
 


### PR DESCRIPTION
Eases debugging.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
