### PR TITLE
New documentation for Rust safety block comments

### DIFF
--- a/new documentation for Rust safety block comments
+++ b/new documentation for Rust safety block comments
@@ -1,0 +1,9 @@
+// SAFETY: This function assumes that `self` is a valid non-null pointer to a `MyStruct` object and that `self` is not modified while the function is executing.
+//
+// Rationale: We assume `self` is valid because it is created by the caller and is guaranteed to be non-null.
+// We also assume `self` is not modified because this function only reads data from `self`.
+impl MyStruct {
+    fn get_data(&self) -> &Data {
+        // ...
+    }
+}


### PR DESCRIPTION
Rust safety block comments are an essential tool for ensuring memory safety in Rust code. By marking code blocks as "safe," developers can signal to the compiler and other developers that the code has been carefully designed to avoid memory unsafety bugs. Enarx project uses a standardized format for Rust safety block comments to make them more effective and easier to read.
The above is An example of a code snippet that demonstrate the use of Rust safety block comments using the new standardized format proposed.