### PR TITLE
support running on the SEV-SNP v8 patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,8 +2116,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a321cabd827642499c77e27314f388dd83a717a5ca716b86476fb947f73ae4"
+source = "git+https://github.com/Freax13/kvm-ioctls.git?rev=d78d745#d78d7456b24bccc491cd88288733d86fbe87622c"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,3 +236,6 @@ rustix = { version = "0.35.11", features = ["std"], default-features = false }
 wasi-common = { version = "2.0.0", default-features = false }
 wasmtime-wasi = { version = "2.0.0", features = ["sync"], default-features = false }
 wiggle = { version = "2.0.0", default-features = false }
+
+[patch.crates-io]
+kvm-ioctls = { git = "https://github.com/Freax13/kvm-ioctls.git", rev = "d78d745" }

--- a/crates/sallyport/src/guest/call/enarxcall/passthrough.rs
+++ b/crates/sallyport/src/guest/call/enarxcall/passthrough.rs
@@ -58,16 +58,23 @@ pub struct BalloonMemory {
     pub pages: usize,
     /// Guest physical address where the memory should be allocated.
     pub addr: *mut c_void,
+    /// Set if private memory must be used, instead of mapped.
+    pub is_private: bool,
 }
 
 impl PassthroughAlloc for BalloonMemory {
     const NUM: Number = Number::BalloonMemory;
 
-    type Argv = Argv<3>;
+    type Argv = Argv<4>;
     type Ret = usize;
 
     fn stage(self) -> Self::Argv {
-        Argv([self.size_exponent, self.pages, self.addr as _])
+        Argv([
+            self.size_exponent,
+            self.pages,
+            self.addr as _,
+            self.is_private as _,
+        ])
     }
 }
 

--- a/crates/sallyport/src/guest/handler.rs
+++ b/crates/sallyport/src/guest/handler.rs
@@ -1109,17 +1109,20 @@ pub trait Handler {
     /// - `size_exponent`: Page size expressed as an exponent of 2
     /// - `pages`: Number of pages to allocate
     /// - `addr`: Guest physical address where the memory should be allocated
+    /// - `is_private`: Set if private memory must be used, instead of mapped
     #[inline]
     fn balloon_memory(
         &mut self,
         size_exponent: usize,
         pages: usize,
         addr: *mut c_void,
+        is_private: bool,
     ) -> Result<usize> {
         self.execute(enarxcall::BalloonMemory {
             size_exponent,
             pages,
             addr,
+            is_private,
         })?
     }
 

--- a/crates/sallyport/tests/enarxcall/mod.rs
+++ b/crates/sallyport/tests/enarxcall/mod.rs
@@ -12,7 +12,10 @@ use sallyport::libc::timespec;
 #[test]
 fn balloon_memory() {
     run_test(1, [0xff; 16], move |_, _, handler| {
-        assert_eq!(handler.balloon_memory(1, 2, 0xfeed as _), Err(ENOSYS));
+        assert_eq!(
+            handler.balloon_memory(1, 2, 0xfeed as _, false),
+            Err(ENOSYS)
+        );
     })
 }
 

--- a/crates/shim-kvm/src/allocator.rs
+++ b/crates/shim-kvm/src/allocator.rs
@@ -252,6 +252,7 @@ impl EnarxAllocator {
                 12, // 1 << 12 == 4096 == page size
                 num_pages,
                 self.end_of_mem.as_u64() as _,
+                snp_active(),
             );
             drop(tls);
 

--- a/src/backend/kvm/mem.rs
+++ b/src/backend/kvm/mem.rs
@@ -6,17 +6,13 @@ use std::os::{
 };
 
 use iocuddle::{Group, Ioctl, Write};
-use kvm_bindings::kvm_userspace_memory_region;
 use kvm_ioctls::VmFd;
 use lset::Span;
 use mmarinus::{perms, Map};
 use x86_64::{PhysAddr, VirtAddr};
 
 const KVM: Group = Group::new(0xAE);
-const KVM_SET_USER_MEMORY_REGION: Ioctl<Write, &kvm_userspace_memory_region> =
-    unsafe { KVM.write(0x46) };
-const KVM_SET_USER_MEMORY_REGION_EXT: Ioctl<Write, &Slot> =
-    unsafe { KVM_SET_USER_MEMORY_REGION.lie() };
+const KVM_SET_USER_MEMORY_REGION2: Ioctl<Write, &Slot> = unsafe { KVM.write(0x49) };
 const KVM_MEM_PRIVATE: u32 = 0x04;
 
 pub struct Region {
@@ -100,7 +96,7 @@ impl Slot {
         };
 
         // Assign it to the VM.
-        KVM_SET_USER_MEMORY_REGION_EXT.ioctl(vm_fd, &slot)?;
+        KVM_SET_USER_MEMORY_REGION2.ioctl(vm_fd, &slot)?;
 
         Ok(slot)
     }

--- a/src/backend/kvm/mem.rs
+++ b/src/backend/kvm/mem.rs
@@ -47,6 +47,10 @@ impl Region {
     pub fn backing(&self) -> &[u8] {
         self.backing.as_ref()
     }
+
+    pub fn backing_mut(&mut self) -> &mut [u8] {
+        self.backing.as_mut()
+    }
 }
 
 #[repr(C)]

--- a/src/backend/kvm/mem.rs
+++ b/src/backend/kvm/mem.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::os::{
-    fd::{FromRawFd, OwnedFd},
+    fd::{AsFd, BorrowedFd, FromRawFd, OwnedFd},
     unix::io::AsRawFd,
 };
 
@@ -50,6 +50,10 @@ impl Region {
 
     pub fn backing_mut(&mut self) -> &mut [u8] {
         self.backing.as_mut()
+    }
+
+    pub fn restricted_fd(&self) -> Option<BorrowedFd> {
+        self.slot.restricted_fd.as_ref().map(AsFd::as_fd)
     }
 }
 

--- a/src/backend/kvm/mem.rs
+++ b/src/backend/kvm/mem.rs
@@ -1,40 +1,126 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::KvmUserspaceMemoryRegion;
+use std::os::{
+    fd::{FromRawFd, OwnedFd},
+    unix::io::AsRawFd,
+};
 
+use iocuddle::{Group, Ioctl, Write};
+use kvm_bindings::kvm_userspace_memory_region;
+use kvm_ioctls::VmFd;
 use lset::Span;
 use mmarinus::{perms, Map};
 use x86_64::{PhysAddr, VirtAddr};
 
+const KVM: Group = Group::new(0xAE);
+const KVM_SET_USER_MEMORY_REGION: Ioctl<Write, &kvm_userspace_memory_region> =
+    unsafe { KVM.write(0x46) };
+const KVM_SET_USER_MEMORY_REGION_EXT: Ioctl<Write, &Slot> =
+    unsafe { KVM_SET_USER_MEMORY_REGION.lie() };
+const KVM_MEM_PRIVATE: u32 = 0x04;
+
 pub struct Region {
-    kvm_region: KvmUserspaceMemoryRegion,
+    slot: Slot,
     backing: Map<perms::ReadWrite>,
 }
 
 impl Region {
-    pub fn new(kvm_region: KvmUserspaceMemoryRegion, backing: Map<perms::ReadWrite>) -> Self {
-        Self {
-            kvm_region,
-            backing,
-        }
+    pub fn new(slot: Slot, backing: Map<perms::ReadWrite>) -> Self {
+        Self { slot, backing }
     }
 
     #[allow(dead_code)]
     pub fn as_guest(&self) -> Span<PhysAddr, u64> {
         Span {
-            start: PhysAddr::new(self.kvm_region.guest_phys_addr),
-            count: self.kvm_region.memory_size,
+            start: PhysAddr::new(self.slot.guest_phys_addr),
+            count: self.slot.memory_size,
         }
     }
 
     pub fn as_virt(&self) -> Span<VirtAddr, u64> {
         Span {
-            start: VirtAddr::new(self.kvm_region.userspace_addr),
-            count: self.kvm_region.memory_size,
+            start: VirtAddr::new(self.slot.userspace_addr),
+            count: self.slot.memory_size,
         }
     }
 
     pub fn backing(&self) -> &[u8] {
         self.backing.as_ref()
     }
+}
+
+#[repr(C)]
+pub struct Slot {
+    slot: u32,
+    flags: u32,
+    guest_phys_addr: u64,
+    memory_size: u64,
+    userspace_addr: u64,
+    restricted_offset: u64,
+    restricted_fd: Option<OwnedFd>,
+    pad1: u32,
+    pad2: [u64; 14],
+}
+
+impl Slot {
+    /// Create a new memory slot and assign it to a VM.
+    pub fn new(
+        vm_fd: &mut VmFd,
+        slot_index: u32,
+        backing_memory: &Map<perms::ReadWrite>,
+        guest_phys_addr: u64,
+        is_private: bool,
+    ) -> std::io::Result<Self> {
+        let memory_size = u64::try_from(backing_memory.len()).unwrap();
+
+        // Optionally allocate private memory.
+        let restricted_fd = is_private
+            .then(|| create_memfd_restricted(memory_size))
+            .transpose()?;
+
+        // Create a slot.
+        let slot = Self {
+            slot: slot_index,
+            flags: KVM_MEM_PRIVATE,
+            guest_phys_addr,
+            memory_size,
+            userspace_addr: u64::try_from(backing_memory.addr()).unwrap(),
+            restricted_offset: 0,
+            restricted_fd,
+            pad1: 0,
+            pad2: [0; 14],
+        };
+
+        // Assign it to the VM.
+        KVM_SET_USER_MEMORY_REGION_EXT.ioctl(vm_fd, &slot)?;
+
+        Ok(slot)
+    }
+}
+
+/// Create a memfd_restricted file descriptor and grow it to `memory_size`.
+fn create_memfd_restricted(memory_size: u64) -> std::io::Result<OwnedFd> {
+    // Create the file descriptor.
+    let memfd_restricted_flags = 0;
+    let restricted_fd = unsafe {
+        // SAFETY: The `memfd_restricted` has no safety relevant side effects.
+        libc::syscall(451, memfd_restricted_flags)
+    };
+    if restricted_fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    // Convert to a owned file descriptor.
+    let restricted_fd = unsafe {
+        // SAFETY: We've just acquired the fd.
+        OwnedFd::from_raw_fd(restricted_fd as _)
+    };
+
+    // Grow the private memory.
+    let ret = unsafe { libc::ftruncate(restricted_fd.as_raw_fd(), memory_size as _) };
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    Ok(restricted_fd)
 }

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -22,7 +22,7 @@ pub mod mem;
 pub mod thread;
 
 pub trait KeepPersonality: Send + Sync {
-    fn map(_vm_fd: &mut VmFd, _region: &Region) -> std::io::Result<()> {
+    fn map(_vm_fd: &mut VmFd, _region: &Region, _is_private: bool) -> std::io::Result<()> {
         Ok(())
     }
 
@@ -66,7 +66,7 @@ impl<P: KeepPersonality> Keep<P> {
         )?;
         let region = Region::new(slot, pages);
 
-        P::map(&mut self.vm_fd, &region)?;
+        P::map(&mut self.vm_fd, &region, is_private)?;
 
         self.regions.push(region);
 

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -51,13 +51,18 @@ pub struct Keep<P: KeepPersonality> {
 
 impl<P: KeepPersonality> Keep<P> {
     /// Allocator for `enarxcall::BalloonMemory'.
-    pub fn map(&mut self, pages: Map<perms::ReadWrite>, to: usize) -> std::io::Result<&mut Region> {
+    pub fn map(
+        &mut self,
+        pages: Map<perms::ReadWrite>,
+        to: usize,
+        is_private: bool,
+    ) -> std::io::Result<&mut Region> {
         let slot = Slot::new(
             &mut self.vm_fd,
             self.regions.len() as u32,
             &pages,
             to as u64,
-            false,
+            is_private,
         )?;
         let region = Region::new(slot, pages);
 

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pub use kvm_bindings::kvm_userspace_memory_region as KvmUserspaceMemoryRegion;
-
 use super::Loader;
 use data::{dev_kvm, kvm_version, CPUIDS};
-use mem::Region;
+use mem::{Region, Slot};
 
 use std::sync::Arc;
 
 use crate::backend::Signatures;
 use anyhow::Result;
-use kvm_bindings::bindings::kvm_userspace_memory_region;
 use kvm_ioctls::Kvm;
 use kvm_ioctls::{VcpuFd, VmFd};
 use mmarinus::{perms, Map};
@@ -53,18 +50,16 @@ pub struct Keep<P: KeepPersonality> {
 }
 
 impl<P: KeepPersonality> Keep<P> {
+    /// Allocator for `enarxcall::BalloonMemory'.
     pub fn map(&mut self, pages: Map<perms::ReadWrite>, to: usize) -> std::io::Result<&mut Region> {
-        let kvm_region = kvm_userspace_memory_region {
-            slot: self.regions.len() as u32,
-            flags: 0,
-            guest_phys_addr: to as u64,
-            memory_size: pages.len() as u64,
-            userspace_addr: pages.addr() as u64,
-        };
-
-        unsafe { self.vm_fd.set_user_memory_region(kvm_region)? };
-
-        let region = Region::new(kvm_region, pages);
+        let slot = Slot::new(
+            &mut self.vm_fd,
+            self.regions.len() as u32,
+            &pages,
+            to as u64,
+            false,
+        )?;
+        let region = Region::new(slot, pages);
 
         P::map(&mut self.vm_fd, &region)?;
 

--- a/src/backend/kvm/thread.rs
+++ b/src/backend/kvm/thread.rs
@@ -52,7 +52,13 @@ impl<P: KeepPersonality + 'static> super::super::Keep for RwLock<super::Keep<P>>
 }
 
 impl<P: KeepPersonality> Thread<P> {
-    pub fn balloon(&mut self, log2: usize, npgs: usize, addr: usize) -> sallyport::Result<usize> {
+    pub fn balloon(
+        &mut self,
+        log2: usize,
+        npgs: usize,
+        addr: usize,
+        is_private: bool,
+    ) -> sallyport::Result<usize> {
         let size: usize = 1 << log2; // Page Size
 
         // Get the current page size
@@ -75,7 +81,7 @@ impl<P: KeepPersonality> Thread<P> {
 
         // Map the memory into the VM
         let vaddr = keep
-            .map(pages, addr)
+            .map(pages, addr, is_private)
             .map_err(|e| e.raw_os_error().unwrap_or(libc::ENOTSUP))?
             .as_virt()
             .start;
@@ -111,10 +117,10 @@ impl<P: KeepPersonality> Thread<P> {
 
             item::Enarxcall {
                 num: item::enarxcall::Number::BalloonMemory,
-                argv: [log2, npgs, addr, ..],
+                argv: [log2, npgs, addr, is_private, ..],
                 ret,
             } => {
-                *ret = match self.balloon(*log2, *npgs, *addr) {
+                *ret = match self.balloon(*log2, *npgs, *addr, *is_private != 0) {
                     Ok(n) => n,
                     Err(e) => -e as usize,
                 };

--- a/src/backend/kvm/thread.rs
+++ b/src/backend/kvm/thread.rs
@@ -1,25 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::Command;
+use super::Keep;
 use super::KeepPersonality;
 #[cfg(feature = "gdb")]
 use crate::backend::execute_gdb;
 use crate::backend::parking::THREAD_PARK;
 use crate::backend::sev::set_memory_attributes;
+use crate::backend::sev::snp::ghcb::Ghcb;
+use crate::backend::sev::snp::ghcb::SnpPscDesc;
 
 use std::io;
 use std::iter;
 use std::mem::size_of;
 use std::sync::{Arc, RwLock};
 
+use anyhow::ensure;
 use anyhow::{bail, Context, Result};
 use kvm_ioctls::{VcpuExit, VcpuFd};
 use libc::timespec;
+use lset::Contains;
 use mmarinus::{perms, Map};
 use sallyport::host::deref_aligned;
 use sallyport::item::enarxcall::Payload;
 use sallyport::item::{Block, Item};
 use sallyport::{item, KVM_SYSCALL_TRIGGER_PORT};
+use tracing::warn;
+use x86_64::PhysAddr;
 
 pub struct Thread<P: KeepPersonality> {
     keep: Arc<RwLock<super::Keep<P>>>,
@@ -168,12 +175,96 @@ impl<P: KeepPersonality> Thread<P> {
 
     fn handle_vmgexit(&mut self, ghcb_msr: u64, _error: u8) -> Result<()> {
         match ghcb_msr & 0xfff {
+            0x000 => {
+                // GHCB Guest Physical Address
+
+                self.handle_ghcb_request(ghcb_msr)?;
+            }
             0x014 => {
                 // SNP Page State Change Request
 
                 self.handle_msr_page_state_request(ghcb_msr)?;
             }
             f => bail!("unimplemented GHCB protocol function {f:#03x}"),
+        }
+
+        Ok(())
+    }
+
+    fn handle_ghcb_request(&mut self, ghcb_msr: u64) -> Result<(), anyhow::Error> {
+        let gpa = ghcb_msr & !0xfff;
+        let gpa = PhysAddr::new(gpa);
+
+        let mut guard = self.keep.write().unwrap();
+        let keep = &mut *guard;
+
+        // Find the memory slot that backs the guest physical address of the
+        // GHCB.
+        let region = keep
+            .regions
+            .iter_mut()
+            .find(|region| region.as_guest().contains(&gpa))
+            .context("can't find GHCB")?;
+        let offset = usize::try_from(gpa - region.as_guest().start).unwrap();
+
+        // Create a reference to the GHCB.
+        let ghcb_slice = &mut region.backing_mut()[offset..][..0x1000];
+        let ghcb = unsafe {
+            // SAFETY: `Ghcb` is a 0x1000 byte sized struct that's valid for
+            // all bit patterns and has no padding bytes.
+            // We assume that the guest passes us a unique reference to the
+            // memory.
+            &mut *(ghcb_slice as *mut [u8] as *mut Ghcb)
+        };
+
+        // Validate ghcb protocol.
+        ensure!(ghcb.ghcb_usage == 0);
+        ensure!(ghcb.protocol_version <= 2);
+
+        match ghcb.save_area.sw_exit_code {
+            0x8000_0010 => {
+                // SNP Page Stage Change
+
+                // Make sure that the page state change struct is in the shared
+                // buffer.
+                // The GHCB spec suggests this, but doesn't require it.
+                // However, our guest implementation always uses the shared
+                // buffer and using that knowledge allows us to simplify the
+                // code.
+                ensure!(
+                    ghcb.save_area.sw_scratch == gpa.as_u64() + 2048,
+                    "the page state change struct is not in the shared buffer"
+                );
+
+                // Create a reference to the page state change struct in the
+                // shared buffer.
+                let psc_desc = unsafe {
+                    // SAFETY: `SnpPscDesc` is a 2032 byte sized struct that's
+                    // valid for all bit patterns and has no padding bytes.
+                    &mut *(&mut ghcb.shared_buffer as *mut [u8; 2032] as *mut SnpPscDesc)
+                };
+
+                while psc_desc.cur_entry <= psc_desc.end_entry {
+                    // Process a page state change.
+                    let res = handle_next_page_state_change_request(psc_desc, keep);
+
+                    // Handle the result.
+                    match res {
+                        Ok(_) => {
+                            psc_desc.cur_entry += 1;
+                        }
+                        Err(error_code) => {
+                            ghcb.save_area.sw_exit_info2 = error_code;
+                            break;
+                        }
+                    }
+                }
+            }
+            _ => {
+                bail!("unimplemented sw_exit_code {:#x}", {
+                    ghcb.save_area.sw_exit_code
+                })
+            }
         }
 
         Ok(())
@@ -201,6 +292,75 @@ impl<P: KeepPersonality> Thread<P> {
 
         Ok(())
     }
+}
+
+fn handle_next_page_state_change_request<P>(
+    psc_desc: &SnpPscDesc,
+    keep: &mut Keep<P>,
+) -> Result<(), u64>
+where
+    P: KeepPersonality,
+{
+    const INVALID_HEADER_ERROR: u64 = 0x0000_0001_0000_0001;
+    const INVALID_ENTRY_ERROR: u64 = 0x0000_0001_0000_0002;
+    const UNSPECIFIED_ERROR: u64 = 0x0000_0100_0000_0000;
+
+    let entry = psc_desc
+        .entries
+        .get(usize::from(psc_desc.cur_entry))
+        .ok_or(INVALID_HEADER_ERROR)?;
+    let cur_page = entry.entry & 0xfff;
+    let gpa = entry.entry & 0x7_ffff_ffff_f000;
+    let operation = (entry.entry >> 52) & 0xf;
+    let page_size = (entry.entry >> 56) & 1;
+
+    // Check that the guest requested page state change for a
+    // 4KiB page. We never map 2MiB pages into the guest, so
+    // there's no reason for the guest to request anything else
+    // and for us to support anything else.
+    if page_size != 0 {
+        return Err(UNSPECIFIED_ERROR);
+    }
+    if cur_page != 0 {
+        return Err(INVALID_ENTRY_ERROR);
+    }
+
+    // Try to execute the request.
+    let res = match operation {
+        0x001 => {
+            // Page assignment, Private
+            set_memory_attributes(&mut keep.vm_fd, gpa, 0x1000, true).map_err(|_| {
+                // Indicate to the guest that an unspecified error occured.
+                UNSPECIFIED_ERROR
+            })
+        }
+        0x002 => {
+            // Page assignment, Shared
+            set_memory_attributes(&mut keep.vm_fd, gpa, 0x1000, false).map_err(|_| {
+                // Indicate to the guest that an unspecified error occured.
+                UNSPECIFIED_ERROR
+            })
+        }
+        0x003 => {
+            // PSMASH hint
+
+            // We're not required to process the hint.
+            Ok(())
+        }
+        0x004 => {
+            // UNSMASH hint
+
+            // We're not required to process the hint.
+            Ok(())
+        }
+        _ => {
+            warn!("unimplemented page state change operation {operation:#x}");
+
+            // Indicate to the guest that the entry is not valid.
+            Err(INVALID_ENTRY_ERROR)
+        }
+    };
+    res
 }
 
 impl<P: KeepPersonality> super::super::Thread for Thread<P> {

--- a/src/backend/sev/builder.rs
+++ b/src/backend/sev/builder.rs
@@ -4,7 +4,7 @@ use super::snp::firmware::Firmware;
 use super::snp::launch::*;
 
 use super::SnpKeepPersonality;
-use crate::backend::kvm::builder::kvm_try_from_builder;
+use crate::backend::kvm::builder::{kvm_try_from_builder, map_sallyports};
 use crate::backend::kvm::mem::Region;
 use crate::backend::sev::config::Config;
 use crate::backend::ByteSized;
@@ -15,10 +15,12 @@ use std::{thread, time};
 
 use crate::backend::sev::cpuid_page::import_from_kvm;
 use anyhow::{anyhow, Context, Error};
+use kvm_bindings::kvm_userspace_memory_region;
 use kvm_ioctls::Kvm;
 use mmarinus::{perms, Map};
 use primordial::Page;
 use rand::{thread_rng, Rng};
+use sallyport::elf::pf::kvm::SALLYPORT;
 use sallyport::elf::pf::snp::{CPUID, SECRETS};
 use shared::std::cpuid_page::CpuidPage;
 use x86_64::VirtAddr;
@@ -109,20 +111,35 @@ impl super::super::Mapper for Builder {
         to: usize,
         with: u32,
     ) -> anyhow::Result<()> {
+        let slot = self.regions.len() as _;
+
         // Ignore regions with no pages.
         if pages.is_empty() {
             return Ok(());
         }
 
-        let mem_region = super::super::kvm::builder::kvm_builder_map(
-            self.config.sallyport_block_size as _,
-            &mut self.sallyports,
-            self.launcher.as_mut(),
-            &mut pages,
-            to,
-            with,
-            self.regions.len() as _,
-        )?;
+        if with & SALLYPORT != 0 {
+            map_sallyports(
+                &pages,
+                self.config.sallyport_block_size,
+                &mut self.sallyports,
+            );
+        }
+
+        let mem_region = kvm_userspace_memory_region {
+            slot,
+            flags: 0,
+            guest_phys_addr: to as _,
+            memory_size: pages.size() as _,
+            userspace_addr: pages.addr() as _,
+        };
+
+        unsafe {
+            self.launcher
+                .as_mut()
+                .set_user_memory_region(mem_region)
+                .context("Failed to set user memory region")?
+        };
 
         let dp = VmplPerms::empty();
 

--- a/src/backend/sev/snp/ghcb.rs
+++ b/src/backend/sev/snp/ghcb.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: Consider sharing these types with the shim.
+
+use const_default::ConstDefault;
+
+/// GHCB Save Area
+#[derive(Debug, Copy, Clone, ConstDefault)]
+#[repr(C, packed)]
+pub struct GhcbSaveArea {
+    reserved1: [u8; 203],
+    pub cpl: u8,
+    reserved8: [u8; 300],
+    pub rax: u64,
+    reserved4: [u8; 264],
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rbx: u64,
+    reserved5: [u8; 112],
+    pub sw_exit_code: u64,
+    pub sw_exit_info1: u64,
+    pub sw_exit_info2: u64,
+    pub sw_scratch: u64,
+    reserved6: [u8; 56],
+    pub xcr0: u64,
+    pub valid_bitmap: [u8; 16],
+    pub x87state_gpa: u64,
+    reserved7: [u8; 1016],
+}
+
+/// GHCB
+#[derive(Debug, Copy, Clone, ConstDefault)]
+#[repr(C, align(4096))]
+pub struct Ghcb {
+    pub save_area: GhcbSaveArea,
+    pub shared_buffer: [u8; 2032],
+    reserved1: [u8; 10],
+    pub protocol_version: u16,
+    pub ghcb_usage: u32,
+}
+
+/// GHCB page state description
+#[derive(Debug, Copy, Clone, ConstDefault)]
+#[repr(C)]
+pub struct SnpPscDesc {
+    pub cur_entry: u16,
+    pub end_entry: u16,
+    pub reserved: u32,
+    pub entries: [PscEntry; 253],
+}
+
+/// GHCB page state entry
+#[derive(Debug, Copy, Clone, ConstDefault)]
+#[repr(C)]
+pub struct PscEntry {
+    pub entry: u64,
+}

--- a/src/backend/sev/snp/mod.rs
+++ b/src/backend/sev/snp/mod.rs
@@ -31,6 +31,7 @@ macro_rules! impl_const_id {
 }
 
 pub mod firmware;
+pub mod ghcb;
 pub mod launch;
 pub mod sign;
 pub mod vcek;


### PR DESCRIPTION
This pr adds the necessary changes to run Enarx on the new SEV-SNP v8 host patches. It's based on pr  #2453 for the v7 patches.

This time only one additional patch is required:
https://github.com/Freax13/linux/commit/82799c49b7dbc50c1ca20b39dd68491bb060045e

Based on #2453