### PR TITLE
fix: use `from_bits_truncate()`

### DIFF
--- a/src/backend/sgx/data.rs
+++ b/src/backend/sgx/data.rs
@@ -102,9 +102,9 @@ pub const CPUIDS: &[CpuId] = &[
         name: "  MiscSelect",
         leaf: 0x00000012,
         subl: 0x00000000,
-        func: |res| match MiscSelect::from_bits(res.ebx) {
-            Some(ms) => (true, Some(format!("{ms:?}"))),
-            None => (false, None),
+        func: |res| {
+            let ms = MiscSelect::from_bits_truncate(res.ebx);
+            (true, Some(format!("{ms:?}")))
         },
         vend: Some(Vendor::Intel),
     },
@@ -112,9 +112,9 @@ pub const CPUIDS: &[CpuId] = &[
         name: "  Features",
         leaf: 0x00000012,
         subl: 0x00000001,
-        func: |res| match Features::from_bits((res.ebx as u64) << 32 | res.eax as u64) {
-            Some(features) => (true, Some(format!("{features:?}"))),
-            None => (false, None),
+        func: |res| {
+            let features = Features::from_bits_truncate((res.ebx as u64) << 32 | res.eax as u64);
+            (true, Some(format!("{features:?}")))
         },
         vend: Some(Vendor::Intel),
     },
@@ -122,9 +122,9 @@ pub const CPUIDS: &[CpuId] = &[
         name: "  Xfrm",
         leaf: 0x00000012,
         subl: 0x00000001,
-        func: |res| match Xfrm::from_bits((res.edx as u64) << 32 | res.ecx as u64) {
-            Some(flags) => (true, Some(format!("{flags:?}"))),
-            None => (false, None),
+        func: |res| {
+            let flags = Xfrm::from_bits_truncate((res.edx as u64) << 32 | res.ecx as u64);
+            (true, Some(format!("{flags:?}")))
         },
         vend: Some(Vendor::Intel),
     },


### PR DESCRIPTION
If enarx or the x86_64 crate does not keep up with CPU tech, using `from_bits` will prevent the usage of enarx on newer CPUs, because the checker will bailout here, although it's mostly used as an informative output.

Happens here with newer XEONs, which have the XTILECFG and XTILEDATA flags (bit 17 and 18) in Xfrm.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
