### PR TITLE
test: pass nonblocking stat to further networking tests

### DIFF
--- a/crates/exec-wasmtime/src/runtime/net/mod.rs
+++ b/crates/exec-wasmtime/src/runtime/net/mod.rs
@@ -54,11 +54,11 @@ pub fn listen_file(
     };
     let tcp = std::net::TcpListener::bind((addr.as_str(), *port))?;
     let tcp = TcpListener::from_std(tcp);
-    tcp.set_nonblocking(true)
-        .context("Error setting channel to nonblocking")?;
     let file = match file {
         ListenFile::Tcp { .. } => wasmtime_wasi::net::Socket::from(tcp).into(),
         ListenFile::Tls { .. } => {
+            tcp.set_nonblocking(true)
+                .context("Error setting channel to nonblocking")?;
             let cfg = rustls::ServerConfig::builder()
                 .with_cipher_suites(DEFAULT_TLS_CIPHER_SUITES)
                 .with_kx_groups(DEFAULT_TLS_KX_GROUPS)

--- a/tests/crates/enarx_wasm_tests/src/bin/connect.rs
+++ b/tests/crates/enarx_wasm_tests/src/bin/connect.rs
@@ -27,7 +27,7 @@ fn main() -> anyhow::Result<()> {
             == "stdin:stdout:stderr:stream"
     );
 
-    assert_stream(unsafe { TcpStream::from_raw_fd(3) })
+    assert_stream(unsafe { TcpStream::from_raw_fd(3) }, false)
 }
 
 #[cfg(not(any(target_os = "wasi", unix)))]

--- a/tests/crates/enarx_wasm_tests/src/bin/listen.rs
+++ b/tests/crates/enarx_wasm_tests/src/bin/listen.rs
@@ -35,7 +35,10 @@ fn main() -> anyhow::Result<()> {
     let (stream, _) = listener
         .accept()
         .context("failed to accept first connection")?;
-    assert_stream(stream).context("failed to assert default stream")?;
+    stream
+        .set_nonblocking(false)
+        .context("failed to set stream to blocking")?;
+    assert_stream(stream, false).context("failed to assert default stream")?;
 
     listener
         .set_nonblocking(false)
@@ -43,7 +46,10 @@ fn main() -> anyhow::Result<()> {
     let (stream, _) = listener
         .accept()
         .context("failed to accept second connection")?;
-    assert_stream(stream).context("failed to assert blocking stream")?;
+    stream
+        .set_nonblocking(false)
+        .context("failed to set stream to blocking")?;
+    assert_stream(stream, false).context("failed to assert blocking stream")?;
 
     listener
         .set_nonblocking(true)
@@ -51,7 +57,10 @@ fn main() -> anyhow::Result<()> {
     loop {
         match listener.accept() {
             Ok((stream, _)) => {
-                assert_stream(stream).context("failed to assert non-blocking stream")?;
+                stream
+                    .set_nonblocking(true)
+                    .context("failed to set stream to non-blocking")?;
+                assert_stream(stream, true).context("failed to assert non-blocking stream")?;
                 break;
             }
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}

--- a/tests/crates/enarx_wasm_tests/src/lib.rs
+++ b/tests/crates/enarx_wasm_tests/src/lib.rs
@@ -28,10 +28,13 @@ pub fn assert_copy_line(
     Ok(())
 }
 
-pub fn assert_stream(mut stream: impl BorrowMut<TcpStream>) -> anyhow::Result<()> {
+pub fn assert_stream(
+    mut stream: impl BorrowMut<TcpStream>,
+    non_blocking: bool,
+) -> anyhow::Result<()> {
     let mut stream = BufReader::new(stream.borrow_mut());
 
-    assert_copy_line(&mut stream, false).context("failed to copy first line")?;
+    assert_copy_line(&mut stream, non_blocking).context("failed to copy first line")?;
     ensure!(stream.buffer().is_empty());
 
     stream


### PR DESCRIPTION
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
