### PR TITLE
fix: calculate correct amount of EPC memory size

### DIFF
--- a/src/backend/sgx/data.rs
+++ b/src/backend/sgx/data.rs
@@ -143,9 +143,9 @@ pub fn epc_size(max: u32) -> Datum {
                 break;
             }
 
-            let low = result.ecx as u64 & 0xfffff000;
-            let high = result.edx as u64 & 0x000fffff;
-            size += high << 12 | low;
+            let low = result.ecx as u64 & 0xffff_f000;
+            let high = result.edx as u64 & 0x000f_ffff;
+            size += high << 32 | low;
         }
 
         let (n, s) = humanize(size as f64);


### PR DESCRIPTION
shift edx by 32bit because:

ecx: contains bits 31:12 of size in the high bits
edx: contains bits 51:32 of size in the low bits

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
